### PR TITLE
fix: accept a conversion that is undefined at one voltage

### DIFF
--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -60,7 +60,18 @@ VOLTAGE_SYMBOL = "v"
 
 # Applied at load time to check a conversion works and to read off the
 # unit its results carry.
-ONE_VOLT: pint.Quantity = 1.0 * ureg.volt
+#
+# Several of them, because a conversion may legitimately be undefined at a
+# single point: 5.0 / (1.0 - v) is a perfectly good response curve that
+# happens to have a pole at one volt. Trying one voltage cannot tell that
+# apart from a conversion that is broken everywhere, and no single choice
+# avoids the problem — moving the probe just relocates the pole that
+# trips it. A conversion is rejected only when every probe fails.
+PROBE_VOLTAGES: tuple[pint.Quantity, ...] = (
+    1.0 * ureg.volt,
+    0.5 * ureg.volt,
+    2.0 * ureg.volt,
+)
 
 DEFAULT_MODE = "linear"
 
@@ -295,13 +306,16 @@ class Calibration:
     def unit(self) -> str:
         """The unit tag every reading from this channel carries.
 
-        Derived by converting one volt, so it reflects what the
+        Derived by converting a probe voltage, so it reflects what the
         conversion actually produces rather than what the file claims.
         Cached for the same reason as calibration_id: a conversion's
         output unit is a property of the calibration, not of a reading,
         and formatting it per sample cost more than building the point.
+
+        Uses the same probe sequence as load-time validation, so a
+        conversion with a pole at one volt still reports its unit.
         """
-        return f"{self.conversion.apply(ONE_VOLT).units:~}"
+        return f"{probe(self.conversion).units:~}"
 
 
 def raw_to_voltage(
@@ -379,10 +393,31 @@ def _parse_channel(
     )
 
 
+def probe(conversion: Conversion) -> pint.Quantity:
+    """Apply a conversion at the first probe voltage it accepts.
+
+    Raises the failure from the first probe if every one of them fails,
+    since that is the voltage a reader is most likely to reason about.
+    """
+    first: Exception | None = None
+    for voltage in PROBE_VOLTAGES:
+        try:
+            return conversion.apply(voltage)
+        except Exception as error:  # noqa: BLE001 — re-raised below if all fail
+            first = first or error
+    assert first is not None
+    raise first
+
+
 def _trial_apply(where: Location, conversion: Conversion) -> None:
-    """Convert a token voltage so a broken conversion fails at load time."""
+    """Convert a token voltage so a broken conversion fails at load time.
+
+    A conversion that fails at every probe voltage is broken. One that
+    fails at a single voltage has a pole there, which is not a fault —
+    see PROBE_VOLTAGES.
+    """
     try:
-        _ = conversion.apply(ONE_VOLT)
+        _ = probe(conversion)
     except CalibrationError:
         raise
     except pint.OffsetUnitCalculusError as error:
@@ -551,7 +586,11 @@ def _optional_stop_rule(
         reference = ureg.volt
         subject = f"gates on the raw voltage in {reference:~}"
     else:
-        reference = conversion.apply(ONE_VOLT).units
+        # Through `probe` rather than one fixed voltage, for the reason
+        # PROBE_VOLTAGES exists: a conversion with a pole at that voltage
+        # is legitimate, and reading its output unit must not depend on
+        # which point happens to be picked.
+        reference = probe(conversion).units
         subject = f"produces {reference:~}"
 
     bounds = {

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -4,6 +4,7 @@ from typing import cast
 
 import pint
 import pytest
+from asteval import Interpreter
 
 from labmon.calibration import (
     _BAND_ORDER,  # pyright: ignore[reportPrivateUsage]
@@ -1309,3 +1310,73 @@ def test_the_gate_is_not_part_of_the_calibration_id(tmp_path: Path) -> None:
     )
 
     assert gated["A0"].calibration_id == ungated["A0"].calibration_id
+
+
+# A conversion may be undefined at a point without being broken
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "5.0 / v",  # pole at zero
+        "5.0 / (1.0 - v)",  # pole at the first probe voltage
+        "5.0 / (0.5 - v)",  # pole at the second
+        "5.0 / (2.0 - v)",  # pole at the third
+        "log(v)",  # undefined at zero
+    ],
+)
+def test_a_conversion_with_a_pole_still_loads(tmp_path: Path, expression: str) -> None:
+    """No single probe voltage avoids every pole; moving one relocates it."""
+    path = _write_config(
+        tmp_path,
+        f"""
+        [channels.A0]
+        sensor_id = "gauge-1"
+        measurement = "pressure"
+        mode = "expression"
+        expression = "{expression}"
+        value_unit = "mbar"
+        """,
+    )
+
+    calibration = load_calibration(path)["A0"]
+
+    assert calibration.unit == "mbar"
+
+
+@pytest.mark.parametrize(
+    ("expression", "message"),
+    [("1.0 / 0.0", "ZeroDivisionError"), ("nosuchfunc(v)", "NameError")],
+)
+def test_a_conversion_broken_everywhere_is_still_rejected(
+    tmp_path: Path, expression: str, message: str
+) -> None:
+    path = _write_config(
+        tmp_path,
+        f"""
+        [channels.A0]
+        sensor_id = "gauge-1"
+        measurement = "pressure"
+        mode = "expression"
+        expression = "{expression}"
+        value_unit = "mbar"
+        """,
+    )
+
+    with pytest.raises(CalibrationError, match=message):
+        _ = load_calibration(path)
+
+
+def test_the_unit_of_a_conversion_with_a_pole_is_still_derivable() -> None:
+    """`unit` probes the same way, so a pole must not break it either."""
+    conversion = ExpressionConversion(
+        expression="5.0 / (1.0 - v)",
+        interpreter=Interpreter(),
+        unit=1.0 * ureg.mbar,
+    )
+    calibration = Calibration(
+        sensor_id="gauge-1", measurement="pressure", conversion=conversion
+    )
+
+    assert calibration.unit == "mbar"


### PR DESCRIPTION
Closes #44.

Load-time validation applied every conversion at exactly one volt, so an expression with a pole there was rejected at startup even though it is a perfectly good response curve. `5.0 / (1.0 - v)` failed; `5.0 / v` and `5.0 / (2.0 - v)` passed, purely because of where their poles happened to sit.

No single probe voltage avoids this — moving the constant only relocates the pole that trips it. Validation now tries three voltages and rejects a conversion only when **every** one fails, which still catches what matters: an expression broken everywhere, a name that does not exist, units that cannot combine.

`Calibration.unit` probes the same way. It derived the unit by applying at one volt too, so fixing only the load-time check would have moved the failure from startup to the first reading.

## Rebased onto current `main`

This branch was written before several things landed, so bringing it up to date needed more than a replay.

**The test-file conflict was additive on both sides** — `main` had appended ~340 lines of recording-gate tests, the branch ~70 lines of its own. Base was empty at that point, so the resolution keeps both.

**One real problem surfaced afterwards**, and only because the tests ran: 22 failures, all `NameError: name 'ONE_VOLT' is not defined`. The recording gate, added on `main` after this branch was written, derives a conversion's output unit to decide what its bounds are compared against — and did it with a single application at one volt:

```python
reference = conversion.apply(ONE_VOLT).units
```

That is a third instance of the very bug this PR fixes, in code that did not exist when the fix was written. Git merged both sides cleanly and produced something that could not run. It now goes through the same `probe()` helper, so a **gated** channel whose conversion has a pole at one volt configures correctly rather than failing to load.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 280 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean
- [x] Commit signed and verified
- [x] The new gate call site exercised by the existing gate tests, which is how the stale reference was caught
