### PR TITLE
docs: add a code of conduct, issue forms, and a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,112 @@
+name: Bug report
+description: Something in labmon does not behave the way the docs say it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most problems here turn out to be wiring rather than logic — a
+        container that cannot reach another, a token that does not match, a
+        panel querying a column that was never written. The questions below
+        are aimed at that, so please answer them even when the cause seems
+        obvious.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which part
+      options:
+        - Server (InfluxDB + Grafana)
+        - mock-sensor
+        - serial-sensor / calibration
+        - Grafana dashboard or panels
+        - Demo stack
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: topology
+    attributes:
+      label: How it is running
+      description: >-
+        Worth stating even for a bug that looks unrelated to networking; a
+        surprising number are not.
+      options:
+        - Everything on one machine (the quickstart)
+        - Server on one machine, sensors on another
+        - Bare install, no Docker
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce it
+      description: Commands, config, and anything you changed from the defaults.
+      placeholder: |
+        1. cp .env.example .env, set ...
+        2. docker compose up -d --wait
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: >-
+        Usually `docker compose logs --tail 100`. Two lines are expected and
+        are not the bug: InfluxDB logging "the request was not authenticated"
+        once a second (its own healthcheck), and `labmon-init-state-dirs`
+        exiting immediately (it is a one-shot). See docs/deployment.md.
+      render: shell
+
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: >-
+        `docker compose version`, the image tags from your `docker compose ps`,
+        and your OS. Add `python --version` for a bare install.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware and calibration
+      description: >-
+        Only for `serial-sensor` problems. The board and how it is connected,
+        a few raw lines as the host sees them (`<channel>,<count>`), and the
+        relevant `[channels.*]` block from your calibration TOML. If a reading
+        is wrong rather than absent, the voltage you measured at the input is
+        the single most useful number you can give.
+      render: shell
+
+  - type: checkboxes
+    id: no-secrets
+    attributes:
+      label: Before submitting
+      options:
+        - label: >-
+            I have checked that nothing above contains an `apiv3_...` token, a
+            password, or anything else from my `.env`.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/quentinmarolleau/labmon/tree/main/docs
+    about: >-
+      Setup, deployment, the demo stack, and the Grafana wrinkles worth
+      knowing before reporting a dashboard problem.
+  - name: Contributing
+    url: https://github.com/quentinmarolleau/labmon/blob/main/CONTRIBUTING.md
+    about: Branching, commit format, and what has to pass before a PR.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,50 @@
+name: Idea or feature request
+description: Something labmon should be able to do and cannot.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        [`BACKLOG.md`](https://github.com/quentinmarolleau/labmon/blob/main/BACKLOG.md)
+        already tracks several larger ideas with effort estimates — TLS,
+        mDNS discovery, a docs site, digitizing analog gauges. If yours is
+        one of them, adding your reasoning to this issue is more useful than
+        a duplicate: what the backlog entry lacks is a concrete need.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: >-
+        The situation you were in, not the feature you have in mind. The
+        feature is easier to design once the problem is clear.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you would like to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried or considered instead
+      description: Including "nothing" — that is useful to know too.
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Does verifying this need physical hardware
+      description: >-
+        Several parts of this project cannot be fully tested without a board
+        or an instrument in hand, which affects how it gets scheduled.
+      options:
+        - "No"
+        - "Yes, and I have it"
+        - "Yes, and I do not have it"
+        - Not sure
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Keep this short. A PR nobody reads carefully is worse than no template.
+Delete any section that has nothing to say.
+-->
+
+## What and why
+
+<!--
+The diff already shows what changed — spend this space on why, the same way
+CONTRIBUTING asks commit bodies to. If it fixes an issue, "Closes #n".
+-->
+
+## Test plan
+
+- [ ] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100`
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run basedpyright`
+- [ ] `uv run typos`
+
+<!--
+Touching docker-compose.yml, the Dockerfile, grafana/ or demo/? Bring the
+stack up and run `python3 scripts/smoke_dashboard.py` as well — the unit
+tests cannot see anything that only breaks once containers are running.
+
+Verified something by hand? Say what you actually observed, not just that
+you checked. "All 14 dashboard queries returned rows" beats "tested locally".
+-->
+
+## Notes for the reviewer
+
+<!--
+Backlog item this addresses (BL-n), anything you deliberately left out, and
+any decision here you would like pushed back on.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, email **q.marolleau-dev@pm.me**. Reports are read only by the maintainer, who is currently the project's sole Community Moderator — so "Community Moderators" below should be read in the singular until that changes. Do not report a violation in a public issue or pull request.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/). It is used unmodified except for the reporting contact above and the note that this project currently has a single moderator.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,13 @@ All four must pass locally — they're exactly what CI runs.
   testing it would only prove Python's own import mechanism works, not
   our code). Don't reach for it to avoid writing a real test.
 
+## Conduct
+
+Participation is covered by the
+[Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant 3.0).
+Report a possible violation by email to q.marolleau-dev@pm.me rather than
+in a public issue.
+
 ## Docs
 
 - Component usage docs live in `docs/` (one file per component, e.g.


### PR DESCRIPTION
Three commits, one per artifact.

## Code of conduct

Contributor Covenant **3.0**, used unmodified apart from the two places the Covenant expects a project to fill in.

Writing one from scratch would have been worse than adopting the standard: the Covenant is recognised on sight, has been argued over by people who do this seriously, and ships an enforcement ladder that answers "and then what?" — the question homemade codes tend to leave open.

Two edits worth flagging:

- **Reporting goes to `q.marolleau-dev@pm.me`**, with an explicit "not in a public issue".
- **A sentence saying "Community Moderators" is one person right now.** The Covenant is written for a team. Better to say so than to let someone discover it while filing a report.

Attribution and the CC BY-SA 4.0 notice are preserved verbatim, with a line noting exactly what was changed — that is what the licence asks for.

## Issue forms

Forms (`.yml`) rather than markdown templates, so fields are genuinely required instead of being deleted along with the boilerplate.

**`bug.yml`** asks what this project actually needs: which component, how the stack is deployed, and logs. Most reports here will be wiring rather than logic, and none of that is guessable from a description of the symptom. It also names the two log lines that look like failures and are not — the 1 Hz healthcheck 401 and `labmon-init-state-dirs` exiting — so they stop getting reported as the bug.

Two fields are specific to this project rather than generic:

- A **hardware and calibration** block, because a `serial-sensor` report without raw counts and the relevant `[channels.*]` entry cannot be acted on at all. It asks for the measured input voltage, which is the single most useful number when a reading is wrong rather than absent.
- A **required confirmation that no `apiv3_` token was pasted in.** Every useful log in this project sits next to one, and the fastest way to leak a token is to paste `docker compose logs` into a public issue.

**`feature.yml`** points at `BACKLOG.md` first and asks for the *problem* before the proposed feature, plus whether verifying it needs hardware — which genuinely determines how it gets scheduled here.

**One change from what I proposed:** blank issues stay **enabled**. With Discussions off and only two forms, a question fitting neither would have nowhere to go. One line in `config.yml` if you disagree.

## PR template

Codifies what `CONTRIBUTING.md` already asks for: why rather than what, the five commands that must pass, and a reminder to run the smoke script when a change can only break once containers are running. Deliberately short — a long template gets selected and deleted whole, which leaves less behind than no template.

## Ordering

The test-plan checklist lists `ruff format --check` (#31) and the smoke script (#33). Neither is on `main` yet, so **merge this after #31**, or the checklist names a command that does not exist.

## Test plan

- [x] All four `.github/*.yml` files parse (checked in a container, since PyYAML is not a dependency here)
- [x] `uv run typos`
- [ ] GitHub accepts the issue forms — its schema is stricter than YAML validity, and a rejected form shows as a banner on the Issues tab. Worth opening a throwaway issue from each form after merge and closing it.
- [ ] The PR template renders on the next PR opened after this merges
- [ ] Community Standards checklist (Insights → Community Standards) shows the code of conduct as present
