### PR TITLE
feat: containerize mock sensors as docker-compose services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.venv
+.git
+.github
+.grafana
+.influxdb3
+__marimo__
+__pycache__
+.pytest_cache
+.ruff_cache
+*.egg-info
+test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.14-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies first so this layer is cache-hit on source-only changes.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --locked --no-install-project --no-dev
+
+# hatchling's build needs README.md present (pyproject.toml: readme = "README.md").
+COPY README.md ./
+COPY src ./src
+RUN uv sync --locked --no-dev
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENTRYPOINT ["mock-sensor"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,14 @@
+x-mock-sensor: &mock-sensor
+  build: .
+  image: labmon:latest
+  depends_on:
+    influxdb:
+      condition: service_healthy
+  environment:
+    - INFLUXDB_HOST=http://influxdb:8181
+    - INFLUXDB_DATABASE=lab
+    - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+
 services:
   influxdb:
     image: influxdb:3-core
@@ -54,3 +65,54 @@ services:
       timeout: 2s
       retries: 30
       start_period: 5s
+
+  mock-room-1:
+    <<: *mock-sensor
+    container_name: mock-room-1
+    command:
+      - --sensor-id=room-1
+      - --measurement=temperature
+      - --setpoint=21
+      - --noise=0.15
+      - --unit=°C
+
+  mock-room-2:
+    <<: *mock-sensor
+    container_name: mock-room-2
+    command:
+      - --sensor-id=room-2
+      - --measurement=temperature
+      - --setpoint=22
+      - --noise=0.15
+      - --unit=°C
+
+  mock-cryo-77k:
+    <<: *mock-sensor
+    container_name: mock-cryo-77k
+    command:
+      - --sensor-id=cryo-77k
+      - --measurement=temperature
+      - --setpoint=77
+      - --noise=0.3
+      - --unit=K
+
+  mock-cryo-4k:
+    <<: *mock-sensor
+    container_name: mock-cryo-4k
+    command:
+      - --sensor-id=cryo-4k
+      - --measurement=temperature
+      - --setpoint=4.2
+      - --noise=0.05
+      - --unit=K
+
+  mock-pressure:
+    <<: *mock-sensor
+    container_name: mock-pressure
+    command:
+      - --sensor-id=chamber-1
+      - --measurement=pressure
+      - --setpoint=1e-7
+      - --noise=0.05
+      - --log-scale
+      - --unit=mbar


### PR DESCRIPTION
## Summary
Part 2 of 3 for the multi-sensor Grafana demo (part 1: #11).

- Add `Dockerfile` (labmon's first) — two-step `uv sync` (deps-only, then full) for layer caching, `--no-dev` to keep pytest/ruff/etc. out of the image
- Add `.dockerignore`
- Add 5 mock sensor services to `docker-compose.yml` via an `x-mock-sensor` YAML anchor for shared config: `mock-room-1`/`mock-room-2` (temperature, ~21-22°C), `mock-cryo-77k`/`mock-cryo-4k` (temperature, 77K/4.2K), `mock-pressure` (pressure, ~1e-7 mbar, `--log-scale`)
- Each service explicitly sets `INFLUXDB_HOST=http://influxdb:8181` — the code's own default (`localhost`) only works for host-side `uv run`, not a container on the compose network

After this PR, `docker compose up -d --wait` already produces live data for all 5 sensors — the existing dashboard just shows them all overlaid on one graph (no `main`-breaking gap); part 3 will split them into the intended panels.

## Test plan
- [x] `docker compose up -d --wait` — all 7 containers healthy/running
- [x] Confirmed image build de-duplication: one `labmon:latest` build shared across all 5 sensor services, not 5 separate builds
- [x] Queried InfluxDB directly: all 5 sensor_ids writing correct measurements/units/values (room-1 ~21°C, room-2 ~22°C, cryo-77k ~77K, cryo-4k ~4.2K, chamber-1 ~1e-7 mbar)
- [x] `uv run pytest`, `ruff check`, `basedpyright`, `typos` all pass (no Python source changed)