### PR TITLE
revert: drop FOSSA license compliance scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,23 +55,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-
-  license-scan:
-    name: license-scan
-    runs-on: ubuntu-latest
-    # Not a required check yet: let it run for a while to confirm it's
-    # reliable before it can block merges.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # run-tests: true only runs `fossa test`, checking a revision that
-      # must already have been analyzed — it does not analyze/upload
-      # itself. Run the action once plain (analyze/upload this commit),
-      # then again with run-tests: true to check the result.
-      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # labmon
 
 [![License: GPLv3](https://img.shields.io/github/license/quentinmarolleau/labmon)](LICENSE)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fquentinmarolleau%2Flabmon.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fquentinmarolleau%2Flabmon?ref=badge_shield)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](pyproject.toml)
 [![codecov](https://codecov.io/gh/quentinmarolleau/labmon/branch/main/graph/badge.svg)](https://codecov.io/gh/quentinmarolleau/labmon)
 [![Repo size](https://img.shields.io/github/repo-size/quentinmarolleau/labmon)](https://github.com/quentinmarolleau/labmon)


### PR DESCRIPTION
## Summary
Dropping the license-scan integration — decided it's not worth the ongoing hassle for a small independent project. Every false-positive from embedded test fixtures/vendored notices in dependencies (Pygments, pyarrow, ruff) needs manual policy review, and that has to be redone on every affected dependency's version bump.

- Remove the `license-scan` job from `.github/workflows/ci.yml`
- Remove the FOSSA Status badge from the README
- PR #8 (fossabot's auto-generated badge PR) closed unmerged
- `FOSSA_API_KEY` repo secret removed

Not included in this PR (needs manual action, not something git can revert): uninstalling the FOSSA GitHub App integration itself from GitHub's app settings, if desired.

## Test plan
- [x] `uv run pytest`, `ruff check`, `basedpyright`, `typos` all pass
- [x] Diff is a clean, exact reversal of the two files FOSSA touched