### PR TITLE
docs: add dynamic tests and basedpyright status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # labmon
 
 [![License: GPLv3](https://img.shields.io/github/license/quentinmarolleau/labmon)](LICENSE)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/quentinmarolleau/labmon/pulls)
+[![Repo size](https://img.shields.io/github/repo-size/quentinmarolleau/labmon)](https://github.com/quentinmarolleau/labmon)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](pyproject.toml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/quentinmarolleau/labmon/ci.yml?branch=main&label=tests&job=test%20%283.14%29)](https://github.com/quentinmarolleau/labmon/actions/workflows/ci.yml)
-[![basedpyright](https://img.shields.io/github/actions/workflow/status/quentinmarolleau/labmon/ci.yml?branch=main&label=basedpyright&job=typecheck)](https://github.com/DetachHead/basedpyright)
 [![codecov](https://codecov.io/gh/quentinmarolleau/labmon/branch/main/graph/badge.svg)](https://codecov.io/gh/quentinmarolleau/labmon)
-[![Repo size](https://img.shields.io/github/repo-size/quentinmarolleau/labmon)](https://github.com/quentinmarolleau/labmon)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/quentinmarolleau/labmon/pulls)
+[![basedpyright](https://img.shields.io/github/actions/workflow/status/quentinmarolleau/labmon/ci.yml?branch=main&label=basedpyright&job=typecheck)](https://github.com/DetachHead/basedpyright)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Maturity: alpha](https://img.shields.io/badge/maturity-alpha-orange)](https://github.com/quentinmarolleau/labmon)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![License: GPLv3](https://img.shields.io/github/license/quentinmarolleau/labmon)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](pyproject.toml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/quentinmarolleau/labmon/ci.yml?branch=main&label=tests&job=test%20%283.14%29)](https://github.com/quentinmarolleau/labmon/actions/workflows/ci.yml)
+[![basedpyright](https://img.shields.io/github/actions/workflow/status/quentinmarolleau/labmon/ci.yml?branch=main&label=basedpyright&job=typecheck)](https://github.com/DetachHead/basedpyright)
 [![codecov](https://codecov.io/gh/quentinmarolleau/labmon/branch/main/graph/badge.svg)](https://codecov.io/gh/quentinmarolleau/labmon)
 [![Repo size](https://img.shields.io/github/repo-size/quentinmarolleau/labmon)](https://github.com/quentinmarolleau/labmon)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/quentinmarolleau/labmon/pulls)


### PR DESCRIPTION
## Summary
- Added two badges to README.md, both dynamic, reading live off `ci.yml`'s per-job status via shields.io's `job=` query parameter (verified against this repo's actual workflow runs before committing to the URLs — both return live "passing" SVGs right now):
  - **Tests**: filtered to the `test (3.14)` job (the leg that also uploads coverage).
  - **basedpyright**: filtered to the `typecheck` job.
- Links: Tests → the workflow's Actions page; basedpyright → the basedpyright project (matching how the existing Ruff badge links to its own project).

No CI changes needed — GitHub's native workflow badge is per-workflow-file only (no per-job granularity), but shields.io's GitHub Actions badge supports a `job=` filter against the same workflow run data, so both badges could point at the single existing `ci.yml` without splitting it into separate workflow files.

## Test plan
- [x] `uv run typos` clean
- [x] Both badge URLs manually curled and confirmed HTTP 200 with the correct live "passing" label/status for this repo