### PR TITLE
ci: run checks on pull requests based on any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
 name: CI
 
 on:
+  # No branch filter on pull_request, so a PR based on another feature
+  # branch is checked too. With one, a stacked PR matches nothing and
+  # GitHub reports "no checks reported" rather than failing — so it can
+  # look mergeable having never been tested. That happened twice while
+  # building the custom-sensor and log-aggregation series.
+  #
+  # push stays filtered: a branch push with an open PR is already covered
+  # by pull_request, and filtering here avoids running everything twice.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,15 @@
 name: smoke
 
 on:
+  # No branch filter on pull_request, so a PR based on another feature
+  # branch is checked too. With one, a stacked PR matches nothing and
+  # GitHub reports "no checks reported" rather than failing — so it can
+  # look mergeable having never been tested. That happened twice while
+  # building the custom-sensor and log-aggregation series.
+  #
+  # push stays filtered: a branch push with an open PR is already covered
+  # by pull_request, and filtering here avoids running everything twice.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
Closes #51.

Both workflows were scoped to `pull_request: branches: [main]`, so a pull request based on another feature branch matched nothing and ran **no checks at all**. GitHub reports that as "no checks reported" rather than as a failure — so a stacked PR can look mergeable having never been tested.

That happened twice while building the custom-sensor and log-aggregation series: #38 had no CI until #37 merged and GitHub retargeted it to `main`.

## The change

Drop the branch filter from `pull_request`. Keep it on `push`, because a branch push with an open PR is already covered by the `pull_request` event, so filtering there avoids running everything twice.

This matters now rather than later: the remaining `v0.2.0-beta` work is deliberately stacked — #47 is the root of a stack carrying #57, #56 and #48 — and without this every one of those would merge unverified.

## Test plan

- [x] Both workflow files parse as YAML, and their triggers resolve to `pull_request` unfiltered plus `push` on `main`
- [x] `typos` clean
- [x] **The real proof is the next stacked PR reporting checks.** The first PR built on top of another branch in this series will demonstrate it; nothing in this PR can.

No other workflows exist — the CodeQL checks come from GitHub's default setup rather than a file in the repository.
