### PR TITLE
chore: centralize INFLUXDB_DATABASE as a configurable env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,13 @@ INFLUXDB_NODE_ID=
 # Auth token for the InfluxDB 3 API (create via `influxdb3 create token`).
 INFLUXDB3_AUTH_TOKEN=
 
+# InfluxDB 3 database name (default: lab).
+INFLUXDB_DATABASE=
+
 # Grafana admin password (default: admin).
 GRAFANA_ADMIN_PASSWORD=
+
+# INFLUXDB_HOST is intentionally not configured here: containers need the
+# Docker network hostname (http://influxdb:8181), while a host-side `uv run
+# mock-sensor` needs http://localhost:8181 (already the code default). One
+# value can't satisfy both, so it stays hardcoded per context instead.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-mock-sensor: &mock-sensor
       condition: service_healthy
   environment:
     - INFLUXDB_HOST=http://influxdb:8181
-    - INFLUXDB_DATABASE=lab
+    - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
     - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
 
 services:
@@ -47,6 +47,7 @@ services:
       - "3000:3000"
     environment:
       - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+      - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
     volumes:
       - type: bind

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -27,9 +27,14 @@ auto-refreshing every 5 seconds:
 datasource using Grafana's built-in InfluxDB data source in **SQL** mode,
 which talks to InfluxDB 3's Flight SQL (gRPC) interface rather than the
 legacy InfluxQL/Flux modes. Since this stack has no TLS between containers,
-`insecureGrpc: true` tells Grafana not to expect it. The auth token is
-injected from the `INFLUXDB3_AUTH_TOKEN` environment variable via
-provisioning's `${VAR}` expansion — never hardcoded into the file.
+`insecureGrpc: true` tells Grafana not to expect it. The auth token and
+database name are injected from the `INFLUXDB3_AUTH_TOKEN` and
+`INFLUXDB_DATABASE` environment variables via provisioning's `${VAR}`
+expansion (confirmed against Grafana's provisioning source — this
+expansion applies to any field, not just `secureJsonData`) — never
+hardcoded into the file. `docker-compose.yml` passes both through to the
+`grafana` service with a `:-lab` fallback, so `INFLUXDB_DATABASE` is always
+set even if `.env` doesn't define it.
 
 ## Writing your own panel query
 

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -77,6 +77,16 @@ Read from the environment (see `.env`, loaded automatically via direnv):
 | `INFLUXDB_HOST`         | `http://localhost:8181`  | InfluxDB server URL               |
 | `INFLUXDB_DATABASE`     | `lab`                    | Target database                   |
 
+`INFLUXDB_DATABASE` is in `.env.example`, so it applies uniformly to a
+host-side run, the containerized mock sensors, and Grafana's datasource.
+`INFLUXDB_HOST` is deliberately left out of `.env.example`: the
+containerized mock sensors need the Docker network hostname
+(`http://influxdb:8181`, hardcoded in `docker-compose.yml`), while a
+host-side run like this one needs `http://localhost:8181` (the default
+above) — one `.env` value can't satisfy both, so set it inline for an
+ad hoc host-side run only, e.g. `INFLUXDB_HOST=http://elsewhere:8181
+uv run mock-sensor ...`.
+
 ## Inspecting written data
 
 Via the InfluxDB3 CLI, inside the running container:

--- a/grafana/provisioning/datasources/influxdb3.yaml
+++ b/grafana/provisioning/datasources/influxdb3.yaml
@@ -9,7 +9,7 @@ datasources:
     isDefault: true
     jsonData:
       version: SQL
-      dbName: lab
+      dbName: ${INFLUXDB_DATABASE}
       # influxdb has no TLS in this local setup; Flight SQL (gRPC) needs to
       # be told explicitly not to expect it.
       insecureGrpc: true


### PR DESCRIPTION
## Summary
- Add `INFLUXDB_DATABASE` (default `lab`) to `.env`/`.env.example`, replacing the hardcoded `lab` in `docker-compose.yml`'s mock-sensor services and the Grafana datasource provisioning file.
- `INFLUXDB_HOST` deliberately stays out of `.env`: containers need the Docker network hostname (`http://influxdb:8181`), while a host-side `uv run mock-sensor` needs `http://localhost:8181` — one `.env` value can't satisfy both, so it stays hardcoded per context (documented with a comment in `.env.example` and in `docs/mock-sensor.md`).
- Confirmed against Grafana's provisioning source (`pkg/services/provisioning/values`) that `${VAR}` env expansion applies to any `jsonData` field, not just `secureJsonData`, so `dbName: ${INFLUXDB_DATABASE}` resolves the same way the token already does.
- Updated `docs/grafana.md` and `docs/mock-sensor.md` to document the new variable and the reasoning for leaving `INFLUXDB_HOST` out of `.env`.

## Test plan
- [x] `uv run typos` clean
- [x] `docker compose up -d --wait` — all 7 containers healthy
- [x] Verified default case: Grafana datasource API reports `dbName: lab` with no override set
- [x] Verified override case: set `INFLUXDB_DATABASE=testdb` in `.env`, recreated containers, confirmed both the Grafana datasource (`dbName: testdb`) and a mock-sensor container's environment picked it up
- [x] Restored original `.env` and brought the stack back to the default `lab` database, confirmed healthy