### PR TITLE
feat: add a template for sensors behind a manufacturer's API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+# Builds labmon:latest — labmon's own code, and nothing beyond it.
+#
+# Every service in both compose files runs this one image: the mock
+# sensors, serial-sensor, the demo feeder, and the client stack. It is
+# also the base that templates/custom-sensor/ builds on.
+#
+# That makes it the wrong place for an instrument's own dependencies. A
+# vendor SDK added here is installed into the image every other sensor
+# runs from, so an SDK that fails to install stops the whole stack
+# building; and this file is version-controlled, so the edit collides
+# with every `git pull`. Put those in your own copy of
+# templates/custom-sensor/Dockerfile, which starts FROM this image.
+
 FROM python:3.14-slim-trixie
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,24 @@ virtual serial port before any hardware arrives.
 > physical Arduino Due. Check readings against a known voltage before
 > trusting them.
 
+### Instruments with their own software
+
+Plenty of instruments never expose a voltage: they come with a
+manufacturer's Python SDK, a REST endpoint or a CLI that hands back a
+reading already in physical units. There is nothing to calibrate, so those
+skip the ADC path entirely.
+
+```
+instrument ──vendor API──► your script ──► InfluxDB ──► Grafana
+```
+
+Copy [`templates/custom-sensor/`](templates/custom-sensor/), replace one
+function with the vendor call, and the batching, retries and shutdown are
+handled for you — including retrying a read that raises, so an instrument
+having a bad night does not stop the process. The template runs against a
+simulated value before you write any instrument code, so the plumbing can
+be proved first. See [`docs/custom-sensor.md`](docs/custom-sensor.md).
+
 ## Running it across the lab
 
 Everything above runs on one machine. A real lab is usually three roles
@@ -236,7 +254,8 @@ this repository.
   - `influx.py` — shared InfluxDB client configuration
   - `writer.py` — queue-backed writer decoupling producers from InfluxDB I/O latency
   - `calibration.py` — turns raw ADC counts into dimensioned physical quantities
-  - `sensors/` — sensor scripts (simulated, and real boards over serial)
+  - `sensors/` — sensor scripts (simulated, boards over serial, and instruments behind a vendor API)
+- `templates/` — copyable starting points for sensors labmon does not ship
 - `firmware/` — reference Arduino sketches for boards labmon reads
 - `demo/` — stands in for a board so the demo runs the real acquisition path
 - `tests/` — pytest suite
@@ -247,7 +266,7 @@ this repository.
 - `docker-compose.yml` — local InfluxDB, Grafana, and demo sensor instances
 - `docker-compose.client.yml` — sensor-only compose file for a remote client machine
 - `calibration.example.toml` — worked example of every sensor conversion mode
-- `deploy/` — example systemd units for a bare-install client
+- `deploy/` — systemd units and docs for machines that can't run the containers
 - `CONTRIBUTING.md` / `AGENTS.md` — workflow, commit conventions, testing policy
 - `BACKLOG.md` — planned/considered future work, roughly prioritized
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ this repository.
 - `docs/` — usage docs per component
 - `typings/` — local type stubs for untyped third-party dependencies
 - `grafana/` — provisioned datasource and dashboards
-- `Dockerfile` — builds labmon's own code for the containerized sensors
+- `Dockerfile` — builds `labmon:latest`, the one image every service runs
+  and the base a custom sensor layers on; not where instrument-specific
+  dependencies go
 - `docker-compose.yml` — local InfluxDB, Grafana, and demo sensor instances
 - `docker-compose.client.yml` — sensor-only compose file for a remote client machine
 - `calibration.example.toml` — worked example of every sensor conversion mode

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,68 @@
+# Running a sensor without Docker
+
+Example systemd units for machines where the containers are not an option.
+Nothing here is needed for the normal path — a sensor in a container is
+supervised by Compose, and these files have no part in it.
+
+## Prefer the container
+
+A container pins the sensor's dependencies next to the code that uses
+them, needs no Python or virtualenv on the host, takes the same commands
+on every machine, and has its output collected without further setup. Use
+it unless something stops you.
+
+What actually stops people, in practice:
+
+- **Policy.** A managed or locked-down control PC where Docker will not be
+  installed. This is the common one, and no technical argument moves it.
+- **A vendor SDK that will not containerise** — a licence dongle, a kernel
+  module, a hard requirement on a particular interpreter or distribution.
+- **A machine too small to want the daemon**, where installing Docker to
+  run one Python script is more setup than the script.
+
+Worth knowing: choosing systemd is not escaping it. A container's
+`restart: unless-stopped` is enforced by the Docker daemon, which is
+itself a systemd unit. The choice is how many supervisors you deal with,
+not whether systemd is involved.
+
+## The units
+
+| Unit | Runs | Guide |
+| --- | --- | --- |
+| `labmon-sensor.service` | `mock-sensor`, for proving a client can reach the server | [client-setup](../docs/client-setup.md) |
+| `labmon-serial-sensor.service` | `serial-sensor`, reading a board over serial | [serial-sensor](../docs/serial-sensor.md) |
+| `labmon-custom-sensor.service` | A continuous script built from [`templates/custom-sensor/`](../templates/custom-sensor/) | [custom-sensor](../docs/custom-sensor.md) |
+| `labmon-custom-sensor-triggered.service` | The same, reading once per run | [custom-sensor](../docs/custom-sensor.md) |
+| `labmon-custom-sensor-triggered.timer` | Schedules the unit above | [custom-sensor](../docs/custom-sensor.md) |
+
+Each file carries its own install instructions in a comment at the top.
+All of them use placeholder paths and a placeholder user, so they need
+editing before they will start.
+
+## Two things that catch people out
+
+**Enable the timer, not the service it starts.** A `Type=oneshot` service
+enabled on its own runs once at boot and never again:
+
+```bash
+sudo systemctl enable --now labmon-custom-sensor-triggered.timer   # correct
+sudo systemctl enable --now labmon-custom-sensor-triggered.service # runs once, ever
+```
+
+**A triggered unit has no `Restart=` on purpose.** A failed reading waits
+for the next scheduled run rather than retrying immediately — retrying a
+rate-limited API straight away is how a temporary refusal becomes a
+lasting one. The continuous units do the opposite, with
+`Restart=on-failure`, because there is nothing scheduling a second attempt.
+
+## Logs
+
+A unit's output goes to the journal:
+
+```bash
+journalctl -u labmon-custom-sensor.service -f
+```
+
+That matters beyond reading it by hand: the journal is where logs are
+collected from on a machine with no Docker, so a sensor run this way ends
+up in the same place as one run in a container.

--- a/deploy/labmon-custom-sensor-triggered.service
+++ b/deploy/labmon-custom-sensor-triggered.service
@@ -1,0 +1,30 @@
+# The unit labmon-custom-sensor-triggered.timer starts. Reads once, writes, exits.
+#
+# Install both files together — a service of Type=oneshot does nothing on
+# its own until something starts it:
+#
+#   sudo cp labmon-custom-sensor-triggered.service /etc/systemd/system/
+#   sudo cp labmon-custom-sensor-triggered.timer /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now labmon-custom-sensor-triggered.timer
+#
+# Note that the *timer* is enabled, not the service. Enabling the service
+# instead would run it once at boot and never again.
+
+[Unit]
+Description=labmon custom API sensor (single reading)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# oneshot, not simple: this process is expected to exit, and systemd should
+# treat that as success rather than as the service having died.
+Type=oneshot
+User=lab
+WorkingDirectory=/home/lab/labmon
+EnvironmentFile=/home/lab/labmon/.env
+ExecStart=/home/lab/labmon/.venv/bin/python /home/lab/labmon/sensor_triggered.py
+
+# No Restart=: a failed reading should wait for the next scheduled run
+# rather than retry immediately. Retrying a rate-limited API straight away
+# is how a temporary refusal becomes a lasting one.

--- a/deploy/labmon-custom-sensor-triggered.timer
+++ b/deploy/labmon-custom-sensor-triggered.timer
@@ -1,0 +1,32 @@
+# Schedules labmon-custom-sensor-triggered.service. Install and enable both — see
+# the .service file for the commands.
+#
+# Inspect the schedule with:
+#
+#   systemctl list-timers labmon-custom-sensor-triggered.timer
+#
+# and check a calendar expression before committing to it:
+#
+#   systemd-analyze calendar '*:0/15'
+
+[Unit]
+Description=Read the labmon custom API sensor on a schedule
+
+[Timer]
+# Every 15 minutes, on the quarter hour. Other useful forms:
+#   OnCalendar=hourly
+#   OnCalendar=*-*-* 06,18:00:00     twice a day
+#   OnUnitActiveSec=90min            relative to the last run, not the clock
+OnCalendar=*:0/15
+
+# Spread the start over 30s. Without this, every timer on the machine with
+# the same schedule fires simultaneously, which matters when several
+# sensors share one rate-limited API.
+RandomizedDelaySec=30s
+
+# Run once at boot if the machine was off when a run was due, rather than
+# silently skipping until the next slot.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/labmon-custom-sensor.service
+++ b/deploy/labmon-custom-sensor.service
@@ -1,0 +1,33 @@
+# Example systemd unit for a sensor read through a manufacturer's API,
+# running directly on a machine rather than in a container — see
+# docs/custom-sensor.md. Copy to /etc/systemd/system/, edit the paths and
+# the user below, then:
+#
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now labmon-custom-sensor.service
+#
+# Check on it with:
+#
+#   systemctl status labmon-custom-sensor.service
+#   journalctl -u labmon-custom-sensor.service -f
+#
+# The journal is not only for reading by hand: it is where these logs are
+# collected from when log aggregation is set up, so a sensor run this way
+# ends up in the same place as one run in a container.
+
+[Unit]
+Description=labmon custom API sensor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=lab
+WorkingDirectory=/home/lab/labmon
+EnvironmentFile=/home/lab/labmon/.env
+ExecStart=/home/lab/labmon/.venv/bin/python /home/lab/labmon/sensor_continuous.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/custom-sensor.md
+++ b/docs/custom-sensor.md
@@ -85,6 +85,13 @@ service in `compose.snippet.yml`. That pins the SDK version next to the
 code that uses it, needs no Python on the host, and has its output
 collected without further setup.
 
+That Dockerfile layers on the repository's own rather than replacing it:
+the root `Dockerfile` builds `labmon:latest`, which every service already
+runs, and your instrument's dependencies go in your copy of the template
+on top of it. Putting them in the shared image instead means a failed SDK
+install stops the whole stack building, and a merge conflict on every
+`git pull`.
+
 On a machine where the container is not an option — a locked-down control
 PC, or an SDK that will not containerise — the same two scripts run
 directly under systemd instead. See [`deploy/`](../deploy/) for the units

--- a/docs/custom-sensor.md
+++ b/docs/custom-sensor.md
@@ -1,0 +1,109 @@
+# Custom sensors
+
+Reading an instrument through a manufacturer's API — a Python SDK, a REST
+endpoint, a CLI — and writing the result alongside every other sensor.
+
+This is the third acquisition path. [`mock-sensor`](mock-sensor.md) invents
+readings and [`serial-sensor`](serial-sensor.md) reads a board over a
+serial line; this one covers everything that arrives already in physical
+units, from a vendor's own software.
+
+The starting point is [`templates/custom-sensor/`](../templates/custom-sensor/).
+
+## The two shapes
+
+A sensor is driven in one of two ways, and the choice is about who decides
+when a reading happens.
+
+**Continuous** — a process stays up and reads on an interval. Right for an
+instrument you can talk to as often as you like. This is `poll()`, run by
+`sensor_continuous.py`.
+
+**Triggered** — a process reads once, writes, and exits, started by
+something else. Right for an API that is rate-limited, billed per call, or
+slow enough that a process sleeping between calls is the wrong shape. This
+is `write_reading()`, run by `sensor_triggered.py` from
+`docker compose run --rm`, cron, or a systemd timer.
+
+Polling a per-call-billed API every five seconds is the mistake this
+distinction exists to prevent.
+
+## Writing the sensor
+
+Replace one function:
+
+```python
+from labmon.sensors.polling import poll
+
+
+def read_value() -> float | None:
+    return device.read_temperature()
+
+
+poll(read_value, sensor_id="cryo-1", measurement="temperature", unit="K", interval=5.0)
+```
+
+`read_value` returns a value in physical units, or `None` to skip this
+tick — an instrument still warming up, or with nothing new since the last
+call. `None` is not an error and is not logged as one.
+
+### Let it raise
+
+**Raising is the correct way to report a failure.** The exception is logged
+with its traceback and the read is retried with backoff, growing to a cap
+so a switched-off instrument is not hammered all night, and resetting on
+the first success. The process does not stop.
+
+Do not wrap the body in `try/except` to keep things running. That is
+already handled, and swallowing an error turns a broken instrument into a
+flat line — the failure mode nobody notices until a week of data is
+missing.
+
+### Recording more than one number
+
+`build_point()` is public for a device read that yields several values at
+once:
+
+```python
+from labmon.sensors.polling import build_point
+
+writer.write(
+    build_point(temperature, sensor_id="cryo-1", measurement="temperature", unit="K")
+)
+writer.write(
+    build_point(pressure, sensor_id="cryo-1", measurement="pressure", unit="mbar")
+)
+```
+
+Same tag conventions, so the readings sit alongside every other sensor's
+rather than in a shape of their own.
+
+## Where it runs
+
+In a container, built from the template's `Dockerfile` and started by the
+service in `compose.snippet.yml`. That pins the SDK version next to the
+code that uses it, needs no Python on the host, and has its output
+collected without further setup.
+
+On a machine where the container is not an option — a locked-down control
+PC, or an SDK that will not containerise — the same two scripts run
+directly under systemd instead. See [`deploy/`](../deploy/) for the units
+and the two mistakes that catch people out.
+
+## Prove the plumbing first
+
+`read_value()` ships returning a simulated value, so the template runs
+before any instrument code exists. Start it, confirm readings reach
+Grafana, then swap in the real device. If it breaks after that, the
+configuration is already known good.
+
+## Why a triggered sensor blocks for a second
+
+`write_reading()` does not return until InfluxDB has stored the reading,
+which costs about a second while its write-ahead log flushes (see
+[latency](latency.md)).
+
+That is deliberate. The alternative — handing the point to the background
+writer the continuous path uses — returns immediately and loses the
+reading, because the process exits before the writer thread sends
+anything. A triggered sensor has no time to be asynchronous in.

--- a/templates/custom-sensor/Dockerfile
+++ b/templates/custom-sensor/Dockerfile
@@ -1,14 +1,25 @@
-# A sensor container built on the labmon image.
+# Your instrument, built on top of the labmon image.
 #
-# The base image has to exist locally first, since it is built from this
-# repository rather than pulled:
+# This is a layer over the repository's own Dockerfile, not a replacement
+# for it:
 #
-#   docker compose build          # from the repo root, creates labmon:latest
-#   docker compose -f docker-compose.client.yml build
+#   python:3.14-slim  ->  labmon:latest  ->  this file
+#                         (repo root)        (your copy)
 #
-# Then build this one from inside templates/custom-sensor/:
+# labmon:latest is built from the repository rather than pulled, so it has
+# to exist locally first, or the FROM below fails with "pull access
+# denied":
+#
+#   docker compose build          # from the repo root
+#
+# After that, `docker compose up` builds this image for you if the service
+# pasted from compose.snippet.yml points its `build:` at this directory.
+# Building by hand is only needed to test it on its own:
 #
 #   docker build -t my-sensor .
+#
+# The `.` is the build context — the directory COPY can reach. A wheel
+# from your vendor has to sit next to this file; COPY cannot climb out.
 FROM labmon:latest
 
 # Your instrument's Python package. uv is already in the base image; the

--- a/templates/custom-sensor/Dockerfile
+++ b/templates/custom-sensor/Dockerfile
@@ -1,0 +1,33 @@
+# A sensor container built on the labmon image.
+#
+# The base image has to exist locally first, since it is built from this
+# repository rather than pulled:
+#
+#   docker compose build          # from the repo root, creates labmon:latest
+#   docker compose -f docker-compose.client.yml build
+#
+# Then build this one from inside templates/custom-sensor/:
+#
+#   docker build -t my-sensor .
+FROM labmon:latest
+
+# Your instrument's Python package. uv is already in the base image; the
+# --python flag points it at the venv labmon itself was installed into,
+# which is not the interpreter uv would pick on its own.
+#
+# A wheel on PyPI:
+#   RUN uv pip install --python /app/.venv/bin/python vendor-sdk==1.4.0
+#
+# A wheel the vendor emailed you, copied in alongside this Dockerfile:
+#   COPY vendor_sdk-1.4.0-py3-none-any.whl /tmp/
+#   RUN uv pip install --python /app/.venv/bin/python /tmp/vendor_sdk-1.4.0-py3-none-any.whl
+#
+# System libraries the SDK links against:
+#   RUN apt-get update && apt-get install -y --no-install-recommends libusb-1.0-0 \
+#       && rm -rf /var/lib/apt/lists/*
+
+COPY sensor_continuous.py sensor_triggered.py /app/
+
+# Overrides the base image's ENTRYPOINT ["mock-sensor"]. Swap in
+# sensor_triggered.py for a container a timer starts and stops.
+ENTRYPOINT ["python", "/app/sensor_continuous.py"]

--- a/templates/custom-sensor/README.md
+++ b/templates/custom-sensor/README.md
@@ -1,0 +1,47 @@
+# Custom sensor template
+
+A starting point for reading an instrument through a manufacturer's API —
+a Python SDK, a REST endpoint, a CLI — and writing the result to InfluxDB
+alongside every other sensor.
+
+Full guide: [`docs/custom-sensor.md`](../../docs/custom-sensor.md).
+
+## Which file to start from
+
+|  | Read whenever you like | Rate-limited, billed, or slow |
+| --- | --- | --- |
+| **Script** | `sensor_continuous.py` | `sensor_triggered.py` |
+| **Service** | `compose.snippet.yml`, first service | `docker compose run --rm` |
+
+Continuous is the common case: a process stays up and reads on an
+interval. Choose triggered when something external should decide *when* a
+reading happens — an API that charges per call, refuses more than a few
+requests an hour, or takes minutes to answer.
+
+Either script also runs without Docker, on a machine where the container
+is not an option — see [`deploy/`](../../deploy/) for the systemd units
+and when they are worth reaching for.
+
+## Getting started
+
+The template runs before you have written any instrument code:
+`read_value()` returns a simulated value. Start it, confirm readings reach
+Grafana, and only then swap in the real device — so that if it breaks
+afterwards, you know it is the instrument and not the configuration.
+
+1. Copy this directory somewhere of your own.
+2. Build the base image once from the repo root: `docker compose build`.
+3. `docker build -t my-sensor .`
+4. Paste the service from `compose.snippet.yml` and `docker compose up -d my-sensor`.
+5. Replace `read_value()` and the `CHANGE-ME` identifiers.
+
+## What you do not have to write
+
+`labmon.sensors.polling` already handles the batching, the InfluxDB
+connection, `SIGINT`/`SIGTERM` shutdown, and — the part worth not
+rewriting — **retry with backoff around a failing read**. An instrument
+that throws at 03:00 is logged with its traceback and retried, not fatal.
+
+Do not catch exceptions inside `read_value()` to keep the process alive.
+That already happens, and swallowing them turns a broken instrument into a
+flat line nobody investigates.

--- a/templates/custom-sensor/README.md
+++ b/templates/custom-sensor/README.md
@@ -22,6 +22,31 @@ Either script also runs without Docker, on a machine where the container
 is not an option — see [`deploy/`](../../deploy/) for the systemd units
 and when they are worth reaching for.
 
+## This template and the repository's own Dockerfile
+
+There are two Dockerfiles, and they stack rather than compete:
+
+```
+python:3.14-slim  ->  labmon:latest  ->  my-cryostat-sensor
+                      (repo root)        (your copy of this template)
+                                     ->  my-gauge-sensor
+```
+
+The one at the repository root builds `labmon:latest`, which every labmon
+service already runs — the mock sensors, `serial-sensor`, the demo feeder,
+the client stack. **Do not add your instrument's dependencies there.**
+Three reasons, in order of how soon they bite:
+
+- It is version-controlled, so the edit collides with every `git pull`.
+- It is shared, so a vendor SDK that fails to install — an unreachable
+  licence server, a wrong architecture — stops the whole stack building,
+  including the sensors that have nothing to do with your instrument.
+- Two instruments whose SDKs pin incompatible dependencies cannot share
+  one image at all. A layer each, and they never have to agree.
+
+The same applies to this directory. Copy it somewhere of your own before
+editing, or your changes are in git's way for the same reason.
+
 ## Getting started
 
 The template runs before you have written any instrument code:

--- a/templates/custom-sensor/compose.snippet.yml
+++ b/templates/custom-sensor/compose.snippet.yml
@@ -1,0 +1,41 @@
+# Paste this service into docker-compose.yml (sensor on the same host as
+# the server) or docker-compose.client.yml (sensor on its own machine),
+# adjusting the build context to point at your copy of this template.
+#
+# Not a compose file in its own right: it has no `services:` parent and
+# will not start on its own.
+
+  my-sensor:
+    build: ./templates/custom-sensor
+    container_name: my-sensor
+    restart: unless-stopped
+    environment:
+      # Same three the other sensors take. On a client machine
+      # INFLUXDB_HOST is the server's address rather than a container name.
+      - INFLUXDB_HOST=http://influxdb:8181
+      - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
+      - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+    # Matches the sensor_id this container writes, so its log lines can be
+    # put next to its readings. Keep the two in step: the label is what
+    # ties a container's output to a series, and nothing checks it for you.
+    labels:
+      labmon.sensor_id: CHANGE-ME
+    depends_on:
+      influxdb:
+        condition: service_healthy
+
+  # A triggered sensor, for an API that should not be polled continuously.
+  # No `restart:` — it is meant to exit — and no `depends_on`, since it is
+  # started by a timer rather than by `compose up`:
+  #
+  #   docker compose run --rm my-sensor-triggered
+  #
+  # my-sensor-triggered:
+  #   build: ./templates/custom-sensor
+  #   entrypoint: ["python", "/app/sensor_triggered.py"]
+  #   environment:
+  #     - INFLUXDB_HOST=http://influxdb:8181
+  #     - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
+  #     - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+  #   labels:
+  #     labmon.sensor_id: CHANGE-ME

--- a/templates/custom-sensor/sensor_continuous.py
+++ b/templates/custom-sensor/sensor_continuous.py
@@ -1,0 +1,62 @@
+"""Read an instrument on a fixed interval and write every reading.
+
+Copy this file, replace `read_value()` with a call to your instrument's
+API, and set the identifiers at the bottom. Everything else — batching,
+retries, shutdown, logging — is handled by `labmon.sensors.polling.poll`.
+
+As shipped, `read_value()` returns a simulated value, so the template runs
+before you have touched any vendor code. Start it, confirm the readings
+appear in Grafana, and only then swap in the real instrument: if something
+goes wrong afterwards, you know it is the instrument and not the plumbing.
+
+Use this file when the instrument can be read as often as you like. If its
+API is rate-limited, billed per call, or takes minutes to answer, use
+`sensor_triggered.py` instead.
+"""
+
+import logging
+import random
+
+from labmon.sensors.polling import poll
+
+# --------------------------------------------------------------------------
+# Replace everything in this block with your instrument.
+# --------------------------------------------------------------------------
+
+# import vendor_sdk
+# device = vendor_sdk.Device("192.0.2.10")
+
+
+def read_value() -> float | None:
+    """Return one reading in physical units, or None if there isn't one.
+
+    Returning None skips this tick without logging an error — the right
+    answer for an instrument that is still warming up, or that has nothing
+    new since the last call.
+
+    Raising is also fine, and is the expected way to report a failure: the
+    exception is logged with its traceback and the read is retried with
+    backoff. It will not stop the process. Do not catch and swallow errors
+    here to "keep things running" — that is already handled, and swallowing
+    them turns a broken instrument into a flat line nobody investigates.
+    """
+    # return device.read_temperature()
+    return random.normalvariate(21.0, 0.1)
+
+
+# --------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # INFO so the periodic "still writing" summary is visible; the
+    # per-reading line is DEBUG.
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    poll(
+        read_value,
+        sensor_id="CHANGE-ME",
+        measurement="temperature",
+        unit="degC",
+        interval=5.0,
+    )

--- a/templates/custom-sensor/sensor_triggered.py
+++ b/templates/custom-sensor/sensor_triggered.py
@@ -1,0 +1,60 @@
+"""Read an instrument once, write the reading, and exit.
+
+For an API that is rate-limited, billed per call, or slow enough that a
+process sleeping between calls is the wrong shape. Something external
+decides when a reading happens — a systemd timer, cron, or a run triggered
+by hand.
+
+Copy this file, replace `read_value()`, and drive it with
+`labmon-sensor-triggered.timer` (see this directory's README) or:
+
+    docker compose run --rm my-sensor
+
+`write_reading` blocks for about a second while InfluxDB flushes its
+write-ahead log, and that is deliberate: the reading is stored by the time
+this process exits. Handing the point to a background thread would be
+faster and would lose it, because the interpreter exits before the thread
+gets to send anything.
+"""
+
+import logging
+import random
+import sys
+
+from labmon.sensors.polling import write_reading
+
+# --------------------------------------------------------------------------
+# Replace everything in this block with your instrument.
+# --------------------------------------------------------------------------
+
+# import vendor_sdk
+
+
+def read_value() -> float | None:
+    """Return one reading in physical units, or None if there isn't one."""
+    # with vendor_sdk.Device("192.0.2.10") as device:
+    #     return device.read_temperature()
+    return random.normalvariate(21.0, 0.1)
+
+
+# --------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    value = read_value()
+    if value is None:
+        # Nothing to record this time. Exit 0: a timer treats a non-zero
+        # status as a failure and will report the unit as failed, which is
+        # wrong for "the instrument had nothing to say".
+        logging.getLogger(__name__).info("No reading available; nothing written")
+        sys.exit(0)
+
+    write_reading(
+        value,
+        sensor_id="CHANGE-ME",
+        measurement="temperature",
+        unit="degC",
+    )


### PR DESCRIPTION
Second of five PRs toward custom-API sensors and log aggregation. Turns [#37](https://github.com/quentinmarolleau/labmon/pull/37)'s helper into something copyable.

> **Stacked on #37.** Based on `feat/custom-sensor-helper`; GitHub will retarget
> this to `main` automatically once that merges.

## The template

`templates/custom-sensor/` — two scripts, a `Dockerfile` extending `labmon:latest`, a compose service to paste, and a README.

`read_value()` ships returning a **simulated** value, so the template runs before any instrument code exists. Start it, confirm readings reach Grafana, then swap in the real device — if it breaks after that, the configuration is already known good.

Named for *why* each runs rather than how long it lives: "continuous" and "triggered" describe who decides when a reading happens, which is the choice being made. "Once" would describe a process lifetime, which is incidental.

## Docker leads; systemd moved out of the way

The units are in `deploy/`, where the two existing ones already live, rather than in the template competing for attention with the path most people want. `deploy/` gains a README indexing all five and saying plainly to prefer the container.

That README is deliberately honest about two things:

- The cases that genuinely rule out a container are **policy** (a locked-down control PC) and unpackageable SDKs — not capability. So the path has to keep working rather than be deprecated.
- Choosing systemd is not escaping it. A container's `restart: unless-stopped` is enforced by the Docker daemon, which is itself a systemd unit.

## A bug the restructure surfaced

Moving the units exposed that the `Dockerfile` only copied `sensor_continuous.py`. My earlier test of the triggered path had worked only because I bind-mounted the script by hand. Without the fix, `docker compose run --rm` on a triggered service would fail with "no such file". It now copies both, verified with no bind-mount.

## Test plan

- [x] Template image builds on `labmon:latest`
- [x] Continuous container against live InfluxDB — 3 rows in 12s at the 5s interval, `unit=degC`
- [x] Triggered container, **no bind-mount** — exit 0, row count 4 → 5
- [x] `systemd-analyze verify` on all 5 units + the timer — parse clean (only the placeholder `ExecStart` path is flagged, exactly as the two pre-existing units are)
- [x] `systemd-analyze calendar '*:0/15'` resolves to every 15 minutes
- [x] Every relative link in every changed `.md` resolves
- [x] `uv run pytest --cov=src --cov-fail-under=100` — 129 passed, 100%
- [x] `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`

