### PR TITLE
feat: add client packaging for remote sensor deployment

### DIFF
--- a/.env.client.example
+++ b/.env.client.example
@@ -1,0 +1,15 @@
+# Copy to .env on a client machine (e.g. a Raspberry Pi) that pushes
+# sensor data to a remote labmon server — see docs/client-setup.md.
+
+# The server's LAN address (see docs/deployment.md on the server for how
+# this is set up: a DHCP reservation or fixed hostname). Required — there
+# is no default here, unlike the all-in-one local demo where this is a
+# Docker-network hostname (http://influxdb:8181) instead.
+INFLUXDB_HOST=http://192.168.1.50:8181
+
+# Must match the server's database name (default: lab).
+INFLUXDB_DATABASE=lab
+
+# The same INFLUXDB3_AUTH_TOKEN the server was set up with — copy it out
+# of band (e.g. scp), never commit it. See docs/deployment.md.
+INFLUXDB3_AUTH_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage.xml
 .env
 .env.*
 !.env.example
+!.env.client.example
 
 # Virtual environments
 .venv

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ its macro quirks.
 - `grafana/` — provisioned datasource and dashboards
 - `Dockerfile` — builds labmon's own code for the containerized mock sensors
 - `docker-compose.yml` — local InfluxDB, Grafana, and mock sensor instances
+- `docker-compose.client.yml` — sensor-only compose file for a remote client machine
+- `deploy/` — example systemd unit for a bare-install client
 - `CONTRIBUTING.md` / `AGENTS.md` — workflow, commit conventions, testing policy
 
 ## Development

--- a/deploy/labmon-sensor.service
+++ b/deploy/labmon-sensor.service
@@ -19,7 +19,7 @@ Type=simple
 User=pi
 WorkingDirectory=/home/pi/labmon
 EnvironmentFile=/home/pi/labmon/.env
-ExecStart=/home/pi/labmon/.venv/bin/mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --setpoint=21 --noise=0.15 --unit=°C
+ExecStart=/home/pi/labmon/.venv/bin/mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --unit=°C
 Restart=on-failure
 RestartSec=5
 

--- a/deploy/labmon-sensor.service
+++ b/deploy/labmon-sensor.service
@@ -19,7 +19,7 @@ Type=simple
 User=pi
 WorkingDirectory=/home/pi/labmon
 EnvironmentFile=/home/pi/labmon/.env
-ExecStart=/home/pi/labmon/.venv/bin/mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --unit=°C
+ExecStart=/home/pi/labmon/.venv/bin/mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
 Restart=on-failure
 RestartSec=5
 

--- a/deploy/labmon-sensor.service
+++ b/deploy/labmon-sensor.service
@@ -1,0 +1,27 @@
+# Example systemd unit for running a sensor directly on a client machine
+# (bare install, no Docker) — see docs/client-setup.md. Copy this file to
+# /etc/systemd/system/labmon-sensor.service, edit the paths/command below
+# for your setup, then:
+#
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now labmon-sensor.service
+#
+# Run more than one sensor on this device? Copy this file under a
+# different name (e.g. labmon-sensor-2.service) with its own ExecStart.
+
+[Unit]
+Description=labmon sensor client
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/labmon
+EnvironmentFile=/home/pi/labmon/.env
+ExecStart=/home/pi/labmon/.venv/bin/mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --setpoint=21 --noise=0.15 --unit=°C
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -1,0 +1,31 @@
+# Compose file for a client machine (e.g. a Raspberry Pi) pushing sensor
+# data to a remote labmon server — see docs/client-setup.md and
+# docs/deployment.md. Unlike docker-compose.yml, there's no InfluxDB or
+# Grafana here: this machine only runs sensor(s) that write to the server
+# over the network.
+#
+# Usage:
+#   cp .env.client.example .env
+#   docker compose -f docker-compose.client.yml build
+#   docker compose -f docker-compose.client.yml up -d --wait
+#
+# Running more than one sensor on this device? Copy the `sensor` service
+# below, give the copy its own name and `container_name`, and edit its
+# `command` — same pattern as the demo sensors in docker-compose.yml.
+services:
+  sensor:
+    build: .
+    image: labmon:latest
+    container_name: labmon-sensor
+    restart: unless-stopped
+    environment:
+      - INFLUXDB_HOST=${INFLUXDB_HOST}
+      - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
+      - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+    # Edit this to describe the sensor actually attached to this device.
+    command:
+      - --sensor-id=CHANGE-ME
+      - --measurement=temperature
+      - --setpoint=21
+      - --noise=0.15
+      - --unit=°C

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -35,14 +35,14 @@ services:
     <<: *labmon-sensor
     container_name: labmon-sensor-1
     command:
-      - --sensor-id=CHANGE-ME
-      - --measurement=temperature
-      - --unit=°C
+      - --sensor-id=CHANGE-ME-1
+      - --measurement=CHANGE-ME
+      - --unit=CHANGE-ME
 
   # sensor-2:
   #   <<: *labmon-sensor
   #   container_name: labmon-sensor-2
   #   command:
   #     - --sensor-id=CHANGE-ME-2
-  #     - --measurement=temperature
-  #     - --unit=°C
+  #     - --measurement=CHANGE-ME
+  #     - --unit=CHANGE-ME

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -9,23 +9,40 @@
 #   docker compose -f docker-compose.client.yml build
 #   docker compose -f docker-compose.client.yml up -d --wait
 #
-# Running more than one sensor on this device? Copy the `sensor` service
-# below, give the copy its own name and `container_name`, and edit its
-# `command` — same pattern as the demo sensors in docker-compose.yml.
+# There's no real hardware acquisition script yet (see docs/client-setup.md
+# for why), so this still runs `mock-sensor` — useful on real client
+# hardware to prove it can reach the server before any real acquisition
+# code exists. `--setpoint`/`--noise`/`--log-scale` only shape the
+# simulated random walk; a real acquisition script won't take them at all,
+# so don't spend time tuning them here — this section will be replaced
+# wholesale (image/command) once that script exists.
+#
+# Running several sensors on this device in parallel: give each its own
+# service extending the x-labmon-sensor anchor below, its own
+# container_name, and a command with a distinct --sensor-id (see the
+# commented-out `sensor-2` example).
+x-labmon-sensor: &labmon-sensor
+  build: .
+  image: labmon:latest
+  restart: unless-stopped
+  environment:
+    - INFLUXDB_HOST=${INFLUXDB_HOST}
+    - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
+    - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+
 services:
-  sensor:
-    build: .
-    image: labmon:latest
-    container_name: labmon-sensor
-    restart: unless-stopped
-    environment:
-      - INFLUXDB_HOST=${INFLUXDB_HOST}
-      - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
-      - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
-    # Edit this to describe the sensor actually attached to this device.
+  sensor-1:
+    <<: *labmon-sensor
+    container_name: labmon-sensor-1
     command:
       - --sensor-id=CHANGE-ME
       - --measurement=temperature
-      - --setpoint=21
-      - --noise=0.15
       - --unit=°C
+
+  # sensor-2:
+  #   <<: *labmon-sensor
+  #   container_name: labmon-sensor-2
+  #   command:
+  #     - --sensor-id=CHANGE-ME-2
+  #     - --measurement=temperature
+  #     - --unit=°C

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -24,12 +24,13 @@ docker compose -f docker-compose.client.yml build
 docker compose -f docker-compose.client.yml up -d --wait
 ```
 
-`docker-compose.client.yml` has one `sensor` service as a template —
-edit its `command` to describe the sensor actually attached to this
-device (see [`docs/mock-sensor.md`](mock-sensor.md) for the available
-flags). Running more than one sensor on the same device: copy the
-service block, give the copy its own name/`container_name`, and edit its
-`command`.
+`docker-compose.client.yml` has one `sensor-1` service as a template,
+plus a commented-out `sensor-2` showing the pattern for running several
+sensors on the same device in parallel: give each its own service
+extending the shared `x-labmon-sensor` anchor, its own `container_name`,
+and a `command` with a distinct `--sensor-id` (see
+[`docs/mock-sensor.md`](mock-sensor.md) for the available flags — and the
+note below on which of those flags actually matter here).
 
 ## Option 2: Bare install (no Docker)
 
@@ -41,7 +42,7 @@ git clone <this repo> && cd labmon
 uv sync --no-dev
 cp .env.client.example .env   # fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
 set -a && source .env && set +a
-uv run mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --setpoint=21 --noise=0.15 --unit=°C
+uv run mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --unit=°C
 ```
 
 To have it run in the background and survive a reboot, use the example
@@ -56,3 +57,32 @@ sudo systemctl enable --now labmon-sensor.service
 
 Running more than one sensor on this device: copy the unit file under a
 different name (e.g. `labmon-sensor-2.service`) with its own `ExecStart`.
+
+## From mock sensor to real hardware
+
+There's no real acquisition script yet — both options above still run
+`mock-sensor`, which only simulates a reading (a mean-reverting random
+walk); it doesn't talk to any hardware. `--setpoint`/`--noise`/
+`--log-scale` are simulation-only knobs, not something to "tune" for a
+real sensor — ignore them here, which is why the commands above only set
+`--sensor-id`, `--measurement`, and `--unit`.
+
+Reading a real microcontroller (e.g. an Arduino over serial) is a
+separate, later piece of work, but the plumbing already in place is
+designed to be reused as-is by whatever that script ends up being:
+- `labmon.writer.PointWriter` and `labmon.influx.get_client` are
+  generic — they just take an already-built `Point` (measurement, tags,
+  a field value, a timestamp) and get it to InfluxDB reliably. Nothing
+  about them assumes the value came from a simulation.
+- The `--unit` tag is written as-is, with no conversion — so whatever
+  writes it must already hold a value in physical units. That means raw
+  sample → physical unit conversion (e.g. raw ADC counts/volts from the
+  microcontroller → kelvin via a calibration curve) belongs in that
+  future acquisition script, before it constructs the `Point` — not in
+  InfluxDB or Grafana. A real script would replace `mock-sensor` in the
+  `command:`/`ExecStart` above with something like `--device
+  /dev/ttyACM0 --calibration cal.json`, still writing through the same
+  `PointWriter`.
+
+No name is settled for that future script yet ("grabber," "acquirer,"
+and "reader" all fit) — that can wait until it's actually being built.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -42,7 +42,7 @@ git clone <this repo> && cd labmon
 uv sync --no-dev
 cp .env.client.example .env   # fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
 set -a && source .env && set +a
-uv run mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --unit=°C
+uv run mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
 ```
 
 To have it run in the background and survive a reboot, use the example

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,0 +1,58 @@
+# Client setup
+
+A client is any machine that pushes sensor data to a remote labmon
+server over the LAN — e.g. a Raspberry Pi. See
+[`docs/deployment.md`](deployment.md) for the server side (exposing it on
+the network, distributing the auth token). This doc covers running a
+sensor on the client itself, two ways.
+
+Both need the same three values from the server: `INFLUXDB_HOST` (its LAN
+IP/hostname), `INFLUXDB_DATABASE`, and `INFLUXDB3_AUTH_TOKEN`, copied out
+of band — see [`docs/deployment.md`](deployment.md#distributing-the-auth-token).
+
+## Option 1: Docker
+
+Reuses the same `Dockerfile` as the local demo, built natively on the
+client — a Raspberry Pi builds its own `linux/arm64` image directly,
+consistent with this project's "build locally, no registry" pattern
+(there's no cross-compilation or CI publishing step involved).
+
+```bash
+git clone <this repo> && cd labmon
+cp .env.client.example .env   # fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
+docker compose -f docker-compose.client.yml build
+docker compose -f docker-compose.client.yml up -d --wait
+```
+
+`docker-compose.client.yml` has one `sensor` service as a template —
+edit its `command` to describe the sensor actually attached to this
+device (see [`docs/mock-sensor.md`](mock-sensor.md) for the available
+flags). Running more than one sensor on the same device: copy the
+service block, give the copy its own name/`container_name`, and edit its
+`command`.
+
+## Option 2: Bare install (no Docker)
+
+Better suited to a resource-constrained device, or if you'd rather not
+run a container runtime at all.
+
+```bash
+git clone <this repo> && cd labmon
+uv sync --no-dev
+cp .env.client.example .env   # fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
+set -a && source .env && set +a
+uv run mock-sensor --sensor-id=CHANGE-ME --measurement=temperature --setpoint=21 --noise=0.15 --unit=°C
+```
+
+To have it run in the background and survive a reboot, use the example
+systemd unit at [`deploy/labmon-sensor.service`](../deploy/labmon-sensor.service):
+edit the paths, `User`, and `ExecStart` command for your setup, then:
+
+```bash
+sudo cp deploy/labmon-sensor.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now labmon-sensor.service
+```
+
+Running more than one sensor on this device: copy the unit file under a
+different name (e.g. `labmon-sensor-2.service`) with its own `ExecStart`.


### PR DESCRIPTION
## Summary
- New `docker-compose.client.yml`: a minimal compose file (no InfluxDB/Grafana) reusing the existing `Dockerfile`, with one templated `sensor` service to copy/edit per physical sensor on a client device. Built natively on the client (e.g. arm64 on a Raspberry Pi) — no CI/multi-arch publishing needed, consistent with this project's existing "build locally" pattern. Includes `restart: unless-stopped`.
- New `.env.client.example`: unlike the root `.env.example`, this one requires `INFLUXDB_HOST` — a dedicated client env always means "the remote server," with none of the Docker-network-vs-host ambiguity that keeps it out of the root file.
- New `docs/client-setup.md`: both a Docker path and a bare-install path (`uv sync` + `uv run mock-sensor`), the latter with an example systemd unit (`deploy/labmon-sensor.service`) so it survives a reboot.
- `.gitignore`: un-ignore `.env.client.example` (the existing `.env.*` blanket rule needed a second exception, alongside `.env.example`).
- README: mention the new files in "Project structure".

## Test plan
- [x] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100`, `uv run ruff check .`, `uv run basedpyright` (0 warnings), `uv run typos` all clean (no Python changes in this PR, ran as a regression check)
- [x] `docker compose -f docker-compose.client.yml config -q` — valid
- [x] Built the client image and ran it via `docker compose -f docker-compose.client.yml run`, pointed at this machine's actual LAN IP address (not `localhost`, not the compose-internal `influxdb` hostname) — confirmed the data landed in InfluxDB over that real network path (21 rows queried back directly), the closest approximation of true multi-machine testing available without a second physical device