### PR TITLE
docs: make the affine example a bipolar input range

### DIFF
--- a/calibration.example.toml
+++ b/calibration.example.toml
@@ -32,13 +32,13 @@ conversion_factor = "50.0 mW / volt"   # 3.3V full scale -> ~165 mW
 # --- affine: a factor plus an offset ------------------------------------
 # Same, for a fit that doesn't pass through the origin. The offset must
 # be dimensionally consistent with factor x volts, which is checked at
-# startup — "5 mbar" here would be rejected rather than silently wrong.
+# startup.
 [channels.A1]
-sensor_id = "pressure-transducer"
-measurement = "pressure"
+sensor_id = "voltage-1"
+measurement = "voltage" # remapping the [0, 3.3]V Arduino input range onto the [-15, 15] V range
 mode = "affine"
-conversion_factor = "40.0 kPa / volt"
-offset = "-12.5 kPa"
+conversion_factor = "9.0909091"
+offset = "-15 V"
 
 # --- spline: a cubic through measured points ----------------------------
 # For a curved response characterised by calibration measurements.


### PR DESCRIPTION
## What

The `affine` channel in `calibration.example.toml` converted volts to kPa, which mostly repeated what the `linear` example directly above already demonstrated. It now shows the case the mode is actually reached for: a signal outside the board's own input range, remapped from the Arduino's [0, 3.3] V onto [-15, 15] V.

```toml
[channels.A1]
sensor_id = "voltage-1"
measurement = "voltage" # remapping the [0, 3.3]V Arduino input range onto the [-15, 15] V range
mode = "affine"
conversion_factor = "9.0909091"
offset = "-15 V"
```

Incidentally it also exercises a **dimensionless** conversion factor — the resulting unit comes from the offset rather than the factor, which nothing else in the example file covers.

## Verified

Endpoints and midpoint land exactly where they should:

```
  0.0 V in -> -15.000000 V
 1.65 V in ->  +0.000000 V
  3.3 V in -> +15.000000 V
```

(30 V / 3.3 V = 9.0909090…; truncating the factor at 8 significant digits costs ~30 nV at full scale.)

## Test plan

- [x] `test_the_shipped_example_file_is_valid` passes — the guard that the example still loads
- [x] `typos` clean