### PR TITLE
feat: add a logs dashboard and validate every dashboard

### DIFF
--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -30,6 +30,13 @@ What the dashboard is *showing* is covered in
 constraints worth knowing before editing any of these panels. The rest of
 this page is about writing panels of your own.
 
+The **Logs** dashboard sits beside it in the same folder, reading Loki
+rather than InfluxDB: log volume by level, warning and error counts, the
+warning and error lines themselves, readings skipped per sensor, and an
+unparsed view of every container. It needs the `logs` profile — without
+it the Loki datasource is provisioned but nothing is running behind it,
+and every panel reads empty. See [`docs/logging.md`](logging.md).
+
 ## How the datasource is wired
 
 `grafana/provisioning/datasources/influxdb3.yaml` provisions an `InfluxDB3`
@@ -125,24 +132,38 @@ chain over the file on every load, and those migrations rewrite panels.
 
 ## What CI checks about a dashboard
 
-`tests/test_dashboard.py` runs a handful of structural checks over
-`lab-overview.json` on every PR. They exist because Grafana's failure mode
-for a malformed dashboard is silence: a query under the wrong key, or a
-datasource uid nobody provisioned, renders "No data" and logs nothing, so
-the dashboard keeps looking correct while showing you nothing.
+`tests/test_dashboard.py` runs a handful of structural checks over every
+file in `grafana/dashboards/` on every PR. They exist because Grafana's
+failure mode for a malformed dashboard is silence: a query under the wrong
+key, or a datasource uid nobody provisioned, renders "No data" and logs
+nothing, so the dashboard keeps looking correct while showing you nothing.
 
-The checks cover the mistakes this file has actually made — every data panel
-carrying at least one target, `rawSql` present and non-empty, no leftover
-`query` twin, the datasource uid matching what
-provisioning creates, unique panel ids, every `$variable` declared, custom
-variables carrying their values inline, `xychart` panels declaring a
-`pluginVersion`, and any `*-panel` type (the naming convention for community
-plugins) appearing in `GRAFANA_PLUGINS`.
+A dashboard you add is picked up with no change to the test file.
+
+The checks cover the mistakes these files have actually made — every data
+panel carrying at least one target, a non-empty query under the key its own
+backend reads (`rawSql` for InfluxDB, `expr` for Loki), no leftover `query`
+twin, every datasource reference resolving to a uid provisioning actually
+creates *and* agreeing with the type it is provisioned as, unique panel ids,
+every `$variable` declared, custom variables carrying their values inline,
+`xychart` panels declaring a `pluginVersion`, and any `*-panel` type (the
+naming convention for community plugins) appearing in `GRAFANA_PLUGINS`.
+
+Datasource references are checked wherever they appear — panels, targets and
+template variables — because an optional datasource makes a particular
+mistake easy: Loki only runs under the `logs` profile, so a dashboard
+reading it can be committed while the provisioning file that backs it is
+still unstaged. The result renders empty for everyone.
+
+Adding a datasource of a new type needs one line in the test file, mapping
+that type to the key it reads its query from. A type the suite does not know
+fails rather than being skipped, so the check cannot be silently switched
+off by using a backend nobody taught it about.
 
 None of them run a query, so SQL that is structurally fine but names a
 column the schema does not have passes here. Catching that needs a live
-stack, not a JSON parse.
-
-A second dashboard is not covered automatically — the paths at the top of
-that file name `lab-overview.json` directly. Point them at a directory when
-there is a second one worth checking.
+stack, not a JSON parse — which is what `scripts/smoke_dashboard.py` does,
+though only for `lab-overview.json`: it speaks SQL and reads `rawSql`, so
+the Logs dashboard's LogQL is checked for shape here and not for meaning
+anywhere. `scripts/smoke_logs.py` covers the other half, proving collection
+reaches Loki at all.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,7 +25,13 @@ then:
 docker compose up -d --wait
 ```
 
-Open Grafana, go to **Explore**, pick the **Loki** datasource, and query:
+Open Grafana and the **Logs** dashboard, in the same `labmon` folder as
+the overview. It shows log volume by level, the warning and error lines
+themselves, readings skipped per sensor, and an unparsed view of
+everything, with a dropdown to narrow to one container.
+
+For anything the dashboard does not answer, go to **Explore**, pick the
+**Loki** datasource, and query directly:
 
 ```logql
 {container="mock-room-1"}
@@ -81,6 +87,18 @@ Query on the fields in Grafana:
 {container=~".+"} | logfmt | level="warning"
 {container=~".+"} | logfmt | sensor_id="cryo-77k"
 ```
+
+**Severities are not spelled the same across the stack.** Python's logging
+module produces `warning` and `critical`; the Go services — Grafana, Loki
+and Alloy — produce `warn` and `fatal`. Since every container is collected
+into the same place, a filter naming one spelling silently drops the other
+half, which reads as a quiet stack rather than a missed filter. Match both:
+
+```logql
+{container=~".+"} | logfmt | level=~"warn|warning"
+```
+
+The Logs dashboard's panels already do.
 
 ### What is logged, and at what level
 

--- a/grafana/dashboards/logs.json
+++ b/grafana/dashboards/logs.json
@@ -1,0 +1,382 @@
+{
+  "uid": "labmon-logs",
+  "title": "Logs",
+  "description": "Container output collected by Alloy and stored in Loki. Needs the `logs` profile; see docs/logging.md.",
+  "tags": [
+    "labmon",
+    "logs"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 42,
+  "version": 1,
+  "editable": true,
+  "graphTooltip": 0,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "templating": {
+    "list": [
+      {
+        "name": "container",
+        "label": "Container",
+        "type": "query",
+        "datasource": {
+          "type": "loki",
+          "uid": "loki"
+        },
+        "query": "label_values(container)",
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".+",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Log volume by level",
+      "description": "Lines per interval, split by severity. A step change here is the fastest way to see that something started going wrong without knowing yet what it was.",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "short",
+          "displayName": "${__field.labels.level}"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "range",
+          "expr": "sum by (level) (count_over_time({container=~\"$container\"} | logfmt [$__auto]))"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Warnings",
+      "description": "Warning lines in the selected window, counting both spellings: Python logs `warning`, Go services log `warn`.",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "instant",
+          "expr": "sum(count_over_time({container=~\"$container\"} | logfmt | level=~\"warn|warning\" [$__range]))"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Errors",
+      "description": "Error lines in the selected window, including Python's `critical` and Go's `fatal`.",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "instant",
+          "expr": "sum(count_over_time({container=~\"$container\"} | logfmt | level=~\"error|critical|fatal\" [$__range]))"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "logs",
+      "title": "Warnings and errors",
+      "description": "The lines worth reading first. Sensors log one warning per problem rather than one per reading, so this stays short even when something is failing continuously.",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "range",
+          "expr": "{container=~\"$container\"} | logfmt | level=~\"warn|warning|error|critical|fatal\""
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Readings skipped, by sensor",
+      "description": "From the periodic summary each sensor emits. A sensor reporting skips is producing readings that cannot be written \u2014 a conversion returning nan or inf \u2014 which looks identical to a dead sensor on the overview dashboard.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short",
+          "decimals": 0,
+          "displayName": "${__field.labels.sensor_id}"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "range",
+          "expr": "sum by (sensor_id) (sum_over_time({container=~\"$container\"} | logfmt | msg=\"wrote readings\" | unwrap skipped [$__auto]))"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "logs",
+      "title": "Everything",
+      "description": "Unparsed, so containers that do not emit logfmt \u2014 InfluxDB, Grafana, Loki itself \u2014 are readable here too. Often the answer to why a sensor stopped is in another container's output.",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "queryType": "range",
+          "expr": "{container=~\"$container\"}"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,16 +1,22 @@
-"""Structural checks on the provisioned Grafana dashboard.
+"""Structural checks on every provisioned Grafana dashboard.
 
-`grafana/dashboards/lab-overview.json` is a thousand lines of hand-edited
-JSON that Grafana loads at boot. Grafana is forgiving with it in the worst
-way: a panel whose query landed under the wrong key, or that points at a
-datasource uid nobody provisioned, renders "No data" and logs nothing. The
-dashboard looks fine until someone reads a number that isn't there.
+`grafana/dashboards/` holds hand-edited JSON that Grafana loads at boot.
+Grafana is forgiving with it in the worst way: a panel whose query landed
+under the wrong key, or that points at a datasource uid nobody provisioned,
+renders "No data" and logs nothing. The dashboard looks fine until someone
+reads a number that isn't there.
 
-None of this validates the dashboard against Grafana's schema — there is no
+Every check runs against every dashboard in that directory, so adding one
+needs no change here. That generality is the point: the suite was written
+around `lab-overview.json` by name, and a second dashboard on a different
+datasource could not be added without first teaching it that a dashboard is
+not necessarily an InfluxDB dashboard.
+
+None of this validates the dashboards against Grafana's schema — there is no
 published schema to validate against — and none of it runs the queries, so a
 `rawSql` naming a column that does not exist passes every check here;
 catching that needs a live stack. Each check below stands for a mistake that
-has actually been made in this file.
+has actually been made in one of these files.
 """
 
 import json
@@ -21,9 +27,17 @@ from typing import cast
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_DASHBOARD = _REPO_ROOT / "grafana" / "dashboards" / "lab-overview.json"
-_DATASOURCE = _REPO_ROOT / "grafana" / "provisioning" / "datasources" / "influxdb3.yaml"
+_DASHBOARD_DIR = _REPO_ROOT / "grafana" / "dashboards"
+_DATASOURCE_DIR = _REPO_ROOT / "grafana" / "provisioning" / "datasources"
 _ENV_EXAMPLE = _REPO_ROOT / ".env.example"
+
+# The key each datasource type reads its query from. A query written under
+# any other name is accepted by the JSON, sent to the backend empty, and
+# comes back as an error the panel never shows — which is the single
+# mistake this file exists to catch, and it is spelled differently per
+# backend. A type missing from here fails the check rather than skipping
+# it, so adding a datasource cannot silently disable the check for it.
+_QUERY_FIELD = {"influxdb": "rawSql", "loki": "expr"}
 
 # `$channel`, `${channel}`, and Grafana's own `$__timeFrom()` macros, which
 # are built in rather than declared by the dashboard.
@@ -50,15 +64,69 @@ def _mappings(value: object) -> list[dict[str, object]]:
     return [_mapping(item) for item in cast(list[object], value)]
 
 
-@pytest.fixture(scope="module")
-def dashboard() -> dict[str, object]:
-    """The dashboard as Grafana will parse it.
+def _dashboard_paths() -> list[Path]:
+    """Every dashboard Grafana will provision, in a stable order."""
+    return sorted(_DASHBOARD_DIR.glob("*.json"))
+
+
+def _provisioned_datasources() -> dict[str, str]:
+    """uid to type, read from every datasource provisioning file.
+
+    Parsed with a regex rather than a YAML library. This is still the only
+    YAML the test suite reads, and the alternative is a dependency carried
+    solely to look up two keys per entry.
+
+    The regex pins `type:` to the indentation of its own entry's `uid:`,
+    so a `type` nested under `jsonData` cannot be mistaken for the
+    datasource's own — which a looser pattern would do the moment someone
+    provisions a datasource whose options happen to include one.
+    """
+    found: dict[str, str] = {}
+    for path in sorted(_DATASOURCE_DIR.glob("*.y*ml")):
+        text = path.read_text(encoding="utf-8")
+        # Split on the list marker so each uid pairs with the type from its
+        # own entry rather than a neighbour's.
+        entries = re.split(r"^\s*-\s+(?=name:)", text, flags=re.MULTILINE)[1:]
+        assert entries, f"no datasource entries found in {path.name}"
+        for entry in entries:
+            uid = re.search(
+                r"^(?P<indent>[ ]*)uid:\s*(?P<uid>\S+)\s*$", entry, re.MULTILINE
+            )
+            assert uid is not None, f"a datasource in {path.name} declares no `uid:`"
+            kind = re.search(
+                rf"^{uid.group('indent')}type:\s*(\S+)\s*$", entry, re.MULTILINE
+            )
+            assert kind is not None, (
+                f"datasource {uid.group('uid')!r} in {path.name} declares no `type:`"
+            )
+            found[uid.group("uid")] = kind.group(1)
+    return found
+
+
+def test_at_least_one_dashboard_is_provisioned() -> None:
+    """Guards the glob itself.
+
+    Every other check is parametrised over the dashboards it finds, so a
+    directory rename would turn this whole module green by collecting
+    nothing at all.
+    """
+    assert _dashboard_paths(), f"no dashboards found in {_DASHBOARD_DIR}"
+
+
+def _dashboard_id(path: Path) -> str:
+    """Names each parametrised run after its file, so a failure says which."""
+    return path.stem
+
+
+@pytest.fixture(scope="module", params=_dashboard_paths(), ids=_dashboard_id)
+def dashboard(request: pytest.FixtureRequest) -> dict[str, object]:
+    """One dashboard as Grafana will parse it, once per file.
 
     Doubles as the "it is still valid JSON" check: every test in this module
     depends on this fixture, so a syntax error fails all of them at once
     rather than surfacing as a confusing assertion elsewhere.
     """
-    return _mapping(_parse(_DASHBOARD))
+    return _mapping(_parse(cast(Path, request.param)))
 
 
 @pytest.fixture(scope="module")
@@ -93,18 +161,27 @@ def test_query_panels_declare_at_least_one_target(
         )
 
 
-def test_every_target_carries_a_non_empty_raw_sql(
+def test_every_target_carries_a_non_empty_query(
     targets: list[tuple[str, dict[str, object]]],
 ) -> None:
-    """The InfluxDB datasource in SQL mode reads `rawSql` and only `rawSql`.
+    """Each backend reads its query from one key and ignores the rest.
 
-    A query written under `query` instead is accepted by the JSON, sent to
-    the backend empty, and comes back as a 400 the panel never shows.
+    InfluxDB in SQL mode reads `rawSql`; Loki reads `expr`. A query written
+    under any other name is accepted by the JSON, sent to the backend
+    empty, and comes back as an error the panel never shows.
     """
     for title, target in targets:
-        raw_sql = target.get("rawSql")
-        assert isinstance(raw_sql, str) and raw_sql.strip(), (
-            f"{title!r} target {target.get('refId')!r} has no rawSql"
+        datasource = _mapping(target.get("datasource", {}))
+        kind = str(datasource.get("type"))
+        field = _QUERY_FIELD.get(kind)
+        assert field is not None, (
+            f"{title!r} targets a {kind!r} datasource, which this suite does "
+            f"not know the query field for; add it to _QUERY_FIELD "
+            f"(known: {sorted(_QUERY_FIELD)})"
+        )
+        query = target.get(field)
+        assert isinstance(query, str) and query.strip(), (
+            f"{title!r} target {target.get('refId')!r} has no {field}"
         )
 
 
@@ -124,30 +201,67 @@ def test_no_target_keeps_a_duplicate_query_field(
         )
 
 
-def test_targets_point_at_the_provisioned_datasource(
+def test_targets_point_at_a_provisioned_datasource(
     targets: list[tuple[str, dict[str, object]]],
 ) -> None:
-    """A uid nobody provisioned fails at render time, not at load time.
+    """A uid nobody provisions fails at render time, not at load time.
 
-    The uid is pulled out of the provisioning file with a regex rather than
-    a YAML parser: this is the only YAML the test suite reads, and one
-    `uid:` line does not justify a dependency.
+    Any provisioned datasource will do — a dashboard is not required to be
+    an InfluxDB one — but the reference has to resolve, and its declared
+    `type` has to be the type that uid actually provisions. A panel
+    claiming `influxdb` against Loki's uid renders empty just as reliably
+    as one naming a uid that does not exist.
     """
-    provisioned = re.search(
-        r"^\s*uid:\s*(\S+)\s*$", _DATASOURCE.read_text(encoding="utf-8"), re.MULTILINE
-    )
-    assert provisioned is not None, f"no `uid:` found in {_DATASOURCE.name}"
+    provisioned = _provisioned_datasources()
 
     for title, target in targets:
         # A target may legitimately omit `datasource` and inherit the panel's,
         # so report the absence as a mismatch rather than dying on a KeyError.
         datasource = _mapping(target.get("datasource", {}))
-        assert datasource.get("uid") == provisioned.group(1), (
-            f"{title!r} points at datasource uid {datasource.get('uid')!r}, "
-            f"but {_DATASOURCE.name} provisions {provisioned.group(1)!r}"
+        uid = datasource.get("uid")
+        assert uid in provisioned, (
+            f"{title!r} points at datasource uid {uid!r}, which nothing in "
+            f"{_DATASOURCE_DIR.name}/ provisions (it provisions "
+            f"{sorted(provisioned)})"
         )
-        assert datasource.get("type") == "influxdb", (
-            f"{title!r} points at a {datasource.get('type')!r} datasource"
+        assert datasource.get("type") == provisioned[str(uid)], (
+            f"{title!r} calls uid {uid!r} a {datasource.get('type')!r} "
+            f"datasource, but it is provisioned as {provisioned[str(uid)]!r}"
+        )
+
+
+def test_every_datasource_a_dashboard_names_has_a_provisioning_file(
+    dashboard: dict[str, object], panels: list[dict[str, object]]
+) -> None:
+    """Catches a dashboard that ships without the file that makes it render.
+
+    Broader than the target check above: panels and template variables
+    carry their own `datasource` blocks, and a variable pointing at a uid
+    nobody provisions yields an empty dropdown, which then interpolates
+    into every query on the dashboard.
+
+    This matters most for the optional parts of the stack. Loki is only
+    started under the `logs` profile, so a logs dashboard is exactly the
+    kind of thing that could be committed while the datasource file that
+    backs it is still sitting unstaged.
+    """
+    provisioned = _provisioned_datasources()
+    variables = _mappings(_mapping(dashboard["templating"])["list"])
+
+    named: list[tuple[str, object]] = []
+    for panel in panels:
+        if "datasource" in panel:
+            named.append((f"panel {panel.get('title')!r}", panel["datasource"]))
+    for variable in variables:
+        if "datasource" in variable:
+            named.append((f"variable {variable.get('name')!r}", variable["datasource"]))
+
+    for where, reference in named:
+        uid = _mapping(reference).get("uid")
+        assert uid in provisioned, (
+            f"{where} names datasource uid {uid!r}, which nothing in "
+            f"{_DATASOURCE_DIR.name}/ provisions (it provisions "
+            f"{sorted(provisioned)})"
         )
 
 
@@ -174,9 +288,15 @@ def test_every_referenced_variable_is_declared(
     for panel in panels:
         # `row` and `text` panels carry no targets at all, hence the default.
         panel_targets = _mappings(panel.get("targets", []))
+        # Every backend's query key, not just InfluxDB's: a `$sensor` that
+        # interpolates to nothing does so in LogQL exactly as it does in SQL.
         text = " ".join(
             [str(panel.get("title", ""))]
-            + [str(target.get("rawSql", "")) for target in panel_targets]
+            + [
+                str(target.get(field, ""))
+                for target in panel_targets
+                for field in _QUERY_FIELD.values()
+            ]
         )
         names = cast(list[str], _VARIABLE_REFERENCE.findall(text))
         referenced = {name for name in names if not name.startswith(_BUILTIN_PREFIX)}


### PR DESCRIPTION
Closes #45.

The `logs` profile provisioned the Loki datasource, so logs were reachable through Explore but there was no dashboard for them. A Loki panel could not simply join `lab-overview.json` — that dashboard loads for everyone, and a panel on a datasource which only has a service behind it under the `logs` profile shows an error for anyone running metrics only.

## The test generalisation

This was the substance of the issue; the dashboard itself was the easy half. `tests/test_dashboard.py` named `lab-overview.json` directly and asserted every target pointed at InfluxDB, which a Loki dashboard fails by construction.

Per the decision on #45:

1. **Iterates `grafana/dashboards/*.json`** via a parametrised fixture. Every existing check inherited the parametrisation with no signature change, and test ids are the filenames, so a failure names the dashboard. Adding a dashboard needs no change to the test file.
2. **The datasource check accepts any provisioned datasource** — and additionally requires the declared `type` to match the type that uid is *provisioned as*. A panel calling Loki's uid an `influxdb` datasource renders empty just as reliably as a uid nobody provisions.
3. **A new check that every datasource a dashboard names has a provisioning file**, covering panels, targets *and* template variables. A variable on a dead uid yields an empty dropdown which then interpolates into every query on the page.

Two more that the issue did not anticipate, both consequences of a Loki dashboard being genuinely different:

- **The `rawSql` check was InfluxDB-specific by construction.** Loki reads `expr`. The check now selects the key from the target's own datasource type via a `_QUERY_FIELD` map, and a type absent from that map **fails** rather than skipping — so the check cannot be silently disabled by using a backend nobody taught it about.
- **The `$variable` scan read only `rawSql`**, leaving an undeclared variable in LogQL invisible. It now reads every backend's query key.

There is also a guard test that the glob finds anything at all, since a directory rename would otherwise turn the whole module green by collecting nothing.

## The dashboard

`grafana/dashboards/logs.json`, uid `labmon-logs`, six panels: log volume by level, warning and error counts for the window, the warning and error lines themselves, readings skipped per sensor (from the periodic summary `#99` added), and an unparsed view of every container. One `container` dropdown driven by `label_values(container)`.

## Verification

Ten mutations applied to the dashboard, each one a mistake a check claims to catch — unprovisioned uid, type disagreeing with provisioning, LogQL under `rawSql`, blank `expr`, unknown datasource type, variable and panel on dead uids, undeclared `$var` in LogQL, data panel with no targets, duplicate panel ids. **10/10 caught.**

Every panel's LogQL was then run through Grafana's Loki proxy against a live `demo,logs` stack. All six return data.

That live run found a real bug in the first draft: **severities are not spelled alike across the stack.** Python's logging module produces `warning` and `critical`; the Go services — Grafana, Loki, Alloy — produce `warn` and `fatal`. The panels originally matched `level="warning"` and so silently hid every warning the other half of the stack produced. Fixed to match both; the "Warnings and errors" panel went from 3 to 24 streams. `docs/logging.md` now records the trap, since it applies to any LogQL written against this stack.

## Known gap

Nothing runs this LogQL in CI. `scripts/smoke_dashboard.py` speaks SQL and reads `rawSql` from `lab-overview.json` alone, so these panels are checked for shape by the unit tests and for meaning by nothing. Stated plainly in `docs/grafana.md` rather than left implicit; worth its own issue.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 272 passed, 100%
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` — clean
- [x] mutation test — 10/10 caught
- [x] every panel query returns data against a live `demo,logs` stack
- [x] Grafana provisions both dashboards with no error in its log
