### PR TITLE
fix: retry InfluxDB writes with backoff instead of dying on failure

### DIFF
--- a/src/labmon/writer.py
+++ b/src/labmon/writer.py
@@ -1,8 +1,14 @@
 """Background, queue-backed writer so producers never block on InfluxDB I/O."""
 
+import logging
 import queue
 import threading
 from typing import Protocol
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_INITIAL_BACKOFF_SECONDS = 1.0
+_MAX_BACKOFF_SECONDS = 30.0
 
 
 class _Writable[T](Protocol):
@@ -21,6 +27,13 @@ class PointWriter[T]:
     poll_interval bounds how long close() can take to notice a stop
     request when the queue is empty (the background thread re-checks for
     a stop roughly every poll_interval seconds while idle).
+
+    A batch that fails to write is retried with exponential backoff
+    (capped, and interruptible by close()) rather than being dropped or
+    left to kill the background thread — a real network to a remote
+    server can have transient outages that a same-host connection never
+    would. A batch still failing when close() is called is logged and
+    dropped rather than retried indefinitely, so shutdown stays prompt.
     """
 
     def __init__(
@@ -56,4 +69,35 @@ class PointWriter[T]:
                     batch.append(self._queue.get_nowait())
                 except queue.Empty:
                     break
-            self._client.write(batch)
+            self._write_with_retry(batch)
+
+    def _write_with_retry(self, batch: list[T]) -> None:
+        """Write a batch, retrying with backoff on failure until it succeeds.
+
+        If close() is requested while a batch is failing, the batch is
+        logged and dropped instead of retried forever, so close() stays
+        responsive even during a sustained outage.
+        """
+        backoff = _INITIAL_BACKOFF_SECONDS
+        attempt = 1
+        while True:
+            try:
+                self._client.write(batch)
+                return
+            except Exception:
+                logger.warning(
+                    "Write attempt %d failed for a batch of %d point(s);"
+                    + " retrying in %.0fs",
+                    attempt,
+                    len(batch),
+                    backoff,
+                    exc_info=True,
+                )
+            if self._stop.wait(timeout=backoff):
+                logger.error(
+                    "Dropping a batch of %d point(s) still unwritten at shutdown",
+                    len(batch),
+                )
+                return
+            backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
+            attempt += 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,6 +1,10 @@
+import logging
 import threading
 import time
 
+import pytest
+
+from labmon import writer as writer_module
 from labmon.writer import PointWriter
 
 
@@ -11,6 +15,40 @@ class FakeClient[T]:
 
     def write(self, batch: list[T]) -> None:
         self.batches.append(list(batch))
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class FlakyClient[T]:
+    """Fails write() a fixed number of times, then succeeds."""
+
+    def __init__(self, fail_times: int) -> None:
+        self._fail_times: int = fail_times
+        self.attempts: int = 0
+        self.batches: list[list[T]] = []
+        self.closed: threading.Event = threading.Event()
+
+    def write(self, batch: list[T]) -> None:
+        self.attempts += 1
+        if self.attempts <= self._fail_times:
+            raise ConnectionError("simulated transient network failure")
+        self.batches.append(list(batch))
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+class AlwaysFailingClient[T]:
+    """Fails every write() call, simulating a sustained outage."""
+
+    def __init__(self) -> None:
+        self.attempts: int = 0
+        self.closed: threading.Event = threading.Event()
+
+    def write(self, _batch: list[T]) -> None:
+        self.attempts += 1
+        raise ConnectionError("simulated persistent outage")
 
     def close(self) -> None:
         self.closed.set()
@@ -52,3 +90,42 @@ def test_survives_idle_polling_before_a_point_arrives() -> None:
 
     written = [point for batch in client.batches for point in batch]
     assert written == [1]
+
+
+def test_write_retries_transient_failures_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(writer_module, "_INITIAL_BACKOFF_SECONDS", 0.01)
+    monkeypatch.setattr(writer_module, "_MAX_BACKOFF_SECONDS", 0.01)
+    client = FlakyClient[int](fail_times=2)
+    writer = PointWriter[int](client, poll_interval=0.01)
+
+    with caplog.at_level(logging.WARNING):
+        writer.write(1)
+        time.sleep(0.1)
+        writer.close()
+
+    written = [point for batch in client.batches for point in batch]
+    assert written == [1]
+    assert client.attempts == 3
+    assert caplog.text.count("Write attempt") == 2
+
+
+def test_close_drops_a_batch_still_failing_at_shutdown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = AlwaysFailingClient[int]()
+    writer = PointWriter[int](client, poll_interval=0.01)
+
+    writer.write(1)
+    time.sleep(0.05)
+
+    start = time.monotonic()
+    with caplog.at_level(logging.ERROR):
+        writer.close()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0
+    assert client.attempts >= 1
+    assert client.closed.is_set()
+    assert "Dropping a batch of 1 point(s)" in caplog.text


### PR DESCRIPTION
## Summary
- `PointWriter._run()`'s background thread had no error handling around the network write call: an unhandled exception silently killed the thread, and once the queue then filled up, producers deadlocked forever on `write()`. Fine on a same-host Docker bridge that basically never fails; a real gap once sensor clients push over an actual LAN/Wi-Fi link (part of the upcoming client/server networking work).
- Failed writes now retry with capped exponential backoff (1s → 30s), interruptible by `close()` so shutdown stays prompt even mid-outage. A batch still failing when `close()` is called is logged and dropped rather than retried forever.
- Added `logging` to the codebase (previously only `print`): a `warning` per failed attempt, an `error` if a batch is dropped at shutdown.

## Test plan
- [x] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100` — 100% coverage, new `FlakyClient`/`AlwaysFailingClient` fakes cover retry-then-success and bounded/non-hanging shutdown during a sustained outage
- [x] `uv run ruff check .`, `uv run basedpyright` (0 warnings), `uv run typos` all clean
- [x] Manual: killed the `influxdb` container mid-write with both a host-side `mock-sensor` and the containerized demo sensors running — all kept running (no crash/deadlock), logged retry warnings, and resumed writing with zero data loss once InfluxDB came back (confirmed via `influxdb3 query`, 124 rows with no gap)