### PR TITLE
feat: add Grafana dashboard for live sensor visualization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ INFLUXDB_NODE_ID=
 
 # Auth token for the InfluxDB 3 API (create via `influxdb3 create token`).
 INFLUXDB3_AUTH_TOKEN=
+
+# Grafana admin password (default: admin).
+GRAFANA_ADMIN_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ coverage.xml
 # InfluxDB local data
 .influxdb3/
 
+# Grafana local data
+.grafana/data/
+
 # Personal experimentation (marimo notebooks, not part of the package)
 __marimo__/
 /test.py

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ uv sync
 uv run mock-temperature-sensor
 ```
 
+Then open [Grafana](http://localhost:3000) (`admin`/`admin`) to watch the
+data live — see [`docs/grafana.md`](docs/grafana.md).
+
 ## Project structure
 
 - `src/labmon/` — application code
@@ -28,7 +31,8 @@ uv run mock-temperature-sensor
 - `tests/` — pytest suite
 - `docs/` — usage docs per component
 - `typings/` — local type stubs for untyped third-party dependencies
-- `docker-compose.yml` — local InfluxDB instance
+- `grafana/` — provisioned datasource and dashboards
+- `docker-compose.yml` — local InfluxDB and Grafana instances
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,32 @@ services:
       timeout: 2s
       retries: 30
       start_period: 5s
+
+  grafana:
+    image: grafana/grafana:13.1.1
+    container_name: grafana
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - type: bind
+        source: ./grafana/provisioning
+        target: /etc/grafana/provisioning
+      - type: bind
+        source: ./grafana/dashboards
+        target: /var/lib/grafana/dashboards
+      - type: bind
+        # Grafana's own state (users, sessions, dashboard edits made via the UI)
+        source: .grafana/data
+        target: /var/lib/grafana
+    healthcheck:
+      test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://127.0.0.1:3000/api/health"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+      start_period: 5s

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,49 @@
+# Grafana
+
+Visualizes data written to InfluxDB. Provisioned automatically — no manual
+setup needed.
+
+## Access
+
+```
+http://localhost:3000
+```
+
+Login: `admin` / `admin` (or `GRAFANA_ADMIN_PASSWORD` if set in `.env`).
+
+The **Mock Temperature Sensor** dashboard (folder: `labmon`) shows every
+sensor writing to the `temperature` table, one line per `sensor_id`,
+auto-refreshing every 5 seconds.
+
+## How the datasource is wired
+
+`grafana/provisioning/datasources/influxdb3.yaml` provisions an `InfluxDB3`
+datasource using Grafana's built-in InfluxDB data source in **SQL** mode,
+which talks to InfluxDB 3's Flight SQL (gRPC) interface rather than the
+legacy InfluxQL/Flux modes. Since this stack has no TLS between containers,
+`insecureGrpc: true` tells Grafana not to expect it. The auth token is
+injected from the `INFLUXDB3_AUTH_TOKEN` environment variable via
+provisioning's `${VAR}` expansion — never hardcoded into the file.
+
+## Writing your own panel query
+
+The SQL mode's macros differ slightly from other Grafana SQL data sources —
+notably there's no `$__timeFilter`. Use:
+
+```sql
+SELECT time, sensor_id, value
+FROM temperature
+WHERE $__timeFrom() <= time AND time <= $__timeTo()
+ORDER BY time
+```
+
+`ORDER BY time` must be ascending — the panel's `time_series` format
+rejects descending results. A result shaped as `(time, label_column,
+numeric_column)` is automatically split into one series per distinct label
+value (here, one line per `sensor_id`).
+
+## Adding more dashboards
+
+Drop a dashboard JSON file into `grafana/dashboards/`; the file provider
+(`grafana/provisioning/dashboards/dashboards.yaml`) picks it up automatically
+within `updateIntervalSeconds` (30s), no restart needed.

--- a/grafana/dashboards/mock-temperature-sensor.json
+++ b/grafana/dashboards/mock-temperature-sensor.json
@@ -1,0 +1,35 @@
+{
+  "title": "Mock Temperature Sensor",
+  "uid": "mock-temperature-sensor",
+  "schemaVersion": 39,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "5s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Temperature",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "influxdb", "uid": "influxdb3" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "influxdb3" },
+          "format": "time_series",
+          "rawSql": "SELECT time, sensor_id, value FROM temperature WHERE $__timeFrom() <= time AND time <= $__timeTo() ORDER BY time"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: labmon
+    folder: labmon
+    type: file
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/influxdb3.yaml
+++ b/grafana/provisioning/datasources/influxdb3.yaml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB3
+    uid: influxdb3
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8181
+    isDefault: true
+    jsonData:
+      version: SQL
+      dbName: lab
+      # influxdb has no TLS in this local setup; Flight SQL (gRPC) needs to
+      # be told explicitly not to expect it.
+      insecureGrpc: true
+    secureJsonData:
+      token: ${INFLUXDB3_AUTH_TOKEN}


### PR DESCRIPTION
## Summary
- Add a `grafana` service (`grafana/grafana:13.1.1`, pinned) to `docker-compose.yml`, healthchecked and depending on `influxdb` being healthy first
- Provision the InfluxDB3 datasource declaratively (`grafana/provisioning/datasources/influxdb3.yaml`) using Grafana's SQL mode (Flight SQL/gRPC), not the legacy InfluxQL/Flux modes — confirmed via Grafana's own source that `version: SQL`, `dbName`, `insecureGrpc`, and `secureJsonData.token` are the real backend field names, not guessed
- Auth token injected via provisioning's `${INFLUXDB3_AUTH_TOKEN}` expansion — never hardcoded in a committed file
- Provision a starter dashboard (`grafana/dashboards/mock-temperature-sensor.json`) showing every sensor writing to the `temperature` table, one series per `sensor_id`, refreshing every 5s
- Add `docs/grafana.md` covering access, how the datasource is wired, and the SQL-mode macro quirks (no `$__timeFilter`, needs ascending `ORDER BY time`)
- `.gitignore` for Grafana's local state (`.grafana/data/`)

## Test plan
- [x] `docker compose up -d --wait` — both services healthy
- [x] Datasource health check via API: `{"message":"OK","status":"OK"}`
- [x] `/api/ds/query` with the dashboard's exact SQL against a live-running mock sensor returns real, freshly-written points, correctly split into a series labeled `sensor_id`
- [x] Full local check suite (pytest, ruff, basedpyright, typos) unaffected — no Python source touched