### PR TITLE
docs: correct what enabling a timer-driven service actually does

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,13 +41,18 @@ editing before they will start.
 
 ## Two things that catch people out
 
-**Enable the timer, not the service it starts.** A `Type=oneshot` service
-enabled on its own runs once at boot and never again:
+**Enable the timer, not the service it starts.**
 
 ```bash
-sudo systemctl enable --now labmon-custom-sensor-triggered.timer   # correct
-sudo systemctl enable --now labmon-custom-sensor-triggered.service # runs once, ever
+sudo systemctl enable --now labmon-custom-sensor-triggered.timer
 ```
+
+`labmon-custom-sensor-triggered.service` has no `[Install]` section, since
+a unit started by something else has nothing to install itself into.
+`systemctl enable` on it prints an explanation and does nothing, so
+reaching for the wrong one costs a moment rather than a silent gap in the
+data. `--now` on the timer matters though: `enable` alone only schedules
+it from the next boot.
 
 **A triggered unit has no `Restart=` on purpose.** A failed reading waits
 for the next scheduled run rather than retrying immediately — retrying a

--- a/deploy/labmon-custom-sensor-triggered.service
+++ b/deploy/labmon-custom-sensor-triggered.service
@@ -8,8 +8,11 @@
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now labmon-custom-sensor-triggered.timer
 #
-# Note that the *timer* is enabled, not the service. Enabling the service
-# instead would run it once at boot and never again.
+# Note that the *timer* is enabled, not the service. This file has no
+# [Install] section, deliberately: a unit something else starts has
+# nothing to install itself into. `systemctl enable` on it therefore does
+# nothing but print an explanation, so the mistake costs a moment rather
+# than a silent gap in the data.
 
 [Unit]
 Description=labmon custom API sensor (single reading)

--- a/deploy/labmon-custom-sensor-triggered.timer
+++ b/deploy/labmon-custom-sensor-triggered.timer
@@ -24,6 +24,12 @@ OnCalendar=*:0/15
 # sensors share one rate-limited API.
 RandomizedDelaySec=30s
 
+# Note that systemd batches timer wakeups to within a minute by default
+# (AccuracySec), on top of the delay above. Neither matters at a
+# fifteen-minute cadence, but both are why a timer shortened to seconds
+# appears not to fire on time. Set AccuracySec=1s if a short interval ever
+# has to be exact.
+
 # Run once at boot if the machine was off when a run was due, rather than
 # silently skipping until the next slot.
 Persistent=true


### PR DESCRIPTION
Follow-up to [#38](https://github.com/quentinmarolleau/labmon/pull/38), which merged before this correction was applied.

## The wrong claim

`deploy/README.md` and the triggered unit both said that enabling the service instead of its timer "runs it once at boot and never again".

Running the units under real systemd — a venv with labmon installed, both scripts, an `.env`, the shipped units installed as user units — says otherwise:

```
The unit files have no installation config (WantedBy=, RequiredBy=, …).
This means they are not meant to be enabled or disabled using systemctl.
```

`labmon-custom-sensor-triggered.service` has **no `[Install]` section**, which is correct — a unit something else starts has nothing to install itself into. `systemctl enable` on it prints an explanation and does nothing at all.

The truth is the better story: the mistake is *impossible*, not merely discouraged. The docs now say that, and note the thing that does matter — `--now` on the timer, since `enable` alone only schedules from the next boot.

## Also recorded

Why a timer shortened for testing appears not to fire: systemd batches timer wakeups to within a minute by default (`AccuracySec`), on top of this timer's own 30s `RandomizedDelaySec`. Neither matters at a fifteen-minute cadence, which is why it is a comment rather than a setting — but both are exactly why a shortened interval looks broken. It cost me twenty minutes of debugging.

## How the units were actually verified

Not `systemd-analyze verify`, which only parses:

| Check | Result |
| --- | --- |
| Continuous service starts | `active` |
| stdout reaches journald | confirmed via `journalctl -u` |
| Writes to InfluxDB | 11 rows |
| `Restart=on-failure` | `kill -9` → new PID, `NRestarts: 1`, back to `active` |
| `EnvironmentFile` delivers the token | sensor connected and wrote |
| Triggered service (`Type=oneshot`) | `inactive` / `Result: success` / exit 0 |
| Timer fires | 4 runs, rows 15 → 18 |
| `[Install]` structure across all 5 units | present on the two continuous + timer, absent on the oneshot |

**Not verified**, because systemd user units cannot: `User=lab` (ignored in user mode) and `After=network-online.target` (substituted `network.target`). Both are copied from the two units that predate #38.

## Test plan

- [x] `uv run pytest --cov=src --cov-fail-under=100` — 134 passed, 100%
- [x] `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`
- [x] `systemd-analyze verify` on all 5 units — only the placeholder `ExecStart` path flagged, as for the pre-existing units
- [x] Every relative link resolves

