### PR TITLE
feat: add a helper for sensors behind a manufacturer's API

### DIFF
--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -1,0 +1,220 @@
+"""Write readings from a sensor this package knows nothing about.
+
+`mock-sensor` invents readings and `serial-sensor` reads a board over a
+serial line. Neither helps with the commonest case in a real lab: an
+instrument behind a manufacturer's Python SDK, REST endpoint or CLI, which
+already hands back a value in physical units. What that leaves is the same
+boilerplate every time — build a client, batch the writes, catch a shutdown
+signal, and survive the vendor API having a bad afternoon.
+
+Two entry points, because a sensor is driven in one of two ways:
+
+`poll()` runs forever, reading every `interval` seconds. This is the
+right shape for an instrument you can talk to as often as you like, and it
+is what a container or a systemd service runs.
+
+`write_reading()` writes one value and returns. This is for an API that is
+rate-limited, billed per call, or simply slow — polled every fifteen
+minutes by a systemd timer or cron, rather than by a process that spends
+899 of every 900 seconds asleep.
+
+Example, in full:
+
+    from labmon.sensors.polling import poll
+    import vendor_sdk
+
+    device = vendor_sdk.Device("192.0.2.10")
+
+    poll(
+        lambda: device.read_temperature(),
+        sensor_id="cryo-1",
+        measurement="temperature",
+        unit="K",
+        interval=5.0,
+    )
+
+Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
+"""
+
+import logging
+import signal
+import sys
+import time
+from collections import Counter
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from types import FrameType
+
+from influxdb_client_3 import Point
+
+from labmon.influx import INFLUXDB_DATABASE, get_client
+from labmon.writer import PointWriter
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# A read that raises backs off instead of retrying at the nominal interval,
+# so an instrument that is switched off is not hammered all night. Capped so
+# recovery is still noticed promptly once it comes back.
+INITIAL_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 60.0
+
+# How often to report that readings are still arriving. Matches
+# serial_sensor: one line per reading is unreadable at any real rate, but
+# silence gives an operator no way to tell "working" from "wedged".
+SUMMARY_INTERVAL_SECONDS = 30.0
+
+
+def build_point(
+    value: float,
+    *,
+    sensor_id: str,
+    measurement: str,
+    unit: str = "",
+    field: str = "value",
+    tags: Mapping[str, str] | None = None,
+) -> Point:
+    """Build the point a reading becomes, without writing it.
+
+    Exposed so a sensor with something unusual to record — several fields
+    from one device read, say — can build on the same tag conventions
+    rather than inventing its own.
+    """
+    point = Point(measurement).tag("sensor_id", sensor_id)
+    # An empty unit tag is not the same as no unit tag: it would split the
+    # series in two, and the halves would look identical in a legend.
+    if unit:
+        point = point.tag("unit", unit)
+    for name, tag_value in (tags or {}).items():
+        point = point.tag(name, tag_value)
+    return point.field(field, value).time(datetime.now(UTC), write_precision="ms")
+
+
+def write_reading(
+    value: float,
+    *,
+    sensor_id: str,
+    measurement: str,
+    unit: str = "",
+    field: str = "value",
+    tags: Mapping[str, str] | None = None,
+) -> None:
+    """Write a single reading, and do not return until it is gone.
+
+    Deliberately not `PointWriter`. That queues a point for a background
+    thread, which is exactly right when a process stays up long enough to
+    drain it — and exactly wrong here, where the caller reads once and
+    exits. A daemon thread dies with the interpreter, taking the unwritten
+    point with it.
+
+    The cost is that this blocks for about a second while InfluxDB flushes
+    its WAL (see docs/latency.md). That is the price of the reading
+    actually being stored, and it is paid once per run rather than once per
+    reading.
+    """
+    client = get_client()
+    try:
+        client.write(
+            [
+                build_point(
+                    value,
+                    sensor_id=sensor_id,
+                    measurement=measurement,
+                    unit=unit,
+                    field=field,
+                    tags=tags,
+                )
+            ]
+        )
+    finally:
+        # In a finally so a timer-driven script does not leak a connection
+        # every time the server is unreachable.
+        client.close()
+
+
+def poll(
+    read: Callable[[], float | None],
+    *,
+    sensor_id: str,
+    measurement: str,
+    unit: str = "",
+    interval: float = 5.0,
+    field: str = "value",
+    tags: Mapping[str, str] | None = None,
+) -> None:
+    """Read every `interval` seconds and write what comes back, forever.
+
+    `read` returns a value in physical units, or None to skip this tick —
+    for a device that is warming up or has nothing new, which is not an
+    error and should not be logged as one.
+
+    **A `read` that raises is logged and retried, never fatal.** A vendor
+    SDK that throws on a transient network blip, a device that reports busy,
+    an expired session — none of these should end the process, because the
+    failure that matters is the one nobody notices until a week of data is
+    missing. Successive failures back off up to MAX_BACKOFF_SECONDS and
+    return to the nominal interval on the first success.
+
+    Runs until SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`), at which
+    point queued readings are flushed and the client closed.
+    """
+    writer: PointWriter[Point] = PointWriter[Point](get_client())
+
+    def shutdown(_signum: int, _frame: FrameType | None) -> None:
+        writer.close()
+        sys.exit(0)
+
+    _ = signal.signal(signal.SIGINT, shutdown)
+    _ = signal.signal(signal.SIGTERM, shutdown)
+
+    logger.info(
+        "Writing '%s' readings for '%s' to %s every %gs",
+        measurement,
+        sensor_id,
+        INFLUXDB_DATABASE,
+        interval,
+    )
+
+    written: Counter[str] = Counter()
+    next_summary = time.monotonic() + SUMMARY_INTERVAL_SECONDS
+    backoff = INITIAL_BACKOFF_SECONDS
+
+    while True:
+        try:
+            value = read()
+        except Exception:
+            logger.warning(
+                "Reading '%s' failed; retrying in %.0fs",
+                sensor_id,
+                backoff,
+                exc_info=True,
+            )
+            time.sleep(backoff)
+            backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+            continue
+
+        backoff = INITIAL_BACKOFF_SECONDS
+        if value is not None:
+            writer.write(
+                build_point(
+                    value,
+                    sensor_id=sensor_id,
+                    measurement=measurement,
+                    unit=unit,
+                    field=field,
+                    tags=tags,
+                )
+            )
+            written[sensor_id] += 1
+            logger.debug("%s: %.4g %s", sensor_id, value, unit)
+
+        now = time.monotonic()
+        if now >= next_summary:
+            logger.info(
+                "Wrote %d reading(s) in the last %.0fs",
+                written.total(),
+                SUMMARY_INTERVAL_SECONDS,
+            )
+            written.clear()
+            next_summary = now + SUMMARY_INTERVAL_SECONDS
+
+        time.sleep(interval)

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,345 @@
+import logging
+import signal
+import time
+from collections.abc import Callable
+from types import FrameType
+from typing import override
+
+import pytest
+from influxdb_client_3 import Point
+
+from labmon.sensors import polling
+from labmon.sensors.polling import build_point, poll, write_reading
+
+SignalHandler = Callable[[int, FrameType | None], None]
+
+
+class _StopLoop(BaseException):
+    """Breaks out of poll()'s infinite loop.
+
+    Deliberately a BaseException, unlike the equivalent in
+    test_serial_sensor: poll() catches Exception around every read so a
+    misbehaving vendor API cannot end the process, which would swallow an
+    ordinary exception used for control flow here and hang the suite.
+    """
+
+
+class FakeInfluxClient:
+    """Records batches, and whether it was closed before the test looked."""
+
+    def __init__(self) -> None:
+        self.batches: list[list[Point]] = []
+        self.closed: bool = False
+
+    def write(self, batch: list[Point]) -> None:
+        self.batches.append(list(batch))
+
+    def close(self) -> None:
+        self.closed = True
+
+    @property
+    def points(self) -> list[Point]:
+        return [point for batch in self.batches for point in batch]
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeInfluxClient:
+    client = FakeInfluxClient()
+    monkeypatch.setattr(polling, "get_client", lambda: client)
+    return client
+
+
+@pytest.fixture
+def registered_handlers(monkeypatch: pytest.MonkeyPatch) -> dict[int, SignalHandler]:
+    handlers: dict[int, SignalHandler] = {}
+
+    def fake_signal(signalnum: int, handler: SignalHandler) -> None:
+        handlers[signalnum] = handler
+
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    return handlers
+
+
+@pytest.fixture
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Runs the loop at full speed, recording what it would have waited."""
+    slept: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+    return slept
+
+
+# --------------------------------------------------------------------------
+# build_point
+# --------------------------------------------------------------------------
+
+
+def test_build_point_carries_the_identifying_tags() -> None:
+    line = build_point(
+        21.5, sensor_id="cryo-1", measurement="temperature", unit="degC"
+    ).to_line_protocol()
+
+    assert line.startswith("temperature,")
+    assert "sensor_id=cryo-1" in line
+    assert "unit=degC" in line
+    assert "value=21.5" in line
+
+
+def test_build_point_omits_an_empty_unit() -> None:
+    # A dimensionless reading should not carry an empty tag, which would
+    # create a second series indistinguishable from the first.
+    line = build_point(1.0, sensor_id="c", measurement="m").to_line_protocol()
+
+    assert "unit=" not in line
+
+
+def test_build_point_accepts_extra_tags_and_a_field_name() -> None:
+    line = build_point(
+        7.0,
+        sensor_id="c",
+        measurement="m",
+        field="setpoint",
+        tags={"rack": "A3"},
+    ).to_line_protocol()
+
+    assert "rack=A3" in line
+    assert "setpoint=7" in line
+
+
+# --------------------------------------------------------------------------
+# write_reading — the one-shot path
+# --------------------------------------------------------------------------
+
+
+def test_write_reading_writes_one_point(fake_client: FakeInfluxClient) -> None:
+    write_reading(4.2, sensor_id="cryo-4k", measurement="temperature", unit="K")
+
+    [point] = fake_client.points
+    assert "sensor_id=cryo-4k" in point.to_line_protocol()
+
+
+def test_write_reading_has_flushed_before_it_returns(
+    fake_client: FakeInfluxClient,
+) -> None:
+    """The whole reason this is not PointWriter.
+
+    A one-shot process exits the moment this returns; a point still sitting
+    in a background thread's queue would die with it.
+    """
+    write_reading(1.0, sensor_id="c", measurement="m")
+
+    assert fake_client.points != []
+    assert fake_client.closed is True
+
+
+def test_write_reading_closes_the_client_even_when_the_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Failing(FakeInfluxClient):
+        @override
+        def write(self, batch: list[Point]) -> None:
+            raise RuntimeError("influx unreachable")
+
+    client = Failing()
+    monkeypatch.setattr(polling, "get_client", lambda: client)
+
+    with pytest.raises(RuntimeError, match="influx unreachable"):
+        write_reading(1.0, sensor_id="c", measurement="m")
+
+    # Otherwise a timer-driven script leaks a connection on every failure.
+    assert client.closed is True
+
+
+# --------------------------------------------------------------------------
+# poll — the continuous path
+# --------------------------------------------------------------------------
+
+
+def _stop_after(values: list[float | None]) -> Callable[[], float | None]:
+    remaining = list(values)
+
+    def read() -> float | None:
+        if not remaining:
+            raise _StopLoop
+        return remaining.pop(0)
+
+    return read
+
+
+@pytest.mark.usefixtures("no_sleep")
+def test_poll_flushes_everything_it_read_on_shutdown(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    with pytest.raises(_StopLoop):
+        poll(_stop_after([1.0, 2.0, 3.0]), sensor_id="c", measurement="m")
+
+    with pytest.raises(SystemExit) as exit_info:
+        registered_handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert exit_info.value.code == 0
+    # Line protocol is "<measurement>,<tags> value=<v> <timestamp>".
+    values = [
+        point.to_line_protocol().split("value=")[1].split()[0]
+        for point in fake_client.points
+    ]
+    assert values == ["1", "2", "3"]
+    assert fake_client.closed is True
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers", "no_sleep")
+def test_poll_registers_both_shutdown_signals(
+    registered_handlers: dict[int, SignalHandler],
+) -> None:
+    with pytest.raises(_StopLoop):
+        poll(_stop_after([]), sensor_id="c", measurement="m")
+
+    assert signal.SIGINT in registered_handlers
+    assert signal.SIGTERM in registered_handlers
+
+
+@pytest.mark.usefixtures("registered_handlers", "no_sleep")
+def test_poll_skips_a_tick_when_read_returns_none(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # None means "no reading this time" — a device warming up, not an error.
+    with pytest.raises(_StopLoop):
+        poll(_stop_after([None, 2.0, None]), sensor_id="c", measurement="m")
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    assert len(fake_client.points) == 1
+
+
+@pytest.mark.usefixtures("registered_handlers", "fake_client")
+def test_poll_waits_the_interval_between_readings(no_sleep: list[float]) -> None:
+    with pytest.raises(_StopLoop):
+        poll(_stop_after([1.0, 2.0]), sensor_id="c", measurement="m", interval=2.5)
+
+    assert no_sleep == [2.5, 2.5]
+
+
+# --------------------------------------------------------------------------
+# poll — a failing vendor API must not end the process
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("registered_handlers", "no_sleep")
+def test_poll_survives_a_read_that_raises(
+    fake_client: FakeInfluxClient,
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A vendor SDK throwing at 03:00 must not stop monitoring."""
+    calls = iter([RuntimeError("device busy"), RuntimeError("device busy"), 42.0])
+
+    def read() -> float | None:
+        try:
+            outcome = next(calls)
+        except StopIteration:
+            raise _StopLoop from None
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    with (
+        caplog.at_level(logging.WARNING, logger=polling.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        poll(read, sensor_id="c", measurement="m", interval=1.0)
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    assert len(fake_client.points) == 1
+    assert "device busy" in caplog.text
+
+
+@pytest.mark.usefixtures("registered_handlers", "fake_client")
+def test_poll_backs_off_while_reads_keep_failing(no_sleep: list[float]) -> None:
+    """Backoff, so a dead device is not hammered once per interval."""
+    failures = iter(range(4))
+
+    def read() -> float | None:
+        try:
+            _ = next(failures)
+        except StopIteration:
+            raise _StopLoop from None
+        raise RuntimeError("unreachable")
+
+    with pytest.raises(_StopLoop):
+        poll(read, sensor_id="c", measurement="m", interval=1.0)
+
+    # Each failure waits longer than the last, rather than retrying at the
+    # nominal interval forever.
+    assert no_sleep == sorted(no_sleep)
+    assert no_sleep[-1] > no_sleep[0]
+
+
+@pytest.mark.usefixtures("registered_handlers", "fake_client")
+def test_poll_backoff_is_capped(no_sleep: list[float]) -> None:
+    failures = iter(range(30))
+
+    def read() -> float | None:
+        try:
+            _ = next(failures)
+        except StopIteration:
+            raise _StopLoop from None
+        raise RuntimeError("unreachable")
+
+    with pytest.raises(_StopLoop):
+        poll(read, sensor_id="c", measurement="m", interval=1.0)
+
+    assert max(no_sleep) == polling.MAX_BACKOFF_SECONDS
+
+
+@pytest.mark.usefixtures("registered_handlers", "fake_client")
+def test_poll_returns_to_the_normal_interval_after_a_recovery(
+    no_sleep: list[float],
+) -> None:
+    remaining: list[float | RuntimeError] = [
+        RuntimeError("x"),
+        RuntimeError("x"),
+        1.0,
+        2.0,
+    ]
+
+    def read() -> float | None:
+        if not remaining:
+            raise _StopLoop
+        outcome = remaining.pop(0)
+        if isinstance(outcome, RuntimeError):
+            raise outcome
+        return outcome
+
+    with pytest.raises(_StopLoop):
+        poll(read, sensor_id="c", measurement="m", interval=1.0)
+
+    # The last two waits are the nominal interval again, not the backoff.
+    assert no_sleep[-2:] == [1.0, 1.0]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers", "no_sleep")
+def test_poll_summarises_once_the_interval_elapses(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The per-reading line is DEBUG, so this carries "it is still working"."""
+    # The clock passes the summary interval only on the second reading.
+    ticks = iter([0.0, 1.0, polling.SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+
+    with (
+        caplog.at_level(logging.INFO, logger=polling.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        poll(_stop_after([1.0, 2.0]), sensor_id="c", measurement="m")
+
+    summaries = [
+        record.getMessage()
+        for record in caplog.records
+        if "Wrote" in record.getMessage()
+    ]
+    assert summaries == ["Wrote 2 reading(s) in the last 30s"]


### PR DESCRIPTION
First of five PRs toward custom-API sensors and log aggregation. This one adds the Python surface only — no compose changes, no new dependency, nothing else in the repo touched.

## Why

`mock-sensor` invents readings; `serial-sensor` reads a board over a serial line. Neither covers what a lab actually has most of: an instrument behind a vendor SDK, REST endpoint or CLI that already returns a value in physical units. Writing one today means copying `mock_sensor.py` and hand-rolling the client, the batching, the shutdown signals and the error recovery — identical every time, and the error recovery is the part that is easy to get wrong.

## What

```python
build_point(value, *, sensor_id, measurement, unit="", field="value", tags=None)
write_reading(value, *, sensor_id, measurement, ...)
poll(read, *, sensor_id, measurement, interval=5.0, ...)
```

A sensor is driven in one of two ways, so there are two entry points:

- **`poll()`** runs forever at a fixed interval. **A `read` that raises is logged with a traceback and retried with capped backoff, never fatal** — a vendor SDK throwing on a transient blip must not end the process, because the failure that matters is the one nobody notices until a week of data is gone. `read` returning `None` skips a tick, for a device that is warming up.
- **`write_reading()`** writes one value and returns, for an API that is rate-limited, billed per call, or slow enough that a systemd timer beats a process sleeping 899 of every 900 seconds.

## The two write paths differ deliberately

`poll()` uses `PointWriter`, whose background thread batches and absorbs the ~1 s WAL flush documented in `docs/latency.md`. `write_reading()` must not: a one-shot process exits the moment it returns, and a point queued in a daemon thread dies with the interpreter.

Measured against a real InfluxDB, running a script that exits immediately after writing:

| Approach | Rows stored |
| --- | --- |
| `write_reading()` | 1 |
| `PointWriter` without `close()` | **0 — silently lost** |

That is the trap this shape exists to prevent, and the reason the two are not one function. Only `build_point` is shared.

## Note for the reviewer

`_StopLoop` in the tests derives from `BaseException`, unlike the identical-looking class in `test_serial_sensor.py`. That is not an oversight — `poll` catches `Exception` around every read by design, which would swallow an ordinary exception used for control flow and hang the suite. It hung on the first run, which is how this was found. The same reasoning means a real `KeyboardInterrupt` still propagates.

## Test plan

- [x] `uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=100` — 129 passed, 100%
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright` — 0 errors, 0 warnings
- [x] `uv run typos`
- [x] One-shot write verified against a live InfluxDB, including the counterfactual above
- [x] Backoff verified to grow, to cap at `MAX_BACKOFF_SECONDS`, and to reset after a recovery

