### PR TITLE
fix: average ADC conversions on the board and settle the mux first

### DIFF
--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -14,6 +14,8 @@ The board sends **raw ADC counts**, never physical units — what a count
 means lives on the host, where it can be changed without reflashing:
 
 1. The board streams one line per reading: `<channel>,<raw_count>`.
+   The count may be fractional (see [Averaging on the
+   board](#averaging-on-the-board) below).
 2. The count is scaled to the voltage the ADC saw, using
    `--resolution-bits` and `--vref`.
 3. That voltage is converted to a physical quantity by the channel's
@@ -142,6 +144,26 @@ readings.
   resets the sketch via DTR; the Native port doesn't, so `serial-sensor`
   can reconnect without disturbing a running sketch.
 - **Analog inputs are 3.3V max** — feeding them 5V damages the board.
+
+### Averaging on the board
+
+The reference sketch reports the mean of a burst of conversions rather
+than a single snapshot, sent as a fractional count (`A0,2048.31` — the
+decimals carry the sub-step resolution the averaging buys).
+
+The burst length is derived from `MAINS_FREQUENCY_HZ`, not set as a round
+number of milliseconds: integrating over a whole number of mains periods
+cancels 50/60 Hz pickup. **On a 60 Hz grid, change that constant** — at
+50 the rejection is lost. Widen the window to `2 *` or `3 *` a period for
+more averaging on a noisy channel; at one reading per second, 20 ms costs
+2% of the interval.
+
+The sketch also discards one conversion and pauses `ADC_SETTLING_US`
+after switching channels, before the burst. The Due's inputs share one
+ADC behind a multiplexer, so the first conversion after a switch is still
+pulled toward the previous channel's voltage — a constant offset, which
+averaging cannot remove. It is invisible on a single-channel setup and
+appears as soon as a second channel is added.
 
 ### A stable device path
 

--- a/firmware/due_native_serial/due_native_serial.ino
+++ b/firmware/due_native_serial/due_native_serial.ino
@@ -2,12 +2,16 @@
  * Minimal reference sketch: stream raw ADC counts over the Arduino Due's
  * Native USB Port, in the line format `serial-sensor` expects.
  *
- *   <channel>,<raw_count>\r\n      e.g.  A0,2048
+ *   <channel>,<raw_count>\r\n      e.g.  A0,2048.31
  *
  * The host side does all interpretation: this sketch deliberately sends
  * raw counts, never volts or physical units. What a count means belongs
  * in the host's calibration.toml, where it can be changed without
  * reflashing the board (see docs/serial-sensor.md).
+ *
+ * Each reported count is the mean of a burst of conversions rather than a
+ * single snapshot — see AVERAGING_WINDOW_US below for why, and why the
+ * count is fractional.
  *
  * Wiring/usage notes:
  *  - Use the *Native* USB port (the one nearer the RESET button), not the
@@ -29,8 +33,41 @@ const int CHANNEL_PINS[] = {A0, A1};
 const int CHANNEL_COUNT = sizeof(CHANNEL_PINS) / sizeof(CHANNEL_PINS[0]);
 
 // Sampling period. The host stamps readings on arrival and does not pace
-// them itself, so this alone sets the sample rate.
+// them itself, so this alone sets the sample rate. The time spent
+// averaging (below) adds to it, so the true period is slightly longer —
+// harmless, since nothing downstream assumes an exact cadence.
 const unsigned long SAMPLE_INTERVAL_MS = 1000;
+
+// Mains frequency: 50 Hz across most of the world, 60 Hz in North America
+// and parts of Asia. Set it to match the local grid.
+const unsigned long MAINS_FREQUENCY_HZ = 50;
+
+// How long to average each channel over. Averaging N conversions cuts
+// uncorrelated noise by sqrt(N), but the bigger win is that integrating
+// over a whole number of mains periods cancels 50/60 Hz pickup outright:
+// the interference sums to zero over a full cycle. That only works if the
+// window is an exact multiple of the mains period, which is why this is
+// derived from MAINS_FREQUENCY_HZ rather than being a round number of
+// milliseconds. Use 2 * or 3 * this for more averaging; a value that is
+// not a whole number of periods loses the hum rejection.
+const unsigned long AVERAGING_WINDOW_US = 1000000UL / MAINS_FREQUENCY_HZ;
+
+// The Due's analog inputs share one ADC behind a multiplexer. Switching
+// channels leaves the sample-and-hold capacitor still charged from the
+// previous input, so the first conversion after a switch is pulled toward
+// the previous channel's voltage. Discarding one conversion and pausing
+// lets the capacitor settle on the new input.
+//
+// This has to happen *before* the averaging burst, not during it: a
+// settling error biases every sample the same way, and averaging cannot
+// remove a constant offset. It costs one wasted conversion plus this
+// delay, once per channel per burst — well under 1% of the window.
+//
+// The error is largest between channels sitting at very different
+// voltages, and vanishes when only one channel is sampled — so a
+// single-channel setup will not show it, and adding a second channel
+// later would silently degrade both.
+const unsigned long ADC_SETTLING_US = 50;
 
 void setup() {
   // The baud rate is ignored on the native port — USB CDC always runs at
@@ -41,12 +78,40 @@ void setup() {
   analogReadResolution(12);
 }
 
+// Average every conversion that fits in AVERAGING_WINDOW_US on one pin.
+//
+// The loop is bounded by elapsed time, not by a sample count, because the
+// mains rejection above depends on the window's *duration*. A fixed count
+// would stretch or shrink the window with whatever analogRead() actually
+// costs on a given core version, silently breaking that property.
+static double average_channel(int pin) {
+  // Let the multiplexer settle on this pin before accumulating.
+  analogRead(pin);
+  delayMicroseconds(ADC_SETTLING_US);
+
+  unsigned long sum = 0;
+  unsigned long samples = 0;
+  // micros() wraps roughly every 71 minutes; unsigned subtraction still
+  // gives the correct elapsed time across the wrap.
+  const unsigned long started_at = micros();
+  do {
+    sum += analogRead(pin);
+    samples++;
+  } while (micros() - started_at < AVERAGING_WINDOW_US);
+
+  // A 12-bit count peaks at 4095, so sum stays far inside 32 bits for any
+  // plausible window. do/while guarantees samples >= 1.
+  return (double)sum / (double)samples;
+}
+
 void loop() {
   for (int i = 0; i < CHANNEL_COUNT; i++) {
     SerialUSB.print(CHANNEL_NAMES[i]);
     SerialUSB.print(',');
+    // Two decimals: rounding the mean back to a whole count would throw
+    // away exactly the sub-LSB resolution the averaging just bought.
     // println() emits CRLF; the host tolerates both CRLF and LF.
-    SerialUSB.println(analogRead(CHANNEL_PINS[i]));
+    SerialUSB.println(average_channel(CHANNEL_PINS[i]), 2);
   }
 
   delay(SAMPLE_INTERVAL_MS);

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -148,7 +148,7 @@ class Calibration:
 
 
 def raw_to_voltage(
-    raw_count: int,
+    raw_count: float,
     resolution_bits: int = ADC_RESOLUTION_BITS,
     v_ref: float = ADC_VREF_VOLTS,
 ) -> pint.Quantity:
@@ -156,6 +156,9 @@ def raw_to_voltage(
 
     Defaults suit a 3.3V, 12-bit ADC; another part just passes its own
     resolution and reference voltage rather than needing a special case.
+
+    The count may be fractional, since a board that averages several
+    conversions per reading resolves below one ADC step.
     """
     # (1 << bits) - 1 is 2**bits - 1, the highest count the ADC reports.
     full_scale = (1 << resolution_bits) - 1

--- a/src/labmon/sensors/serial_source.py
+++ b/src/labmon/sensors/serial_source.py
@@ -8,11 +8,18 @@ No throughput here justifies a binary framing, and plain text stays
 debuggable with nothing more than `screen` or `minicom` when a board
 misbehaves.
 
+The count may be fractional: a board that averages several conversions
+per reading reports a mean, and rounding it back to a whole count would
+discard the sub-LSB resolution that averaging buys. Whole counts parse
+just as well, so a board that sends one snapshot per reading needs no
+change.
+
 Nothing in this module knows what a count *means* — turning one into a
 physical quantity is `labmon.calibration`'s job.
 """
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -38,7 +45,7 @@ class RawReading:
     """One uncalibrated sample: which channel, and what count it reported."""
 
     channel: str
-    raw_count: int
+    raw_count: float
 
 
 class SerialPort(Protocol):
@@ -85,10 +92,18 @@ def parse_reading(line: bytes) -> RawReading | None:
         return None
 
     try:
-        return RawReading(channel=channel, raw_count=int(raw_count))
+        count = float(raw_count)
     except ValueError:
-        logger.warning("Skipping malformed line (count is not an integer): %r", line)
+        logger.warning("Skipping malformed line (count is not a number): %r", line)
         return None
+
+    # float() accepts "nan" and "inf", which would otherwise reach InfluxDB
+    # and poison every aggregate computed over the series.
+    if not math.isfinite(count):
+        logger.warning("Skipping malformed line (count is not finite): %r", line)
+        return None
+
+    return RawReading(channel=channel, raw_count=count)
 
 
 def open_serial_port(

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -40,6 +40,20 @@ def test_parse_reading_tolerates_surrounding_whitespace() -> None:
     )
 
 
+def test_parse_reading_keeps_a_fractional_count() -> None:
+    # A board averaging several conversions per reading resolves below one
+    # ADC step; rounding here would discard exactly that gain.
+    assert parse_reading(b"A0,2048.31\r\n") == RawReading(
+        channel="A0", raw_count=2048.31
+    )
+
+
+def test_parse_reading_accepts_scientific_notation() -> None:
+    assert parse_reading(b"A0,2.04831e3\r\n") == RawReading(
+        channel="A0", raw_count=2048.31
+    )
+
+
 def test_parse_reading_ignores_an_empty_read() -> None:
     # A read timeout yields no bytes; that is normal, not a malformed line.
     assert parse_reading(b"") is None
@@ -55,6 +69,11 @@ def test_parse_reading_ignores_a_blank_line() -> None:
         pytest.param(b"garbage\n", id="no-separator"),
         pytest.param(b"A0,2048,extra\n", id="too-many-fields"),
         pytest.param(b"A0,not-a-number\n", id="non-numeric-count"),
+        # float() would accept these where int() did not; a non-finite
+        # count reaching InfluxDB poisons every aggregate over the series.
+        pytest.param(b"A0,nan\n", id="nan-count"),
+        pytest.param(b"A0,inf\n", id="inf-count"),
+        pytest.param(b"A0,-inf\n", id="negative-inf-count"),
         pytest.param(b",2048\n", id="empty-channel"),
         pytest.param(b"\xff\xfe\n", id="undecodable-bytes"),
     ],


### PR DESCRIPTION
## What

The reference sketch sampled each channel once per second, discarding the other 999.996 ms of a board that can convert roughly 25,000 times a second. It now averages a burst of conversions instead, and settles the ADC multiplexer before each burst.

## The two changes to the sketch

**Averaging.** The burst window is derived from `MAINS_FREQUENCY_HZ` rather than set as a round number of milliseconds — integrating over a whole number of mains periods cancels 50/60 Hz pickup, the same trick a bench multimeter's NPLC setting uses. It only works if the window is an exact multiple of the period, hence deriving it. **A 60 Hz grid needs that constant changed.**

The burst is bounded by elapsed time, not by a sample count. A fixed count would stretch or shrink the window with whatever `analogRead()` actually costs on a given core version, silently breaking the hum rejection.

**Mux settling.** The Due's analog inputs share one ADC behind a multiplexer, so the first conversion after a channel switch is still pulled toward the previous channel's voltage. The sketch now discards one conversion and pauses `ADC_SETTLING_US` before accumulating — *before* the burst rather than during it, since a settling error biases every sample equally and averaging cannot remove a constant offset. It costs ~90 µs out of a 20 ms window.

This error is invisible on a single-channel setup and appears as soon as a second channel is added. Credit to [JPBureik/experiment-monitoring](https://github.com/JPBureik/experiment-monitoring), where it is documented against the same board after years of continuous running.

## Host side

Averaging resolves below one ADC step, so rounding the mean back to a whole count would discard exactly what it buys. Counts are now fractional on the wire (`A0,2048.31`) and parse as floats:

- `RawReading.raw_count` and `raw_to_voltage()` widen from `int` to `float`. Everything downstream is a Pint quantity already, so nothing else changes.
- Whole counts still parse — `float("2048")` is fine — so a board sending one snapshot per reading keeps working unchanged.
- `float()` accepts `"nan"` and `"inf"` where `int()` did not. Non-finite counts are now rejected explicitly, rather than reaching InfluxDB and poisoning every aggregate computed over the series.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 82 passed, 100% coverage
- [x] `ruff check`, `basedpyright` (0 errors, 0 warnings), `typos` all clean
- [x] New cases: fractional count, scientific notation, and `nan`/`inf`/`-inf` rejection
- [ ] **Unverified on hardware** — the sketch still has never run on a physical Due. The settling delay and the mains-period window both need checking against a known voltage, and the effective sample count per burst is an estimate until `analogRead()` is timed on the board.