### PR TITLE
feat: label a sensor's logs with the sensor_id its readings carry

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -25,6 +25,20 @@ discovery.relabel "containers" {
 		regex         = "/(.*)"
 		target_label  = "container"
 	}
+
+	// A container that declares which sensor it is gets that as a label,
+	// spelled exactly as the InfluxDB tag, so a reading and the lines the
+	// sensor wrote while producing it can be filtered by the same value.
+	//
+	// Docker sanitises the label name on the way in: labmon.sensor_id
+	// becomes __meta_docker_container_label_labmon_sensor_id. A container
+	// without the label produces no sensor_id at all rather than an empty
+	// one, which would otherwise be a series of its own.
+	rule {
+		source_labels = ["__meta_docker_container_label_labmon_sensor_id"]
+		regex         = "(.+)"
+		target_label  = "sensor_id"
+	}
 }
 
 loki.source.docker "containers" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,8 @@ services:
   mock-room-1:
     <<: *mock-sensor
     container_name: mock-room-1
+    labels:
+      labmon.sensor_id: room-1
     command:
       - --sensor-id=room-1
       - --measurement=temperature
@@ -216,6 +218,8 @@ services:
   mock-room-2:
     <<: *mock-sensor
     container_name: mock-room-2
+    labels:
+      labmon.sensor_id: room-2
     command:
       - --sensor-id=room-2
       - --measurement=temperature
@@ -226,6 +230,8 @@ services:
   mock-cryo-77k:
     <<: *mock-sensor
     container_name: mock-cryo-77k
+    labels:
+      labmon.sensor_id: cryo-77k
     command:
       - --sensor-id=cryo-77k
       - --measurement=temperature
@@ -236,6 +242,8 @@ services:
   mock-cryo-4k:
     <<: *mock-sensor
     container_name: mock-cryo-4k
+    labels:
+      labmon.sensor_id: cryo-4k
     command:
       - --sensor-id=cryo-4k
       - --measurement=temperature
@@ -246,6 +254,8 @@ services:
   mock-pressure:
     <<: *mock-sensor
     container_name: mock-pressure
+    labels:
+      labmon.sensor_id: chamber-1
     command:
       - --sensor-id=chamber-1
       - --measurement=pressure
@@ -260,6 +270,8 @@ services:
   mock-wavemeter:
     <<: *mock-sensor
     container_name: mock-wavemeter
+    labels:
+      labmon.sensor_id: wavemeter-1
     command:
       - --sensor-id=wavemeter-1
       - --measurement=frequency

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -75,6 +75,44 @@ still works exactly as before and is often quicker for a glance; Loki is
 for history, for correlating two containers, and for looking at a machine
 you are not sitting in front of.
 
+## Finding a sensor's logs from its readings
+
+A container can declare which sensor it is, and Alloy turns that into a
+Loki label spelled exactly like the InfluxDB tag:
+
+```yaml
+  my-sensor:
+    labels:
+      labmon.sensor_id: cryo-77k
+```
+
+Then one identifier reaches both halves of the stack. In Grafana, a
+measurement filtered by `sensor_id = 'cryo-77k'` and a log query of
+`{sensor_id="cryo-77k"}` describe the same instrument, so a trace that
+went flat and the lines written while it was going flat can sit on one
+screen.
+
+The demo's six mock sensors carry the label, which is where the values
+under **Explore → Loki → label browser** come from.
+
+A container with no such label simply has no `sensor_id`, rather than an
+empty one — an empty label value would be a series of its own and would
+clutter every label browser in Grafana.
+
+### One container, several sensors
+
+The label describes a *container*, so it only fits when a container is one
+sensor. `demo-serial-sensor` is the counter-example: it reads six
+calibrated channels — `cryo-diode`, `bias-monitor`, `pirani-1`, `laser-1`,
+`beam-x`, `beam-y` — and no single value would be true.
+
+It is therefore left unlabelled, and its logs are reached by
+`{container="demo-serial-sensor"}`. Splitting them per channel would mean
+parsing each line rather than reading a container's metadata, which is a
+larger and more fragile thing than this buys. If you have a multi-channel
+sensor whose logs you want split, one container per channel is the simpler
+answer.
+
 ### If a container's output never appears
 
 Almost always buffering rather than collection. Python block-buffers stdout


### PR DESCRIPTION
Logs and measurements have been reachable from the same Grafana since [#39](https://github.com/quentinmarolleau/labmon/pull/39), but not by the same name. A reading is tagged `sensor_id`; its log lines were only findable by container. Answering "what was this instrument saying while its trace went flat" meant knowing which container ran which sensor and translating by hand.

## What it does

A container declares which sensor it is:

```yaml
  my-sensor:
    labels:
      labmon.sensor_id: cryo-77k
```

Alloy promotes that to a Loki label spelled exactly like the InfluxDB tag, so one identifier reaches both halves of the stack. Verified against a live stack:

```
InfluxDB, sensor_id='room-2'        Loki, {sensor_id="room-2"}
   21.487 °C                           room-2: 21.49 °C
   21.482 °C                           room-2: 21.48 °C
   21.687 °C                           room-2: 21.69 °C
```

## One detail worth reviewing

The relabel rule matches `(.+)` rather than passing the value straight through:

```alloy
	rule {
		source_labels = ["__meta_docker_container_label_labmon_sensor_id"]
		regex         = "(.+)"
		target_label  = "sensor_id"
	}
```

Without the regex, a container with no such label gets an **empty** `sensor_id` — which is a distinct series in Loki, and would put a blank entry in every label browser in Grafana. Confirmed: `grafana` and the other unlabelled containers carry no `sensor_id` key at all.

## What it deliberately does not solve

`demo-serial-sensor` reads six calibrated channels — `cryo-diode`, `bias-monitor`, `pirani-1`, `laser-1`, `beam-x`, `beam-y` — so no single container-level value would be true. It stays unlabelled and its logs are reached by `{container="demo-serial-sensor"}`.

Splitting per channel would mean parsing every log line instead of reading container metadata: more fragile, and a commitment to a log message format that is currently free to change. `docs/logging.md` says so, and suggests one container per channel as the simpler answer if the split is really wanted.

Worth noting this interacts with [#57](https://github.com/quentinmarolleau/labmon/issues/57): whatever per-reading log format is settled there is what a future per-channel splitter would have to parse.

## Test plan

- [x] `sensor_id` values in Loki: `chamber-1, cryo-4k, cryo-77k, room-1, room-2, wavemeter-1`
- [x] Unlabelled container carries no `sensor_id` key
- [x] Cross-system correlation returns matching values, above
- [x] `alloy fmt` clean · `docker compose config` valid for both profile sets
- [x] `uv run pytest --cov=src --cov-fail-under=100` — 134 passed, 100%
- [x] `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`

Verified from a clean `--build --force-recreate` on current `main`, not a stale image.

