### PR TITLE
feat: collect container logs with Loki and Alloy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .github
 .grafana
 .influxdb3
+.loki
 __marimo__
 __pycache__
 .pytest_cache

--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,19 @@ INFLUXDB_DATABASE=
 # Grafana admin password (default: admin).
 GRAFANA_ADMIN_PASSWORD=
 
-# Which docker-compose profiles are active. "demo" brings up the five mock
-# sensors alongside InfluxDB/Grafana (today's full local demo experience).
-# Leave this blank/unset on a real server deployment to start only InfluxDB
-# and Grafana — see docs/deployment.md.
+# Which docker-compose profiles are active, comma-separated. "demo" brings
+# up the five mock sensors alongside InfluxDB/Grafana (today's full local
+# demo experience). "logs" adds Loki and Alloy, collecting every
+# container's output — see docs/logging.md. Leave this blank/unset on a
+# real server deployment to start only InfluxDB and Grafana — see
+# docs/deployment.md.
 COMPOSE_PROFILES=demo
+
+# How long Loki keeps a log line, when the "logs" profile is active
+# (default: 720h, i.e. 30 days). Loki's own minimum is 24h. Logs are far
+# bulkier than measurements, so this is the setting that decides how much
+# disk the stack uses over time.
+LOKI_RETENTION_PERIOD=
 
 # Grafana panel plugins to install at startup, as a comma-separated list of
 # `id@version`. The demo dashboard's needle gauge needs this one. Leave it

--- a/.env.example
+++ b/.env.example
@@ -25,9 +25,11 @@ GRAFANA_ADMIN_PASSWORD=
 COMPOSE_PROFILES=demo
 
 # How long Loki keeps a log line, when the "logs" profile is active
-# (default: 720h, i.e. 30 days). Loki's own minimum is 24h. Logs are far
-# bulkier than measurements, so this is the setting that decides how much
-# disk the stack uses over time.
+# (default: 720h, i.e. 30 days). Logs are far bulkier than measurements,
+# so this is the setting that decides how much disk the stack uses over
+# time. Do not go below 24h: Loki documents that as its minimum but
+# accepts less without complaint, and cannot honour it — see
+# docs/logging.md.
 LOKI_RETENTION_PERIOD=
 
 # Grafana panel plugins to install at startup, as a comma-separated list of

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ coverage.xml
 # Grafana local data
 .grafana/data/
 
+# Loki local data
+.loki/
+
 # Personal experimentation (marimo notebooks, not part of the package)
 __marimo__/
 /test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,12 @@ COPY src ./src
 RUN uv sync --locked --no-dev
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Python block-buffers stdout when it is not a terminal, which it never is
+# in a container. A sensor printing one short line per reading fills that
+# buffer so slowly that `docker compose logs` shows nothing for twenty
+# minutes, and a log collector has nothing to collect — both of which look
+# like a dead sensor rather than a buffering artefact.
+ENV PYTHONUNBUFFERED=1
+
 ENTRYPOINT ["mock-sensor"]

--- a/README.md
+++ b/README.md
@@ -261,11 +261,12 @@ this repository.
 - `tests/` — pytest suite
 - `docs/` — usage docs per component
 - `typings/` — local type stubs for untyped third-party dependencies
-- `grafana/` — provisioned datasource and dashboards
+- `grafana/` — provisioned datasources and dashboards
+- `loki/` · `alloy/` — log storage and collection, behind the `logs` profile
 - `Dockerfile` — builds `labmon:latest`, the one image every service runs
   and the base a custom sensor layers on; not where instrument-specific
   dependencies go
-- `docker-compose.yml` — local InfluxDB, Grafana, and demo sensor instances
+- `docker-compose.yml` — local InfluxDB, Grafana, demo sensors, and optional log aggregation
 - `docker-compose.client.yml` — sensor-only compose file for a remote client machine
 - `calibration.example.toml` — worked example of every sensor conversion mode
 - `deploy/` — systemd units and docs for machines that can't run the containers

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,40 @@
+// Collects container logs and ships them to Loki.
+//
+// Alloy replaced Promtail, which reached end of life in March 2026. The
+// syntax here is Alloy's own, not YAML: components are declared and wired
+// together by referring to each other's exports.
+//
+// Nothing in this file is labmon-specific — it collects from every
+// container on the host, including InfluxDB and Grafana themselves, since
+// "why did the sensor stop" is often answered by a different container.
+
+// Discovers containers, and re-reads the list so a sensor started later is
+// picked up without restarting Alloy.
+discovery.docker "containers" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "15s"
+}
+
+discovery.relabel "containers" {
+	targets = discovery.docker.containers.targets
+
+	// Docker reports names with a leading slash ("/grafana"), which would
+	// otherwise appear in every query.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+loki.source.docker "containers" {
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.containers.output
+	forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,18 @@ x-mock-sensor: &mock-sensor
     - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
 
 services:
-  # Prepares the two bind-mounted state directories, then exits. Docker
-  # creates a missing bind-mount source as root:root, which leaves influxdb3
-  # (uid 1500) and Grafana (uid 472) unable to write to their own data dirs —
-  # so on a fresh clone InfluxDB dies with "failed to initialize catalog:
-  # Permission denied" and every other service fails its dependency. Doing it
-  # here rather than in a documented `sudo chown` keeps the quickstart to two
-  # commands and needs no host privileges beyond Docker itself.
+  # Prepares the bind-mounted state directories, then exits. Docker creates
+  # a missing bind-mount source as root:root, which leaves influxdb3
+  # (uid 1500), Grafana (uid 472) and Loki (uid 10001) unable to write to
+  # their own data dirs — so on a fresh clone InfluxDB dies with "failed to
+  # initialize catalog: Permission denied" and every other service fails its
+  # dependency. Doing it here rather than in a documented `sudo chown` keeps
+  # the quickstart to two commands and needs no host privileges beyond
+  # Docker itself.
+  #
+  # .loki/data is prepared unconditionally even though Loki is behind the
+  # `logs` profile: this service cannot know which profiles are active, and
+  # an unused empty directory costs nothing.
   #
   # The parent directories are handed to whoever owns the repo, read at run
   # time rather than guessed, so they stay removable without root. Re-running
@@ -38,11 +43,12 @@ services:
       - |
         set -e
         owner="$$(stat -c '%u:%g' /repo)"
-        mkdir -p /repo/.influxdb3/data /repo/.grafana/data
-        chown "$$owner" /repo/.influxdb3 /repo/.grafana
+        mkdir -p /repo/.influxdb3/data /repo/.grafana/data /repo/.loki/data
+        chown "$$owner" /repo/.influxdb3 /repo/.grafana /repo/.loki
         chown 1500:1500 /repo/.influxdb3/data
         chown 472:0 /repo/.grafana/data
-        chmod 755 /repo/.influxdb3/data /repo/.grafana/data
+        chown 10001:10001 /repo/.loki/data
+        chmod 755 /repo/.influxdb3/data /repo/.grafana/data /repo/.loki/data
         echo "state directories ready"
 
   influxdb:
@@ -120,6 +126,82 @@ services:
       timeout: 2s
       retries: 30
       start_period: 5s
+
+  # Log aggregation, behind the `logs` profile: off unless COMPOSE_PROFILES
+  # asks for it, so a metrics-only deployment stays two containers lighter.
+  # See docs/logging.md.
+  loki:
+    image: grafana/loki:3.7.0
+    container_name: loki
+    profiles: [logs]
+    depends_on:
+      init-state-dirs:
+        condition: service_completed_successfully
+    # Not published to the host: only Grafana and Alloy talk to Loki, both
+    # from inside this network. Reaching it from another machine is a
+    # deliberate step, not the default (see docs/logging.md).
+    expose:
+      - "3100"
+    command:
+      - -config.file=/etc/loki/config.yaml
+      # Lets ${LOKI_RETENTION_PERIOD} in the config come from .env.
+      - -config.expand-env=true
+    environment:
+      - LOKI_RETENTION_PERIOD=${LOKI_RETENTION_PERIOD:-720h}
+    volumes:
+      - type: bind
+        source: ./loki/config.yaml
+        target: /etc/loki/config.yaml
+        read_only: true
+      - type: bind
+        source: .loki/data
+        target: /loki
+    # No healthcheck, unlike every other service here: the image is
+    # distroless and contains exactly one binary, /usr/bin/loki. There is
+    # no shell, wget or curl for a CMD check to use, and Docker offers no
+    # way to probe one container from another. Alloy retries a failed push,
+    # so the seconds before Loki is ready cost nothing.
+
+  alloy:
+    image: grafana/alloy:v1.18.0
+    container_name: alloy
+    profiles: [logs]
+    depends_on:
+      # service_started, not service_healthy: Loki has no healthcheck to
+      # wait on (see above). This only orders startup.
+      loki:
+        condition: service_started
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      # Without this the UI binds to localhost inside the container and
+      # the port below reaches nothing.
+      - --server.http.listen-addr=0.0.0.0:12345
+    ports:
+      # Alloy's own UI, showing each component's health and what it last
+      # sent. The first place to look when logs are not arriving.
+      - "12345:12345"
+    volumes:
+      - type: bind
+        source: ./alloy/config.alloy
+        target: /etc/alloy/config.alloy
+        read_only: true
+      # Reading container logs means talking to the Docker API, and access
+      # to this socket is equivalent to root on the host. read_only does
+      # not meaningfully restrict it — the socket is still a full API.
+      # This is the cost of collecting logs without touching each
+      # container; docs/logging.md covers what to do if that trade is
+      # wrong for your machine.
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+      # A named volume rather than a bind: this is Alloy's own bookkeeping
+      # (how far it has read in each container's log), not something to
+      # inspect, and Alloy runs as root — a bind would leave a root-owned
+      # directory in the repo that needs sudo to delete.
+      - alloy-data:/var/lib/alloy/data
 
   mock-room-1:
     <<: *mock-sensor
@@ -223,3 +305,9 @@ services:
     command:
       - --port=socket://demo-adc-feeder:5555
       - --calibration=/app/demo/calibration.demo.toml
+
+volumes:
+  # Alloy's read positions. Named rather than bound so nothing root-owned
+  # lands in the repo; `docker compose down -v` resets it, at the cost of
+  # re-reading each container's log from the start.
+  alloy-data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,6 +28,17 @@ machine's `.env`: `docker compose up -d --wait` then starts only
 `influxdb` and `grafana` — nothing simulates sensor data, since real
 clients will be doing that over the network instead.
 
+The other profile is `logs`, which adds Loki and Alloy to collect every
+container's output. It is off by default and is independent of `demo`, so
+a server that wants log aggregation but no simulated sensors sets
+`COMPOSE_PROFILES=logs`. See [`docs/logging.md`](logging.md), including
+what mounting the Docker socket costs.
+
+Note that a profile is needed to stop its services as well as to start
+them. `docker compose down` on a stack brought up with
+`COMPOSE_PROFILES=demo,logs` leaves Loki and Alloy running unless the same
+profiles are set.
+
 `GRAFANA_PLUGINS` is the other variable to leave blank on a server. It
 lists Grafana panel plugins to fetch at startup, and the demo sets it to
 the one plugin its detuning gauge needs. Unset, Grafana installs nothing

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,124 @@
+# Logs
+
+Measurements say a reading stopped arriving. They never say why. The
+reasons live in a container's output — an expired API token, an instrument
+reporting busy, a traceback from a vendor SDK — and by default that is only
+reachable by running `docker compose logs` on the right machine, with no
+history beyond what Docker happens to still hold.
+
+The `logs` profile adds two containers that fix this: **Loki** stores log
+lines, and **Alloy** collects them from every container on the host and
+ships them over. Both are Grafana's own, so the result is queryable in the
+same Grafana that shows the measurements.
+
+## Turning it on
+
+Off by default. Add `logs` to `COMPOSE_PROFILES` in `.env`:
+
+```bash
+COMPOSE_PROFILES=demo,logs
+```
+
+then:
+
+```bash
+docker compose up -d --wait
+```
+
+Open Grafana, go to **Explore**, pick the **Loki** datasource, and query:
+
+```logql
+{container="mock-room-1"}
+```
+
+Every container is collected, not only sensors — "why did the sensor stop"
+is often answered by InfluxDB's or Grafana's output rather than the
+sensor's own.
+
+Stopping needs the profile too, or the two containers are left running:
+
+```bash
+COMPOSE_PROFILES=demo,logs docker compose down
+```
+
+## Retention
+
+`LOKI_RETENTION_PERIOD` in `.env`, 30 days by default:
+
+```bash
+LOKI_RETENTION_PERIOD=168h   # a week
+```
+
+Loki's own minimum is 24h. This is the setting that decides how much disk
+the stack uses over time — log lines are far bulkier than measurements, so
+a year of logs costs more than a year of readings.
+
+Retention only works because `loki/config.yaml` enables the compactor.
+With `retention_enabled` off — Loki's default — the retention period is
+silently ignored and logs accumulate until the disk fills.
+
+## Where it collects from
+
+Alloy reads container output through the Docker API. That means anything a
+container writes to stdout or stderr is collected, with no logging library,
+no configuration, and no change to the container.
+
+The label `container` carries the container's name. `docker compose logs`
+still works exactly as before and is often quicker for a glance; Loki is
+for history, for correlating two containers, and for looking at a machine
+you are not sitting in front of.
+
+### If a container's output never appears
+
+Almost always buffering rather than collection. Python block-buffers stdout
+when it is not a terminal, which it never is in a container, so a program
+printing a short line every few seconds can fill a buffer for twenty
+minutes before anything is written. `docker compose logs` shows nothing
+either, which is the giveaway that the problem is upstream of Alloy.
+
+labmon's own image sets `PYTHONUNBUFFERED=1` for this reason. A container
+built from something else may need the same, or to log through `logging`
+rather than `print`.
+
+## What Alloy needs, and what that costs
+
+Alloy mounts `/var/run/docker.sock`. **Access to that socket is equivalent
+to root on the host** — it allows starting a container with the host
+filesystem mounted. Marking the mount `read_only` does not meaningfully
+constrain it, since the socket is a full API either way.
+
+This is the honest trade for collecting logs without modifying every
+container. It is a reasonable one on a dedicated lab server that is already
+running the stack as a whole. It is less reasonable on a shared or
+multi-tenant machine.
+
+If it is the wrong trade for yours:
+
+- Put a socket proxy in front, restricting Alloy to `GET /containers`.
+- Or drop Alloy and use Docker's `loki` logging driver, which sends output
+  straight from the daemon and needs no socket access. It is a host-level
+  plugin install, and it cannot read journald or files, which is why it is
+  not the default here.
+
+## When something is missing
+
+Alloy has a UI at [http://localhost:12345](http://localhost:12345) showing
+every component, its health, and what it last sent. Check there before
+suspecting Loki: a component in a failed state names its own problem.
+
+Loki itself has no healthcheck in `docker-compose.yml`, unlike every other
+service. Its image is distroless — it contains exactly one binary and no
+shell, `wget` or `curl` for a check to use. Alloy retries a failed push, so
+the few seconds before Loki is ready cost nothing.
+
+## What is not here yet
+
+- **Logs from other machines.** Alloy collects from the host it runs on. A
+  remote sensor machine needs its own Alloy forwarding here, which also
+  means exposing Loki's push endpoint beyond this network.
+- **Logs from bare-metal sensors.** A sensor run under systemd rather than
+  Docker writes to the journal, which Alloy can read but is not yet
+  configured to.
+- **Devices that speak syslog.** Instruments, switches and UPS units that
+  can be pointed at a syslog collector — Alloy has a listener for it,
+  unconfigured for want of a device to test against.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -49,9 +49,16 @@ COMPOSE_PROFILES=demo,logs docker compose down
 LOKI_RETENTION_PERIOD=168h   # a week
 ```
 
-Loki's own minimum is 24h. This is the setting that decides how much disk
-the stack uses over time — log lines are far bulkier than measurements, so
-a year of logs costs more than a year of readings.
+This is the setting that decides how much disk the stack uses over time —
+log lines are far bulkier than measurements, so a year of logs costs more
+than a year of readings.
+
+**Do not set it below 24h.** That is Loki's documented minimum, but Loki
+does not enforce it: `1h` starts cleanly, is reported back by `/config`
+as `1h`, and produces no warning. It will not do what it says either, since
+retention cannot be finer than the 24h index period the schema requires.
+The result is a setting that appears to have been accepted and quietly
+means something else.
 
 Retention only works because `loki/config.yaml` enables the compactor.
 With `retention_enabled` off — Loki's default — the retention period is

--- a/grafana/provisioning/datasources/loki.yaml
+++ b/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    # InfluxDB3 stays the default: measurements are what most panels want,
+    # and logs are reached deliberately.
+    isDefault: false
+    jsonData:
+      # Loki holds far less history than InfluxDB. Asking for a year of
+      # logs returns nothing useful and takes a while to do it.
+      maxLines: 1000

--- a/loki/config.yaml
+++ b/loki/config.yaml
@@ -39,7 +39,10 @@ schema_config:
         period: 24h
 
 limits_config:
-  # How long a log line is kept. The minimum Loki accepts is 24h.
+  # How long a log line is kept. Loki documents 24h as the minimum but does
+  # not enforce it: a shorter value starts cleanly, reports itself back
+  # unchanged, and cannot take effect, because retention is no finer than
+  # the 24h index period above.
   retention_period: ${LOKI_RETENTION_PERIOD:-720h}
 
   # A lab instrument's clock is often wrong, and a device that boots

--- a/loki/config.yaml
+++ b/loki/config.yaml
@@ -1,0 +1,66 @@
+# Single-binary Loki for a lab-sized deployment: one process, logs on the
+# local filesystem, no object store and no clustering.
+#
+# Started from the config the image ships at /etc/loki/local-config.yaml,
+# with retention and analytics changed. Everything else is that file
+# verbatim, so it can be diffed against a newer image's default.
+#
+# Read with -config.expand-env=true, so ${VAR} below comes from .env.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  # The default is `info`, which reports every successful push. On a stack
+  # whose whole job is collecting logs, that is a log source in itself.
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        # Retention requires a 24h index period. Do not shorten it.
+        period: 24h
+
+limits_config:
+  # How long a log line is kept. The minimum Loki accepts is 24h.
+  retention_period: ${LOKI_RETENTION_PERIOD:-720h}
+
+  # A lab instrument's clock is often wrong, and a device that boots
+  # without NTP can stamp lines hours out. Accepting them keeps the
+  # evidence; the default rejects anything older than a week.
+  reject_old_samples: false
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  # Without this the compactor only compacts, and retention_period above
+  # is silently ignored — logs accumulate until the disk fills.
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# Off by default here. Loki otherwise reports usage statistics to
+# Grafana Labs, which is not a reasonable default for a machine sitting on
+# a lab network.
+analytics:
+  reporting_enabled: false


### PR DESCRIPTION
Third of five PRs toward custom-API sensors and log aggregation. Independent of [#37](https://github.com/quentinmarolleau/labmon/pull/37) and [#38](https://github.com/quentinmarolleau/labmon/pull/38) — branched from `main`, so it gets full CI.

## Why

Measurements say a reading stopped arriving. They never say *why*. The reasons live in a container's output — an expired token, an instrument reporting busy, a vendor traceback — and until now that was only reachable by running `docker compose logs` on the right machine, with no history.

## What

Loki stores log lines; Alloy collects them from every container on the host. Both behind a **`logs` profile, off by default**, so a metrics-only deployment stays two containers lighter and the quickstart is unchanged.

```bash
COMPOSE_PROFILES=demo,logs
docker compose up -d --wait
```

Then in Grafana → Explore → Loki: `{container="mock-room-1"}`.

## A pre-existing bug this exposed

Six of twelve containers were missing — every `mock-*` sensor. Not a collection failure: `mock_sensor.py` uses `print()`, and **Python block-buffers stdout when it is not a TTY**. At ~25 bytes every 5 s, Docker itself saw nothing for roughly twenty minutes — `docker compose logs mock-room-1` was empty too. `demo-serial-sensor` appeared only because it logs via `logging` to stderr.

`PYTHONUNBUFFERED=1` in the Dockerfile fixes it. This existed before this PR; log collection is what made it visible.

## Deliberate choices

- **Loki has no healthcheck**, unlike every other service. Its image is distroless and contains exactly one binary — no shell, `wget` or `curl` for a `CMD` check, and Docker cannot probe one container from another. Alloy retries a failed push, so the gap costs nothing. Commented in place so it does not read as an omission.
- **Alloy mounts `/var/run/docker.sock`, which is root-equivalent on the host.** `read_only` does not meaningfully constrain it. `docs/logging.md` says so plainly and gives the two ways out (socket proxy, or Docker's `loki` logging driver) rather than leaving it to be discovered.
- **Analytics reporting off.** Loki otherwise sends usage statistics to Grafana Labs; not a reasonable default for a machine on a lab network.
- **`reject_old_samples: false`.** A device that boots without NTP stamps lines hours out, and the evidence is worth keeping.
- **Retention needs the compactor.** With `retention_enabled` off — Loki's default — `retention_period` is silently ignored and logs grow until the disk fills.

## Test plan

- [x] `COMPOSE_PROFILES=demo,logs docker compose up -d --wait` — all 12 services up
- [x] `{container="mock-room-1"}` returns real lines (`room-1: 21.44 °C`)
- [x] **12 of 12** containers collected
- [x] Grafana provisions both InfluxDB3 and Loki datasources
- [x] Default profile starts **no** Loki/Alloy; `scripts/smoke_dashboard.py` still passes all 14 queries
- [x] True cold start — `.loki` deleted as root, recreated and chowned to 10001, 12 containers collected
- [x] `alloy fmt` clean · `docker compose config` valid for both profile sets
- [x] `pytest --cov-fail-under=100` · `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`

## Known gap

The `cold start` smoke job does not exercise the `logs` profile, since it is off by default. Worth its own change rather than widening this one.

