### PR TITLE
feat: store the voltage a reading was converted from

### DIFF
--- a/calibration.example.toml
+++ b/calibration.example.toml
@@ -14,6 +14,12 @@
 # for an absolute temperature, or delta_degC for a relative span. A file
 # that gets this wrong is rejected at startup, not mid-run.
 
+# Every reading is written with the voltage it was converted from, in an
+# input_volts field, so a calibration corrected later can be applied to
+# readings already stored. Uncomment to turn that off for every channel
+# below; individual channels can override it either way.
+# store_input = false
+
 # --- linear: one dimensioned factor -------------------------------------
 # For a response through the origin, e.g. from a linear fit of measured
 # value against sensor voltage. The reading's unit is derived from the

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -19,7 +19,9 @@ means lives on the host, where it can be changed without reflashing:
 3. That voltage is converted to a physical quantity by the channel's
    entry in the calibration file (see the modes below).
 4. The result is written as a point, tagged with the channel's
-   `sensor_id` and its `unit`.
+   `sensor_id` and its `unit`, in a `value` field — alongside an
+   `input_volts` field holding the voltage from step 2 (see
+   [Keeping the conversion's input](#keeping-the-conversions-input)).
 
 A malformed line, or a channel with no calibration entry, is logged and
 skipped rather than being fatal — one bad line shouldn't stop a
@@ -64,6 +66,41 @@ factor × volts — adding millibars to kelvin is caught here.
 
 Voltages are always in **volts**, the ADC's own output. A datasheet
 quoted in millivolts gets scaled once, visibly, in the config.
+
+### Keeping the conversion's input
+
+Each reading is stored twice: the converted `value`, and the voltage it
+came from in an `input_volts` field.
+
+The second one is what makes a calibration correctable after the fact.
+Conversions are not generally invertible — `piecewise_linear` clamps
+outside its measured range, so every out-of-range reading collapsed onto
+the same endpoint, and `expression` is arbitrary — so a `value` alone
+cannot be recomputed under a corrected calibration. It also distinguishes
+a fault in the instrument from one in the config: if `value` jumps while
+`input_volts` is flat, the sensor is fine and the calibration isn't. A
+floating or saturated input shows up as `input_volts` pinned at 0 or at
+`--vref`, which a clamping conversion would otherwise hide behind a
+plausible-looking physical value.
+
+It costs one float per reading. Turn it off per channel, or file-wide:
+
+```toml
+store_input = false          # file-wide default
+
+[channels.A0]
+sensor_id = "cryo-77k"
+measurement = "temperature"
+conversion_factor = "42.5 kelvin / volt"
+store_input = true           # ... overridden for this channel
+```
+
+Existing Grafana panels are unaffected: they select `value` explicitly
+and won't pick up the new field unless asked.
+
+Note that `--vref` and `--resolution-bits` are *not* recorded. They don't
+need to be — both scale the stored voltage linearly, so getting either
+wrong stays correctable with a query.
 
 ### Choosing between `spline` and `piecewise_linear`
 

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -52,6 +52,13 @@ VOLTAGE_SYMBOL = "v"
 
 DEFAULT_MODE = "linear"
 
+# Whether to store the voltage a reading was converted from alongside the
+# converted value. On by default: a conversion is not generally
+# invertible (piecewise_linear clamps, expression is arbitrary), so
+# without the input, correcting a wrong calibration cannot reach readings
+# already written.
+DEFAULT_STORE_INPUT = True
+
 _COMMON_KEYS = ("sensor_id", "measurement")
 
 _OFFSET_UNIT_MESSAGE = (
@@ -145,6 +152,7 @@ class Calibration:
     sensor_id: str
     measurement: str
     conversion: Conversion
+    store_input: bool = DEFAULT_STORE_INPUT
 
 
 def raw_to_voltage(
@@ -176,13 +184,22 @@ def load_calibration(path: Path) -> dict[str, Calibration]:
     if not isinstance(raw_channels, dict) or not raw_channels:
         raise CalibrationError(f"{path}: no [channels.<name>] section found")
 
+    # A top-level store_input sets the default for every channel; each
+    # channel may still override it.
+    default_store_input = _optional_bool(
+        str(path), document, "store_input", DEFAULT_STORE_INPUT
+    )
+
     channels = cast(dict[str, object], raw_channels)
     return {
-        name: _parse_channel(path, name, entry) for name, entry in channels.items()
+        name: _parse_channel(path, name, entry, default_store_input)
+        for name, entry in channels.items()
     }
 
 
-def _parse_channel(path: Path, name: str, entry: object) -> Calibration:
+def _parse_channel(
+    path: Path, name: str, entry: object, default_store_input: bool
+) -> Calibration:
     if not isinstance(entry, dict):
         raise CalibrationError(
             f"{path}: channel '{name}' must be a [channels.{name}] table"
@@ -206,6 +223,7 @@ def _parse_channel(path: Path, name: str, entry: object) -> Calibration:
         sensor_id=common["sensor_id"],
         measurement=common["measurement"],
         conversion=conversion,
+        store_input=_optional_bool(where, fields, "store_input", default_store_input),
     )
 
 
@@ -226,7 +244,9 @@ def _trial_apply(where: str, conversion: Conversion) -> None:
 
 
 def _build_linear(where: str, fields: dict[str, object]) -> Conversion:
-    return LinearConversion(factor=_require_quantity(where, fields, "conversion_factor"))
+    return LinearConversion(
+        factor=_require_quantity(where, fields, "conversion_factor")
+    )
 
 
 def _build_affine(where: str, fields: dict[str, object]) -> Conversion:
@@ -308,6 +328,17 @@ def _require_str(where: str, fields: dict[str, object], key: str) -> str:
     value = fields[key]
     if not isinstance(value, str):
         raise CalibrationError(f"{where} key '{key}' must be a string")
+    return value
+
+
+def _optional_bool(
+    where: str, fields: dict[str, object], key: str, default: bool
+) -> bool:
+    if key not in fields:
+        return default
+    value = fields[key]
+    if not isinstance(value, bool):
+        raise CalibrationError(f"{where} key '{key}' must be true or false")
     return value
 
 

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -36,6 +36,7 @@ from labmon.calibration import (
     Calibration,
     load_calibration,
     raw_to_voltage,
+    ureg,
 )
 from labmon.influx import INFLUXDB_DATABASE, get_client
 from labmon.sensors.serial_source import (
@@ -52,6 +53,12 @@ logger: logging.Logger = logging.getLogger(__name__)
 # sensor's --field, there's nothing to vary here: a channel's identity
 # lives in its sensor_id tag, not in the field name.
 FIELD_NAME = "value"
+
+# The voltage a reading was converted from, written alongside the
+# converted value unless the channel opts out (see Calibration.store_input).
+# Named for its unit because the `unit` tag describes the converted value,
+# not this.
+INPUT_FIELD_NAME = "input_volts"
 
 
 def run(
@@ -113,6 +120,11 @@ def run(
             .field(FIELD_NAME, value.magnitude)
             .time(datetime.now(UTC), write_precision="ms")
         )
+        if calibration.store_input:
+            # Keeping the conversion's input makes a wrong calibration
+            # correctable after the fact; without it, readings already
+            # written can't be recomputed.
+            point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
         writer.write(point)
         logger.info("%s: %.4g %s", calibration.sensor_id, value.magnitude, value.units)
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -287,6 +287,99 @@ def test_load_calibration_reads_every_channel(tmp_path: Path) -> None:
     assert isinstance(channels["A1"].conversion, AffineConversion)
 
 
+def test_load_calibration_stores_the_conversion_input_by_default(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+        [channels.A0]
+        sensor_id = "cryo-77k"
+        measurement = "temperature"
+        conversion_factor = "42.5 kelvin / volt"
+        """,
+    )
+
+    assert load_calibration(path)["A0"].store_input is True
+
+
+def test_load_calibration_honours_a_per_channel_store_input(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+        [channels.A0]
+        sensor_id = "cryo-77k"
+        measurement = "temperature"
+        conversion_factor = "42.5 kelvin / volt"
+        store_input = false
+        """,
+    )
+
+    assert load_calibration(path)["A0"].store_input is False
+
+
+def test_load_calibration_lets_a_channel_override_the_file_default(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+        store_input = false
+
+        [channels.A0]
+        sensor_id = "cryo-77k"
+        measurement = "temperature"
+        conversion_factor = "42.5 kelvin / volt"
+
+        [channels.A1]
+        sensor_id = "chamber-1"
+        measurement = "pressure"
+        conversion_factor = "1e-6 mbar / volt"
+        store_input = true
+        """,
+    )
+
+    channels = load_calibration(path)
+
+    assert channels["A0"].store_input is False
+    assert channels["A1"].store_input is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(
+            """
+            store_input = "yes"
+
+            [channels.A0]
+            sensor_id = "cryo-77k"
+            measurement = "temperature"
+            conversion_factor = "42.5 kelvin / volt"
+            """,
+            id="file-level",
+        ),
+        pytest.param(
+            """
+            [channels.A0]
+            sensor_id = "cryo-77k"
+            measurement = "temperature"
+            conversion_factor = "42.5 kelvin / volt"
+            store_input = "yes"
+            """,
+            id="channel-level",
+        ),
+    ],
+)
+def test_load_calibration_rejects_a_non_boolean_store_input(
+    tmp_path: Path, body: str
+) -> None:
+    path = _write_config(tmp_path, body)
+
+    with pytest.raises(CalibrationError, match="must be true or false"):
+        _ = load_calibration(path)
+
+
 def test_load_calibration_rejects_a_file_without_channels(tmp_path: Path) -> None:
     path = _write_config(tmp_path, "title = 'not a calibration file'\n")
 

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -48,11 +48,12 @@ class FakeRawSource:
         self.closed = True
 
 
-def _temperature_calibration() -> Calibration:
+def _temperature_calibration(store_input: bool = True) -> Calibration:
     return Calibration(
         sensor_id="cryo-77k",
         measurement="temperature",
         conversion=LinearConversion(factor=ureg("42.5 kelvin / volt")),
+        store_input=store_input,
     )
 
 
@@ -91,8 +92,51 @@ def test_run_writes_a_calibrated_point(
     [point] = batch
     line = point.to_line_protocol()
     # A full-scale count is ~3.3V, so 3.3 * 42.5 K/V is ~140.25 K, and
-    # the unit tag comes from pint's own short-form symbol.
-    assert line.startswith("temperature,sensor_id=cryo-77k,unit=K value=140.2")
+    # the unit tag comes from pint's own short-form symbol. Line protocol
+    # orders fields alphabetically, so the input precedes the value.
+    assert line.startswith("temperature,sensor_id=cryo-77k,unit=K ")
+    assert "value=140.2" in line
+    assert "input_volts=3.3" in line
+
+
+def test_run_stores_the_conversion_input_by_default(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # Half of full scale is ~1.65V; keeping it makes a wrong calibration
+    # correctable after the fact.
+    source = FakeRawSource([RawReading(channel="A0", raw_count=2048)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    # The writer batches on a background thread; closing it flushes.
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "input_volts=1.65" in point.to_line_protocol()
+
+
+def test_run_omits_the_conversion_input_when_the_channel_opts_out(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+
+    with pytest.raises(_StopLoop):
+        run(
+            source=source,
+            calibrations={"A0": _temperature_calibration(store_input=False)},
+        )
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    line = point.to_line_protocol()
+    assert "input_volts" not in line
+    assert "value=140.2" in line
 
 
 @pytest.mark.usefixtures("fake_client")


### PR DESCRIPTION
First of the two changes from the provenance discussion. The second (`calibration_id` + a `[provenance]` sub-table) follows separately.

## Problem

`serial_sensor.py` wrote only `value.magnitude`. The voltage it was converted from — the input to the conversion — existed nowhere afterwards.

That makes a wrong calibration permanently wrong for everything already stored. Fixing `calibration.toml` only ever helps future readings, and the old ones can't be recomputed even in principle:

- **The conversions aren't invertible.** `piecewise_linear` clamps outside its measured range, so every out-of-range reading collapsed onto the same endpoint value — information destroyed, not transformed. `expression` is arbitrary.
- **There's no record of which calibration produced a row.** Even where inversion works (`linear`, `affine`), you'd need to know what was in force at each timestamp.

## Change

Each point gains an `input_volts` field beside `value`, same measurement, tags and timestamp.

Two diagnostics come free:

- `value` jumps while `input_volts` is flat → the fault is the calibration or the software, not the instrument. That question comes up every time a reading looks wrong.
- A floating or saturated input is visible as a voltage pinned at 0 or `--vref`. Through a clamping conversion it would otherwise land on a perfectly plausible physical value.

## Volts, not raw counts

A count is meaningless without `--resolution-bits` and `--vref`, which are CLI arguments recorded nowhere. A voltage is self-describing, and it's the direct input to the layer that actually gets revised. Nothing is lost: both parameters scale the stored voltage linearly, so either being wrong stays correctable with a query.

## Configuration

On by default — the failure mode of not having it is unrecoverable, the cost is one float per reading, and a slowly-varying float compresses well in a columnar store.

```toml
store_input = false          # file-wide default

[channels.A0]
sensor_id = "cryo-77k"
measurement = "temperature"
conversion_factor = "42.5 kelvin / volt"
store_input = true           # ... overridden per channel
```

A non-boolean value is rejected at startup, at either level.

## Compatibility

Existing Grafana panels select `value` explicitly and won't pick up the new field unless asked. Points written before this change simply lack it.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 84 passed, 100% coverage
- [x] `ruff check`, `basedpyright` (0 errors, 0 warnings), `typos` clean
- [x] New cases: field present by default, absent when opted out, per-channel override of a file-wide default, non-boolean rejected at both levels
- [x] Existing line-protocol assertion updated — fields serialise alphabetically, so `input_volts` now precedes `value`