### PR TITLE
feat: collect logs from sensors running under systemd

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -33,6 +33,66 @@ loki.source.docker "containers" {
 	forward_to = [loki.write.local.receiver]
 }
 
+// A sensor that cannot run in a container runs under systemd instead (see
+// deploy/), and writes to the journal rather than to the Docker API. This
+// picks those up, so both deployment shapes end up in the same place.
+discovery.relabel "journal" {
+	targets = []
+
+	// Which unit produced the entry. A *user* unit — one installed with
+	// `systemctl --user`, which needs no root — reports the manager rather
+	// than itself in _SYSTEMD_UNIT, naming `user@1000.service` for every one
+	// of them. Its own name is in _SYSTEMD_USER_UNIT, so that wins when it
+	// is present. Matching on (.+) means the rule does not fire for a system
+	// unit, where the field is empty.
+	rule {
+		source_labels = ["__journal__systemd_unit"]
+		target_label  = "unit"
+	}
+
+	rule {
+		source_labels = ["__journal__systemd_user_unit"]
+		regex         = "(.+)"
+		target_label  = "unit"
+	}
+
+	// Only labmon's own units. The host journal is the whole machine —
+	// docker, containerd, the network manager, every login session — 775 MB
+	// on the machine this was written on, against a handful of sensor lines.
+	// Collecting all of it would dwarf everything else in Loki and sweep up
+	// system logs nobody asked to centralise.
+	//
+	// Applied after the two rules above so it matches the real unit name in
+	// both cases. Widen it to collect more; `.*` collects the whole machine.
+	rule {
+		source_labels = ["unit"]
+		regex         = "labmon-.*"
+		action        = "keep"
+	}
+
+	// systemd records a priority per entry, which Docker has no equivalent
+	// of. Do not read more into it than is there: everything a plain script
+	// writes arrives as `info`, stderr included — systemd does not infer
+	// severity from the stream. Only an explicit `<N>` prefix on the line
+	// changes it, which is what systemd's SyslogLevelPrefix reads.
+	//
+	// So this is a hook for real severities rather than a source of them.
+	rule {
+		source_labels = ["__journal_priority_keyword"]
+		target_label  = "level"
+	}
+}
+
+loki.source.journal "units" {
+	// The persistent journal. A host with volatile-only logging keeps it at
+	// /run/log/journal instead, in which case nothing is collected here and
+	// the mount in docker-compose.yml needs changing to match.
+	path          = "/var/log/journal"
+	relabel_rules = discovery.relabel.journal.rules
+	labels        = {job = "systemd-journal"}
+	forward_to    = [loki.write.local.receiver]
+}
+
 loki.write "local" {
 	endpoint {
 		url = "http://loki:3100/loki/api/v1/push"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -68,6 +68,14 @@ A unit's output goes to the journal:
 journalctl -u labmon-custom-sensor.service -f
 ```
 
-That matters beyond reading it by hand: the journal is where logs are
-collected from on a machine with no Docker, so a sensor run this way ends
-up in the same place as one run in a container.
+That matters beyond reading it by hand: with the `logs` profile active on
+the same host, Alloy collects the journal too, so a sensor run this way is
+queryable in Grafana alongside the containers:
+
+```logql
+{unit="labmon-custom-sensor.service"}
+```
+
+Only units named `labmon-*` are collected, not the whole machine — see
+[logging](../docs/logging.md). A sensor on a *different* machine from the
+stack is not covered yet.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,31 @@ services:
         source: /var/run/docker.sock
         target: /var/run/docker.sock
         read_only: true
+      # The host journal, for sensors run under systemd rather than in a
+      # container (see deploy/). Read-only, and the Alloy config collects
+      # only labmon's own units rather than the whole machine.
+      #
+      # A host that keeps logs in memory only has them at /run/log/journal
+      # instead; both are mounted so either works, and a missing one is an
+      # empty directory rather than an error.
+      - type: bind
+        source: /var/log/journal
+        target: /var/log/journal
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: /run/log/journal
+        target: /run/log/journal
+        read_only: true
+        bind:
+          create_host_path: true
+      # Journal entries are keyed by machine id; without this the reader
+      # cannot resolve which machine's journal it is looking at.
+      - type: bind
+        source: /etc/machine-id
+        target: /etc/machine-id
+        read_only: true
       # A named volume rather than a bind: this is Alloy's own bookkeeping
       # (how far it has read in each container's log), not something to
       # inspect, and Alloy runs as root — a bind would leave a root-owned

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -87,10 +87,46 @@ labmon's own image sets `PYTHONUNBUFFERED=1` for this reason. A container
 built from something else may need the same, or to log through `logging`
 rather than `print`.
 
+## Sensors that run under systemd
+
+A sensor that cannot run in a container runs under systemd instead (see
+[`deploy/`](../deploy/)), and writes to the journal rather than through the
+Docker API. Alloy collects those too, so both deployment shapes end up in
+the same place:
+
+```logql
+{unit="labmon-custom-sensor.service"}
+```
+
+Both system units and user units work. A user unit — one installed with
+`systemctl --user`, needing no root — names the manager rather than itself
+in its systemd unit field, reporting `user@1000.service` for every one of
+them; its real name is recorded separately, and that is what gets used.
+
+### Only labmon's own units
+
+The host journal is the whole machine: Docker, containerd, the network
+manager, every login session. On the machine this was developed on that was
+775 MB against a handful of sensor lines, so collecting all of it would
+dwarf everything else in Loki and centralise system logs nobody asked to
+centralise.
+
+`alloy/config.alloy` therefore keeps only units whose name starts with
+`labmon-`. Widen that regex to collect more; `.*` collects the machine.
+
+### About the `level` label
+
+Journal entries carry a `level`, which container logs have no equivalent
+of. It is less than it appears: **everything a plain script writes arrives
+as `info`, stderr included.** systemd does not infer severity from the
+stream — only an explicit `<N>` prefix on the line changes it.
+
+So `level` is a hook for real severities rather than a source of them.
+
 ## What Alloy needs, and what that costs
 
-Alloy mounts `/var/run/docker.sock`. **Access to that socket is equivalent
-to root on the host** — it allows starting a container with the host
+Alloy mounts `/var/run/docker.sock`, plus the host journal read-only.
+**Access to that socket is equivalent to root on the host** — it allows starting a container with the host
 filesystem mounted. Marking the mount `read_only` does not meaningfully
 constrain it, since the socket is a full API either way.
 
@@ -121,11 +157,8 @@ the few seconds before Loki is ready cost nothing.
 ## What is not here yet
 
 - **Logs from other machines.** Alloy collects from the host it runs on. A
-  remote sensor machine needs its own Alloy forwarding here, which also
-  means exposing Loki's push endpoint beyond this network.
-- **Logs from bare-metal sensors.** A sensor run under systemd rather than
-  Docker writes to the journal, which Alloy can read but is not yet
-  configured to.
+  sensor on a *different* machine needs its own Alloy forwarding here, which
+  also means exposing Loki's push endpoint beyond this network.
 - **Devices that speak syslog.** Instruments, switches and UPS units that
   can be pointed at a syslog collector — Alloy has a listener for it,
   unconfigured for want of a device to test against.


### PR DESCRIPTION
Closes #62.

Alloy reads container output through the Docker API, so a sensor running under systemd was invisible to it. That is the path [`deploy/`](https://github.com/quentinmarolleau/labmon/tree/main/deploy) exists for — a control PC where a vendor SDK will not containerise, or where policy forbids Docker — and those units already write to the journal. Nothing was collecting it.

A `loki.source.journal` alongside the Docker source closes that, so a bare-metal sensor is queryable exactly like a containerised one:

```logql
{unit="labmon-custom-sensor.service"}
```

## Only labmon's own units

The host journal is the whole machine: Docker, containerd, the network manager, every login session. Measured on the machine this was developed on, that is **775 MB against a handful of sensor lines**. Collecting all of it would dwarf everything else in Loki and centralise system logs nobody asked to centralise, so the config keeps only units named `labmon-*`. Widening it is one regex.

## The unit name has to be resolved twice

Testing found this the hard way. A **user** unit — installed with `systemctl --user`, needing no root, which is a legitimate way to run a sensor — reports the *manager* rather than itself:

```
_SYSTEMD_UNIT      = user@1000.service
_SYSTEMD_USER_UNIT = labmon-journal-probe.service
```

My first version filtered on `_SYSTEMD_UNIT` alone and silently collected nothing for user units. Both fields are now resolved before the filter runs, so it matches the real sensor either way.

## About the `level` label

Journal entries carry a priority, which container logs have no equivalent of. The comment in the config says exactly how little that means, because an earlier version of it claimed more than was true: **everything a plain script writes arrives as `info`, stderr included.** systemd does not infer severity from the stream — only an explicit `<N>` prefix changes it, which I confirmed works. So `level` is a hook for real severities rather than a source of them, and whether labmon's sensors should emit those prefixes is #57.

## On the open question in #62

The issue asked how a systemd unit should carry a `sensor_id`, since it has no Docker label. That question is now answered elsewhere: #61 was closed, and #64 extracts `sensor_id` from the log line instead — which works identically for a journal line and a container line. So this PR takes `unit` as the identifier for now and needs no bare-metal-specific mechanism later.

## Test plan

- [x] All six Alloy components healthy, including `journal tailer is running`
- [x] A `labmon-*` unit's output reaches Loki, labelled `unit=…` and `level=info`
- [x] Container collection unaffected — 12 of 12 still collected
- [x] `alloy fmt` clean · `docker compose config` valid for both profile sets
- [x] `uv run pytest --cov=src --cov-fail-under=100` — 134 passed, 100%
- [x] `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`
- [x] Real *system* unit.** Installing to `/etc/systemd/system` needs root.
