### PR TITLE
ci: add FOSSA license compliance scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # run-tests: true only runs `fossa test`, checking a revision that
+      # must already have been analyzed — it does not analyze/upload
+      # itself. Run the action once plain (analyze/upload this commit),
+      # then again with run-tests: true to check the result.
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
       - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  license-scan:
+    name: license-scan
+    runs-on: ubuntu-latest
+    # Not a required check yet: let it run for a while to confirm it's
+    # reliable before it can block merges.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # labmon
 
 [![License: GPLv3](https://img.shields.io/github/license/quentinmarolleau/labmon)](LICENSE)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fquentinmarolleau%2Flabmon.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fquentinmarolleau%2Flabmon?ref=badge_shield)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](pyproject.toml)
 [![codecov](https://codecov.io/gh/quentinmarolleau/labmon/branch/main/graph/badge.svg)](https://codecov.io/gh/quentinmarolleau/labmon)
 [![Repo size](https://img.shields.io/github/repo-size/quentinmarolleau/labmon)](https://github.com/quentinmarolleau/labmon)


### PR DESCRIPTION
## Summary
- Add a `license-scan` job using `fossas/fossa-action` (pinned by commit SHA), with `run-tests: true` so it actually reflects license-policy pass/fail rather than just performing a bare scan
- `continue-on-error: true` for now — not added to required branch protection checks yet, so we can watch it run reliably a few times before it can block merges
- Add the FOSSA Status badge to the README

Checked the attribution report FOSSA already generated from the initial scan: every dependency's actual declared license (MIT/BSD/Apache-2.0/MPL-2.0/PSF-2.0) is GPLv3-compatible. The noisy-looking entries (Pygments listing GPL/proprietary licenses, pyarrow listing WTFPL/Protobuf/etc.) come from file-level scanning of embedded test fixtures and vendored third-party notices, not those packages' own licenses.

## Test plan
- [x] Workflow runs on this PR; `license-scan` job executes (non-blocking either way)
- [x] `uv run pytest`, `ruff check`, `basedpyright` unaffected
