### PR TITLE
perf: cut the acquisition loop from 275 us to 111 us per reading

### DIFF
--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -29,6 +29,7 @@ in millivolts gets scaled once, visibly, when writing the config.
 """
 
 import bisect
+import functools
 import hashlib
 import itertools
 import tomllib
@@ -51,6 +52,10 @@ ADC_VREF_VOLTS = 3.3
 
 # The name an `expression` conversion uses for the measured voltage.
 VOLTAGE_SYMBOL = "v"
+
+# Applied at load time to check a conversion works and to read off the
+# unit its results carry.
+ONE_VOLT: pint.Quantity = 1.0 * ureg.volt
 
 DEFAULT_MODE = "linear"
 
@@ -229,16 +234,33 @@ class Calibration:
     store_input: bool = DEFAULT_STORE_INPUT
     provenance: Mapping[str, object] = NO_PROVENANCE
 
-    @property
+    @functools.cached_property
     def calibration_id(self) -> str:
         """Short hash identifying which conversion produced a reading.
 
         Written as a tag so a stored reading can be matched back to the
         calibration file that produced it — the file itself is in version
         control, so the database only needs to say *which* revision.
+
+        Cached because it is read once per reading and cannot change: the
+        conversion is fixed when the file is parsed. Recomputing it meant
+        hashing a fingerprint built from pint unit formatting on every
+        sample, which measured at a fifth of the acquisition loop.
         """
         digest = hashlib.sha256(self.conversion.fingerprint().encode()).hexdigest()
         return digest[:CALIBRATION_ID_LENGTH]
+
+    @functools.cached_property
+    def unit(self) -> str:
+        """The unit tag every reading from this channel carries.
+
+        Derived by converting one volt, so it reflects what the
+        conversion actually produces rather than what the file claims.
+        Cached for the same reason as calibration_id: a conversion's
+        output unit is a property of the calibration, not of a reading,
+        and formatting it per sample cost more than building the point.
+        """
+        return f"{self.conversion.apply(ONE_VOLT).units:~}"
 
 
 def raw_to_voltage(
@@ -318,7 +340,7 @@ def _parse_channel(
 def _trial_apply(where: Location, conversion: Conversion) -> None:
     """Convert a token voltage so a broken conversion fails at load time."""
     try:
-        _ = conversion.apply(1.0 * ureg.volt)
+        _ = conversion.apply(ONE_VOLT)
     except CalibrationError:
         raise
     except pint.OffsetUnitCalculusError as error:

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -141,7 +141,7 @@ def run(
         point = (
             Point(calibration.measurement)
             .tag("sensor_id", calibration.sensor_id)
-            .tag("unit", f"{value.units:~}")
+            .tag("unit", calibration.unit)
             .tag(CALIBRATION_ID_TAG, calibration.calibration_id)
             .field(FIELD_NAME, value.magnitude)
             .time(datetime.now(UTC), write_precision="ms")

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -23,6 +23,8 @@ import argparse
 import logging
 import signal
 import sys
+import time
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from types import FrameType
@@ -64,6 +66,14 @@ INPUT_FIELD_NAME = "input_volts"
 # field so it can be filtered and grouped on; cardinality stays low
 # because a calibration changes a handful of times over a sensor's life.
 CALIBRATION_ID_TAG = "calibration_id"
+
+# How often to report that readings are still arriving. The per-reading
+# line moved to DEBUG because at 100 Hz across a handful of channels it
+# emits hundreds of lines a second, which costs a fifth of the
+# acquisition loop and buries the warnings worth seeing. This keeps the
+# "it is working" signal an operator actually wants, at a volume a
+# journal can hold.
+SUMMARY_INTERVAL_SECONDS = 30.0
 
 
 def _log_calibrations(calibrations: dict[str, Calibration]) -> None:
@@ -118,6 +128,9 @@ def run(
     # warn once each rather than on every reading forever.
     warned_channels: set[str] = set()
 
+    written: Counter[str] = Counter()
+    next_summary = time.monotonic() + SUMMARY_INTERVAL_SECONDS
+
     while True:
         reading = source.read()
         if reading is None:
@@ -152,7 +165,21 @@ def run(
             # written can't be recomputed.
             point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
         writer.write(point)
-        logger.info("%s: %.4g %s", calibration.sensor_id, value.magnitude, value.units)
+        written[calibration.sensor_id] += 1
+        logger.debug(
+            "%s: %.4g %s", calibration.sensor_id, value.magnitude, calibration.unit
+        )
+
+        now = time.monotonic()
+        if now >= next_summary:
+            logger.info(
+                "Wrote %d reading(s) in the last %.0fs (%s)",
+                written.total(),
+                SUMMARY_INTERVAL_SECONDS,
+                ", ".join(f"{name} {count}" for name, count in sorted(written.items())),
+            )
+            written.clear()
+            next_summary = now + SUMMARY_INTERVAL_SECONDS
 
 
 def main() -> None:

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,10 +1,12 @@
 from pathlib import Path
+from typing import cast
 
 import pint
 import pytest
 
 from labmon.calibration import (
     AffineConversion,
+    Calibration,
     CalibrationError,
     ExpressionConversion,
     InterpolatedConversion,
@@ -15,6 +17,27 @@ from labmon.calibration import (
     raw_to_voltage,
     ureg,
 )
+
+
+class _CountingConversion:
+    """A conversion that reports how often it was asked to do work.
+
+    Both `calibration_id` and `unit` are cached because they are read
+    once per reading and cannot change; counting is how a test says that
+    without reaching into the cache itself.
+    """
+
+    def __init__(self) -> None:
+        self.fingerprints: int = 0
+        self.applications: int = 0
+
+    def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
+        self.applications += 1
+        return voltage * ureg("42.5 kelvin / volt")
+
+    def fingerprint(self) -> str:
+        self.fingerprints += 1
+        return "counting|42.5 kelvin / volt"
 
 
 def _write_config(tmp_path: Path, body: str) -> Path:
@@ -899,3 +922,46 @@ def test_load_calibration_rejects_an_expression_that_is_not_numeric(
 
     with pytest.raises(CalibrationError, match="not a number"):
         _ = load_calibration(path)
+
+
+def test_calibration_id_is_computed_once_per_calibration() -> None:
+    """It is read once per reading, so recomputing it dominated the loop."""
+    calibration = Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=_CountingConversion(),
+    )
+    conversion = cast(_CountingConversion, calibration.conversion)
+
+    first = calibration.calibration_id
+    second = calibration.calibration_id
+
+    assert first == second
+    assert conversion.fingerprints == 1
+
+
+def test_unit_is_derived_from_the_conversion_and_computed_once() -> None:
+    """The unit tag describes the calibration, not the individual reading."""
+    calibration = Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=_CountingConversion(),
+    )
+    conversion = cast(_CountingConversion, calibration.conversion)
+
+    assert calibration.unit == "K"
+    assert calibration.unit == "K"
+    assert conversion.applications == 1
+
+
+def test_unit_matches_what_a_reading_actually_carries() -> None:
+    """A cached unit is only safe while it agrees with the live conversion."""
+    calibration = Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=LinearConversion(factor=ureg("42.5 kelvin / volt")),
+    )
+
+    converted = calibration.conversion.apply(2.0 * ureg.volt)
+
+    assert calibration.unit == f"{converted.units:~}"

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -1,6 +1,7 @@
 import logging
 import signal
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 from types import FrameType
@@ -331,3 +332,55 @@ def test_main_parses_custom_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     [call] = run_calls
     assert call["resolution_bits"] == 10
     assert call["v_ref"] == 5.0
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_per_reading_lines_are_debug_not_info(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """At 100 Hz an INFO line per reading buries every warning worth seeing."""
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=serial_sensor.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    reading_lines = [
+        record for record in caplog.records if "140.2" in record.getMessage()
+    ]
+    assert [record.levelno for record in reading_lines] == [logging.DEBUG]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_a_summary_is_logged_once_the_interval_elapses(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-reading line moved to DEBUG, so this carries "it is working"."""
+    # Two readings: the clock jumps past the interval only for the second,
+    # so exactly one summary covering both should be emitted. Patched on
+    # the time module itself, which serial_sensor imports rather than
+    # re-exports.
+    ticks = iter([0.0, 1.0, serial_sensor.SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    source = FakeRawSource(
+        [
+            RawReading(channel="A0", raw_count=4095),
+            RawReading(channel="A0", raw_count=4095),
+        ]
+    )
+
+    with (
+        caplog.at_level(logging.INFO, logger=serial_sensor.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    summaries = [
+        record.getMessage()
+        for record in caplog.records
+        if "Wrote" in record.getMessage()
+    ]
+    assert summaries == ["Wrote 2 reading(s) in the last 30s (cryo-77k 2)"]


### PR DESCRIPTION
Profiling the acquisition loop to answer a question that kept coming up — what sample rate can this stack actually sustain? Two thirds of the per-reading cost turned out to be work that does not depend on the reading.

Measured on the loop body, best-of-5, AMD Ryzen 3 5300U / Python 3.14.5:

```
before                       275.5 us     3,630 readings/s
after                        110.6 us     9,044 readings/s   2.49x
```

## What was slow

`cProfile` over 5,000 readings of the real loop:

| Stage | Share |
| --- | --- |
| `Calibration.calibration_id` | 22% |
| per-reading `logger.info` | 20% |
| `raw_to_voltage` (pint) | 19% |
| `conversion.apply` (pint) | 11% |
| `f"{value.units:~}"` (pint) | ~10% |

Worth recording because it is the opposite of what you would guess: building the `Point` and putting it on the queue costs about 1 us in total. Everything that matters is pint and logging.

## What changed

**Caching (f505a2a).** `calibration_id` was a plain property, so every reading re-ran the conversion's fingerprint through pint unit formatting and then SHA-256'd it — 52 us to rebuild a string fixed when the TOML was parsed. The unit tag had the same shape. Both become `cached_property`, which works on the frozen dataclass because it writes through `__dict__` rather than `setattr`, and leaves hash and equality alone.

**Logging (7306cdb).** One INFO line per reading is hundreds of lines a second at 100 Hz, tens of millions a day in the journal, and enough noise to bury the warnings that matter. It moves to DEBUG, with a 30-second summary in its place reporting how many readings each sensor produced.

The summary is an addition rather than part of the measured change — without it, moving the line to DEBUG removes all per-reading feedback during board bring-up. Easy to drop if you would rather keep this minimal.

## What this means for acquisition rate

1 Hz and 10 Hz were never in question. 100 Hz now holds to roughly 75 channels per process rather than 30.

Two ceilings still sit below the Python one and are unaffected by this PR:

- **Serial wire.** At the documented 115200 baud, a `<channel>,<count>` line caps the link at ~1,440 lines/s, so 100 Hz across 15 channels saturates it. Native USB CDC is not baud-limited.
- **Visibility latency.** Up to ~1.5 s before a reading is queryable — 0.5 s in the writer's queue plus InfluxDB's 1 s WAL flush. Invisible behind the dashboard's 5 s refresh.

## Deliberately not changed

Collapsing pint out of the hot path entirely measured 37x (7.5 us, ~133,000 readings/s, numerically identical). It is not here: it trades directly against BL-2's intent, and 9,000 readings/s is already far past the serial link. Worth revisiting only if something needs it.

## Test plan

- [x] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100` — 119 passed, 100%
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright` — 0 errors, 0 warnings
- [x] `uv run typos`
- [x] Each new test verified to fail when its fix is reverted (3 of 3)
- [x] Speedup re-measured on the merged code, not the prototype

