### PR TITLE
feat: split server/demo compose profiles, document LAN deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ INFLUXDB_DATABASE=
 # Grafana admin password (default: admin).
 GRAFANA_ADMIN_PASSWORD=
 
+# Which docker-compose profiles are active. "demo" brings up the five mock
+# sensors alongside InfluxDB/Grafana (today's full local demo experience).
+# Leave this blank/unset on a real server deployment to start only InfluxDB
+# and Grafana — see docs/deployment.md.
+COMPOSE_PROFILES=demo
+
 # INFLUXDB_HOST is intentionally not configured here: containers need the
 # Docker network hostname (http://influxdb:8181), while a host-side `uv run
 # mock-sensor` needs http://localhost:8181 (already the code default). One

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ demo mock sensors from `docker compose up`.
 
 ![labmon architecture: sensors and edge devices feed InfluxDB 3, which Grafana queries for dashboards](docs/assets/images/diagram.png)
 
-This is the target architecture — microcontrollers and edge devices
-(Arduino, Raspberry Pi, etc.) feeding InfluxDB directly aren't built yet.
-What's implemented today: sensor scripts write into InfluxDB through a
-queue-backed writer, so producers are never blocked by write latency. The
-demo mock sensors, InfluxDB, and Grafana all run as containers managed by
-`docker-compose.yml` (labmon's own code is built via `Dockerfile`); you
-can also run an extra sensor script directly on the host via `uv run
-mock-sensor` (see [`docs/mock-sensor.md`](docs/mock-sensor.md)). Grafana
-queries InfluxDB via its SQL (Flight SQL) mode — see
-[`docs/grafana.md`](docs/grafana.md) for why that mode specifically, and
-its macro quirks.
+This is the target architecture. Sensor scripts write into InfluxDB
+through a queue-backed writer (resilient to real network hiccups, not
+just same-host latency), so producers are never blocked or lost to a
+transient outage. The demo mock sensors, InfluxDB, and Grafana all run as
+containers managed by `docker-compose.yml` (labmon's own code is built
+via `Dockerfile`); you can also run an extra sensor script directly on
+the host via `uv run mock-sensor` (see
+[`docs/mock-sensor.md`](docs/mock-sensor.md)). Grafana queries InfluxDB
+via its SQL (Flight SQL) mode — see [`docs/grafana.md`](docs/grafana.md)
+for why that mode specifically, and its macro quirks.
+
+Beyond one machine, InfluxDB/Grafana can run on a central **server** with
+separate **client** machines (e.g. a Raspberry Pi) pushing sensor data to
+it over the LAN, and other computers in the room reaching Grafana in a
+browser — see [`docs/deployment.md`](docs/deployment.md). Real hardware
+sensor drivers (e.g. reading a microcontroller like an Arduino over
+serial) aren't built yet; the mock sensors stand in for now.
 
 ## Project structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 x-mock-sensor: &mock-sensor
   build: .
   image: labmon:latest
+  profiles: [demo]
   depends_on:
     influxdb:
       condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,71 @@
+# Deployment
+
+Everything in the [Quickstart](../README.md#quickstart) runs on one
+machine. A real lab setup is a small LAN with three roles:
+
+- **Server** — one central machine running InfluxDB3 + Grafana
+  (`docker-compose.yml`).
+- **Clients** — separate machines (e.g. a Raspberry Pi wired to a sensor)
+  pushing data to the server over the network — see
+  [`docs/client-setup.md`](client-setup.md).
+- **Viewers** — any other computer in the room opening Grafana in a
+  browser.
+
+This doc covers the server side: exposing it to the LAN, and the
+`COMPOSE_PROFILES` toggle between "local demo" and "real server."
+
+## Demo vs. server: `COMPOSE_PROFILES`
+
+The five `mock-*` sensor services in `docker-compose.yml` are tagged
+`profiles: [demo]`, so they only start when the `demo` profile is active.
+`.env.example` ships with `COMPOSE_PROFILES=demo`, which Compose reads
+automatically — no `--profile` flag needed — so `docker compose up -d
+--wait` keeps giving you today's full local demo (InfluxDB, Grafana, and
+all five mock sensors) if you copy `.env.example` as-is.
+
+For a real server, leave `COMPOSE_PROFILES` unset (or blank) in that
+machine's `.env`: `docker compose up -d --wait` then starts only
+`influxdb` and `grafana` — nothing simulates sensor data, since real
+clients will be doing that over the network instead.
+
+## Exposing the server to the LAN
+
+`docker-compose.yml`'s port bindings (`8181:8181` for InfluxDB, `3000:3000`
+for Grafana) already bind to `0.0.0.0` by default — Compose's short port
+syntax doesn't restrict to `127.0.0.1`. So making the server reachable
+from the rest of the LAN needs no compose changes, just:
+
+1. **A stable address for the server.** Either set a DHCP reservation for
+   its LAN IP on your router, or give it a fixed hostname (e.g. via
+   `/etc/hosts` on each client, or your router's local DNS if it has one).
+   Clients point at this address directly (see
+   [`docs/client-setup.md`](client-setup.md)) — there's no service
+   discovery (mDNS/Avahi) here, by design, to keep the setup simple.
+2. **Open the two ports on the server's firewall**, if one is active.
+   e.g. on a `ufw`-managed host:
+   ```bash
+   sudo ufw allow 8181/tcp   # InfluxDB
+   sudo ufw allow 3000/tcp   # Grafana
+   ```
+
+Viewers reach Grafana at `http://<server-ip-or-hostname>:3000`; clients
+write to InfluxDB at `http://<server-ip-or-hostname>:8181`.
+
+## Security: plain HTTP, by design (for now)
+
+This stack talks plain HTTP/gRPC, with no TLS — the same as the local
+demo (see [`docs/grafana.md`](grafana.md)'s note on `insecureGrpc`). On a
+real LAN this means `INFLUXDB3_AUTH_TOKEN` travels unencrypted between
+clients and the server. That's an accepted tradeoff for a trusted lab
+network, not an oversight — TLS (e.g. via a reverse proxy, or InfluxDB's
+own TLS support) is a reasonable future upgrade if the network model ever
+changes, but isn't built here.
+
+## Distributing the auth token
+
+Every client needs the same `INFLUXDB3_AUTH_TOKEN` the server was set up
+with (see the root [`.env.example`](../.env.example)). Copy it out of
+band — e.g. `scp` the value directly into each client's own env file
+(see [`docs/client-setup.md`](client-setup.md)) — never commit it, and
+never send it over an unencrypted channel you don't already trust (email,
+chat, etc.).


### PR DESCRIPTION
## Summary
- Tag the five `mock-*` sensor services in `docker-compose.yml` with `profiles: [demo]`. Compose services under a profile don't start unless that profile is active.
- `.env.example`: add `COMPOSE_PROFILES=demo` — Compose reads this automatically (no `--profile` flag needed), so `docker compose up -d --wait` keeps giving today's full local demo for anyone copying `.env.example` as-is. A real server's `.env` leaves `COMPOSE_PROFILES` unset, so the same command starts only `influxdb` + `grafana`.
- New `docs/deployment.md`: the real topology (server / clients / room viewers), why exposing the server to the LAN needs no compose change (port bindings already default to `0.0.0.0`) — just a stable address and firewall ports (8181, 3000), an explicit note that this stack is plain HTTP by design (auth-token-protected, not encrypted — an accepted tradeoff for a trusted lab LAN, TLS is a future option not built now), and how to distribute the auth token to clients out of band.
- Updated README's Architecture section to match, linking to the new doc.

## Test plan
- [x] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100`, `uv run ruff check .`, `uv run basedpyright` (0 warnings), `uv run typos` all clean
- [x] `docker compose config -q` — compose file valid; `docker compose config --services` confirms only `influxdb`/`grafana` with no profile active, and adding `demo` brings back all 7
- [x] Regression: brought the full stack up with `COMPOSE_PROFILES=demo` (today's `.env.example` default) — all 7 containers healthy, unchanged from before
- [x] Brought the stack up with `COMPOSE_PROFILES` unset — confirmed a clean server-only state (only `influxdb`/`grafana` running), then restored the full demo