### PR TITLE
feat: terminate TLS at a reverse proxy with an internal CA

### DIFF
--- a/.env.client.example
+++ b/.env.client.example
@@ -13,3 +13,13 @@ INFLUXDB_DATABASE=lab
 # The same INFLUXDB3_AUTH_TOKEN the server was set up with — copy it out
 # of band (e.g. scp), never commit it. See docs/deployment.md.
 INFLUXDB3_AUTH_TOKEN=
+
+# Only when the server runs the `tls` profile. Point INFLUXDB_HOST at the
+# proxy's port instead (https://192.168.1.50:8443) and set this to the CA
+# certificate copied from the server, which `scripts/export-ca.sh`
+# produces there. The certificate is public — it is the private key
+# behind it that stays on the server — but a substituted one is exactly
+# what an interceptor would need, so copy it by a route you trust.
+#
+# Leave both unset to keep talking plain HTTP.
+#INFLUXDB_TLS_CA=/etc/labmon/labmon-ca.crt

--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,31 @@ LOKI_RETENTION_PERIOD=
 # needs no network at boot, at the cost of that one panel not rendering.
 GRAFANA_PLUGINS=briangann-gauge-panel@2.2.0
 
+# Where the TLS proxy answers, when the "tls" profile is active — one
+# list per port, since a site address is written out whole and cannot be
+# built from a host and a port separately. Each entry becomes an address
+# Caddy issues a certificate for, so list every name and IP clients use
+# to reach the server. Separate them with a comma AND a space, and quote
+# the value: Caddy rejects a bare comma, and the quotes keep the line
+# readable by a shell sourcing this file. Blank means loopback only,
+# which is enough for a stack reached from the machine running it.
+# For example, an InfluxDB list reachable both ways:
+#     "https://192.0.2.10:8443, https://lab-server:8443"
+LABMON_TLS_INFLUXDB_SITES=
+LABMON_TLS_GRAFANA_SITES=
+
+# Which address to serve when a client sends no SNI (default: 127.0.0.1),
+# which is what addressing the server by IP does. Set it to the server's
+# LAN IP on a real deployment, or those clients fail the handshake before
+# they send a request.
+LABMON_TLS_DEFAULT_SNI=
+
+# The CA certificate to verify the server against, for a host-side `uv
+# run mock-sensor` talking to a stack behind the "tls" profile. Point it
+# at the file `./scripts/export-ca.sh` writes. Leave it blank/unset when
+# talking to a plain-HTTP stack — see docs/client-setup.md.
+INFLUXDB_TLS_CA=
+
 # INFLUXDB_HOST is intentionally not configured here: containers need the
 # Docker network hostname (http://influxdb:8181), while a host-side `uv run
 # mock-sensor` needs http://localhost:8181 (already the code default). One

--- a/.env.example
+++ b/.env.example
@@ -57,12 +57,6 @@ LABMON_TLS_GRAFANA_SITES=
 # they send a request.
 LABMON_TLS_DEFAULT_SNI=
 
-# The CA certificate to verify the server against, for a host-side `uv
-# run mock-sensor` talking to a stack behind the "tls" profile. Point it
-# at the file `./scripts/export-ca.sh` writes. Leave it blank/unset when
-# talking to a plain-HTTP stack — see docs/client-setup.md.
-INFLUXDB_TLS_CA=
-
 # INFLUXDB_HOST is intentionally not configured here: containers need the
 # Docker network hostname (http://influxdb:8181), while a host-side `uv run
 # mock-sensor` needs http://localhost:8181 (already the code default). One

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -131,6 +131,41 @@ jobs:
             exit 1
           fi
 
+      # The write and the query take different routes through the proxy:
+      # HTTP for one, Flight SQL over cleartext HTTP/2 for the other, and
+      # only the query depends on `versions h2c 2`. Reading the rows back
+      # with `docker compose exec influxdb` would not touch the proxy at
+      # all, so dropping that one line would leave CI green while every
+      # client query returned 404 — the exact half-working state the
+      # setting exists to prevent.
+      - name: A client queries back through the proxy
+        run: |
+          token="$(grep '^INFLUXDB3_AUTH_TOKEN=' .env | cut -d= -f2-)"
+          network="$(docker inspect influxdb \
+            --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')"
+          docker run --rm -i --network "$network" \
+            --entrypoint python \
+            -v "$PWD/labmon-ca.crt:/ca.crt:ro" \
+            -e INFLUXDB_HOST=https://caddy:8443 \
+            -e INFLUXDB_TLS_CA=/ca.crt \
+            -e INFLUXDB_DATABASE=lab \
+            -e INFLUXDB3_AUTH_TOKEN="$token" \
+            labmon:latest - <<'PY'
+          from labmon.influx import get_client
+
+          rows = (
+              get_client()
+              .query(
+                  "SELECT count(*) AS n FROM temperature"
+                  " WHERE sensor_id = \x27tls-smoke\x27"
+              )
+              .to_pylist()
+          )
+          print(f"Flight SQL through the proxy returned: {rows}")
+          if not rows or rows[0]["n"] < 1:
+              raise SystemExit("the query path through the proxy sees no rows")
+          PY
+
       # Grafana through the proxy is the viewer's route, so both suites run
       # again against it. Cheap — the stack is already up and warm.
       - name: Dashboards and logs work through the proxy

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -111,6 +111,10 @@ jobs:
           # --entrypoint, because the image's own is `mock-sensor`: without
           # it `timeout` and its arguments are appended to the sensor's
           # command line instead of wrapping it.
+          # --preserve-status reports the sensor's own fate rather than
+          # timeout's, so a crash on the TLS path reads differently in the
+          # log from the SIGTERM that ends a healthy run.
+          status=0
           docker run --rm --network "$network" \
             --entrypoint timeout \
             -v "$PWD/labmon-ca.crt:/ca.crt:ro" \
@@ -119,8 +123,14 @@ jobs:
             -e INFLUXDB_DATABASE=lab \
             -e INFLUXDB3_AUTH_TOKEN="$token" \
             labmon:latest \
-            12 mock-sensor --sensor-id tls-smoke --measurement temperature \
-              --interval 1 || true
+            --preserve-status 12 mock-sensor --sensor-id tls-smoke \
+              --measurement temperature --interval 1 || status=$?
+          # 0 if it handled the signal, 143 if it took SIGTERM as it was.
+          case "$status" in
+            0|143) echo "sensor ended on the timeout (status $status)" ;;
+            *) echo "sensor died on the TLS path (status $status)" >&2
+               exit 1 ;;
+          esac
           rows="$(docker compose exec -T influxdb influxdb3 query --database lab \
             --token "$token" \
             "SELECT count(*) AS n FROM temperature WHERE sensor_id = 'tls-smoke'" \

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -67,12 +67,85 @@ jobs:
       - name: Every container's logs reach Loki
         run: python3 scripts/smoke_logs.py --timeout 120
 
+      # Same trick again: the proxy joins the running stack rather than
+      # starting a second one. The site lists name `caddy` as well as
+      # loopback, so a container on the compose network can reach it under
+      # a name the certificate actually covers.
+      - name: Start the TLS proxy
+        run: |
+          {
+            printf 'LABMON_TLS_INFLUXDB_SITES="https://127.0.0.1:8443, https://caddy:8443"\n'
+            printf 'LABMON_TLS_GRAFANA_SITES="https://127.0.0.1:3443, https://caddy:3443"\n'
+          } >> .env
+          COMPOSE_PROFILES=demo,logs,tls docker compose up -d --wait caddy
+
+      - name: Export the CA the way an operator would
+        run: ./scripts/export-ca.sh labmon-ca.crt
+
+      # Both ports must reject a client that does not trust the CA, and
+      # accept one that does. The negative half matters most: without it a
+      # proxy serving no TLS at all would pass.
+      - name: Both TLS ports verify against the exported CA
+        run: |
+          for port in 8443 3443; do
+            if curl -sS -o /dev/null "https://127.0.0.1:$port/" 2>/dev/null; then
+              echo "port $port accepted a client with no CA — TLS is not enforced" >&2
+              exit 1
+            fi
+            code="$(curl -sS --cacert labmon-ca.crt -o /dev/null \
+              -w '%{http_code}' "https://127.0.0.1:$port/")"
+            echo "port $port with the CA: HTTP $code"
+            case "$code" in
+              000) echo "port $port unreachable even with the CA" >&2; exit 1 ;;
+            esac
+          done
+
+      # The whole point of the exercise: the exact path a real client
+      # takes. Runs the shipped image so the package under test does the
+      # writing, rather than a curl that only proves the proxy is up.
+      - name: A sensor writes through the proxy
+        run: |
+          token="$(grep '^INFLUXDB3_AUTH_TOKEN=' .env | cut -d= -f2-)"
+          network="$(docker inspect influxdb \
+            --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')"
+          # --entrypoint, because the image's own is `mock-sensor`: without
+          # it `timeout` and its arguments are appended to the sensor's
+          # command line instead of wrapping it.
+          docker run --rm --network "$network" \
+            --entrypoint timeout \
+            -v "$PWD/labmon-ca.crt:/ca.crt:ro" \
+            -e INFLUXDB_HOST=https://caddy:8443 \
+            -e INFLUXDB_TLS_CA=/ca.crt \
+            -e INFLUXDB_DATABASE=lab \
+            -e INFLUXDB3_AUTH_TOKEN="$token" \
+            labmon:latest \
+            12 mock-sensor --sensor-id tls-smoke --measurement temperature \
+              --interval 1 || true
+          rows="$(docker compose exec -T influxdb influxdb3 query --database lab \
+            --token "$token" \
+            "SELECT count(*) AS n FROM temperature WHERE sensor_id = 'tls-smoke'" \
+            | grep -oE '[0-9]+' | tail -1)"
+          echo "rows written through TLS: ${rows:-0}"
+          if [ "${rows:-0}" -lt 1 ]; then
+            echo "no rows arrived through the proxy" >&2
+            exit 1
+          fi
+
+      # Grafana through the proxy is the viewer's route, so both suites run
+      # again against it. Cheap — the stack is already up and warm.
+      - name: Dashboards and logs work through the proxy
+        run: |
+          python3 scripts/smoke_dashboard.py --timeout 120 \
+            --url https://127.0.0.1:3443 --cacert labmon-ca.crt
+          python3 scripts/smoke_logs.py --timeout 120 \
+            --url https://127.0.0.1:3443 --cacert labmon-ca.crt
+
       - name: Logs
         if: failure()
-        run: COMPOSE_PROFILES=demo,logs docker compose logs --no-color --tail 200
+        run: COMPOSE_PROFILES=demo,logs,tls docker compose logs --no-color --tail 200
 
       # The profile is needed to stop its services as well as to start
       # them; without it Loki and Alloy are left running.
       - name: Stop
         if: always()
-        run: COMPOSE_PROFILES=demo,logs docker compose down -v
+        run: COMPOSE_PROFILES=demo,logs,tls docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ coverage.xml
 # Personal experimentation (marimo notebooks, not part of the package)
 __marimo__/
 /test.py
+
+# The CA certificate `scripts/export-ca.sh` copies out of the stack. It
+# is public, not secret, but it is per-deployment, so it does not belong
+# in the repository.
+labmon-ca.crt

--- a/README.md
+++ b/README.md
@@ -224,10 +224,11 @@ A client can be a Docker container or a plain Python install — both are
 documented, and a board can equally well be plugged straight into the
 server, in which case there is no client machine at all.
 
-Traffic is plain HTTP today, deliberately: it assumes a trusted lab
-network, and the reasoning (plus what changes if that stops being true)
-is written down in
-[`docs/deployment.md`](docs/deployment.md#security-plain-http-by-design-for-now).
+Traffic is plain HTTP by default, deliberately: it assumes a trusted lab
+network. Where that assumption does not hold, the `tls` profile puts a
+reverse proxy with its own CA in front of InfluxDB and Grafana, without
+disturbing the clients that have not moved yet — see
+[`docs/deployment.md`](docs/deployment.md#encrypting-client-and-viewer-traffic).
 
 ## How it works
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,6 +9,11 @@
 # still reaches Loki, over plain HTTP inside the compose network — one
 # Docker bridge on one host, where encryption buys nothing and would mean
 # distributing trust to every service as well as to every client.
+#
+# The two site-address lists are separate variables rather than one list of
+# hosts because a Caddyfile cannot build an address from a host and a port:
+# the site address is written out whole. Both should name the same hosts.
+# Separate them with a comma AND a space — Caddy rejects a bare comma.
 
 {
 	# Nothing here should be redirected to port 443: the plain ports stay
@@ -24,10 +29,7 @@
 	default_sni {$LABMON_TLS_DEFAULT_SNI}
 }
 
-# The addresses clients and viewers use. Both are listed so one deployment
-# can be reached by IP and by a hosts-file name, and Caddy issues for each.
-# `LABMON_TLS_HOSTS` is a comma-separated list; see docs/deployment.md.
-{$LABMON_TLS_HOSTS}:8443 {
+{$LABMON_TLS_INFLUXDB_SITES} {
 	tls internal
 
 	# InfluxDB 3 serves the HTTP write API *and* Flight SQL on one port.
@@ -42,7 +44,7 @@
 	}
 }
 
-{$LABMON_TLS_HOSTS}:3443 {
+{$LABMON_TLS_GRAFANA_SITES} {
 	tls internal
 	reverse_proxy grafana:3000
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,48 @@
+# TLS termination for the lab LAN, under the `tls` profile.
+#
+# The stack has no public DNS name, so ACME is not an option (see #66) and
+# certificates come from Caddy's own embedded CA instead. Clients trust one
+# long-lived root, copied out of band exactly once; the leaves it signs
+# rotate on their own and clients never see the change.
+#
+# Only the boundary is encrypted. Grafana still reaches InfluxDB, and Alloy
+# still reaches Loki, over plain HTTP inside the compose network — one
+# Docker bridge on one host, where encryption buys nothing and would mean
+# distributing trust to every service as well as to every client.
+
+{
+	# Nothing here should be redirected to port 443: the plain ports stay
+	# reachable during the transition, and a redirect to a port that is
+	# not published just looks like the server is broken.
+	auto_https disable_redirects
+
+	# A client that addresses the server by IP sends no SNI, so Caddy has
+	# no name to route the connection on. Without this it aborts the
+	# handshake with an internal-error alert — and addressing the server by
+	# LAN IP is the normal case here, since there is no DNS to rely on.
+	# Names the certificate to serve when SNI is absent.
+	default_sni {$LABMON_TLS_DEFAULT_SNI}
+}
+
+# The addresses clients and viewers use. Both are listed so one deployment
+# can be reached by IP and by a hosts-file name, and Caddy issues for each.
+# `LABMON_TLS_HOSTS` is a comma-separated list; see docs/deployment.md.
+{$LABMON_TLS_HOSTS}:8443 {
+	tls internal
+
+	# InfluxDB 3 serves the HTTP write API *and* Flight SQL on one port.
+	# Flight SQL is gRPC, which is HTTP/2 — and cleartext HTTP/2 (h2c) on
+	# the inside, since the backend has no TLS. Without this the proxy
+	# downgrades to HTTP/1.1 and every Flight call comes back 404, so
+	# writes would work while queries silently did not.
+	reverse_proxy influxdb:8181 {
+		transport http {
+			versions h2c 2
+		}
+	}
+}
+
+{$LABMON_TLS_HOSTS}:3443 {
+	tls internal
+	reverse_proxy grafana:3000
+}

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -14,7 +14,6 @@
 # hosts because a Caddyfile cannot build an address from a host and a port:
 # the site address is written out whole. Both should name the same hosts.
 # Separate them with a comma AND a space — Caddy rejects a bare comma.
-
 {
 	# Nothing here should be redirected to port 443: the plain ports stay
 	# reachable during the transition, and a redirect to a port that is

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -30,6 +30,21 @@ x-labmon-sensor: &labmon-sensor
     - INFLUXDB_HOST=${INFLUXDB_HOST}
     - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}
     - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
+    # Only when the server runs the `tls` profile — see
+    # docs/client-setup.md. Empty reads the same as unset here, so
+    # leaving it out of .env keeps the client on plain HTTP.
+    - INFLUXDB_TLS_CA=${INFLUXDB_TLS_CA:-}
+  # The certificate has to exist inside the container as well, at the
+  # path the variable names — mounting it there means one value serves a
+  # bare install and a container alike. Uncomment alongside the variable:
+  # left in place, a bind mount of a file that is not there would have
+  # Docker silently create a directory where the certificate should be.
+  #
+  # A service that declares its own `volumes:` replaces this list rather
+  # than adding to it, so `serial-sensor` below carries its own copy of
+  # the line.
+  # volumes:
+  #   - ${INFLUXDB_TLS_CA}:${INFLUXDB_TLS_CA}:ro
 
 services:
   sensor-1:
@@ -64,6 +79,8 @@ services:
   #     - /dev/labmon-due:/dev/labmon-due
   #   volumes:
   #     - ./calibration.toml:/app/calibration.toml:ro
+  #     # Only with the tls profile, as above.
+  #     - ${INFLUXDB_TLS_CA}:${INFLUXDB_TLS_CA}:ro
   #   command:
   #     - --port=/dev/labmon-due
   #     - --calibration=/app/calibration.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,8 +361,62 @@ services:
       - --port=socket://demo-adc-feeder:5555
       - --calibration=/app/demo/calibration.demo.toml
 
+  # TLS termination for the LAN, off unless COMPOSE_PROFILES includes it.
+  # Additive by design: the plain 8181/3000 ports keep working exactly as
+  # before, so a deployment adopts TLS on its own schedule rather than at
+  # upgrade time. See docs/deployment.md.
+  caddy:
+    image: caddy:2.10-alpine
+    container_name: caddy
+    # Comes back after a reboot or a daemon restart, but stays down once
+    # deliberately stopped. This half of the deployment is the always-on
+    # one: without it a power cut leaves the stack down until somebody
+    # notices, while every client fills its queue and then blocks.
+    restart: unless-stopped
+    profiles: [tls]
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    ports:
+      - "8443:8443"
+      - "3443:3443"
+    environment:
+      # The names and addresses the certificate is issued for. Comma
+      # separated, each one becoming a site address Caddy issues for.
+      - LABMON_TLS_HOSTS=${LABMON_TLS_HOSTS:-https://127.0.0.1}
+      # Which of them to serve when a client sends no SNI, which is what
+      # addressing the server by IP does.
+      - LABMON_TLS_DEFAULT_SNI=${LABMON_TLS_DEFAULT_SNI:-127.0.0.1}
+    volumes:
+      - type: bind
+        source: ./caddy/Caddyfile
+        target: /etc/caddy/Caddyfile
+        read_only: true
+      # The CA's private key and certificates. Named rather than bound so
+      # nothing root-owned lands in the repo — but unlike alloy-data this
+      # one must NOT be discarded: losing it means every client that
+      # trusts the old root has to be visited again. `docker compose down
+      # -v` destroys it. See docs/deployment.md.
+      - type: volume
+        source: caddy-data
+        target: /data
+    healthcheck:
+      # Caddy's admin API, on loopback inside the container only. Proves
+      # the process is up and its config loaded; the TLS ports themselves
+      # are proven by the smoke job.
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:2019/config/"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+
 volumes:
   # Alloy's read positions. Named rather than bound so nothing root-owned
   # lands in the repo; `docker compose down -v` resets it, at the cost of
   # re-reading each container's log from the start.
   alloy-data:
+  # Caddy's internal CA: its root key, the intermediate, and every leaf
+  # it has issued. Deliberately outlives container recreation — the root
+  # is what every client was told to trust, so losing it invalidates all
+  # of them at once.
+  caddy-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,9 +381,11 @@ services:
       - "8443:8443"
       - "3443:3443"
     environment:
-      # The names and addresses the certificate is issued for. Comma
-      # separated, each one becoming a site address Caddy issues for.
-      - LABMON_TLS_HOSTS=${LABMON_TLS_HOSTS:-https://127.0.0.1}
+      # The addresses the proxy answers on, one list per port, each
+      # entry becoming a site address Caddy issues a certificate for.
+      # Separated by a comma AND a space; Caddy rejects a bare comma.
+      - LABMON_TLS_INFLUXDB_SITES=${LABMON_TLS_INFLUXDB_SITES:-https://127.0.0.1:8443}
+      - LABMON_TLS_GRAFANA_SITES=${LABMON_TLS_GRAFANA_SITES:-https://127.0.0.1:3443}
       # Which of them to serve when a client sends no SNI, which is what
       # addressing the server by IP does.
       - LABMON_TLS_DEFAULT_SNI=${LABMON_TLS_DEFAULT_SNI:-127.0.0.1}

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -9,6 +9,8 @@ sensor on the client itself, two ways.
 Both need the same three values from the server: `INFLUXDB_HOST` (its LAN
 IP/hostname), `INFLUXDB_DATABASE`, and `INFLUXDB3_AUTH_TOKEN`, copied out
 of band — see [`docs/deployment.md`](deployment.md#distributing-the-auth-token).
+A server running the `tls` profile needs two more, which apply to either
+option below — see [Connecting over TLS](#connecting-over-tls).
 
 Docker or bare install is only a packaging choice; either can run either
 sensor script. The examples below start with `mock-sensor` because it
@@ -63,6 +65,54 @@ sudo systemctl enable --now labmon-sensor.service
 
 Running more than one sensor on this device: copy the unit file under a
 different name (e.g. `labmon-sensor-2.service`) with its own `ExecStart`.
+
+## Connecting over TLS
+
+Only when the server runs the `tls` profile — see
+[`docs/deployment.md`](deployment.md#encrypting-client-and-viewer-traffic)
+for turning it on there. Two things change on this machine, and neither
+depends on which of the two options above it uses.
+
+**Dial the proxy rather than the database**, with an `https://` scheme
+and the proxy's port:
+
+```bash
+INFLUXDB_HOST=https://192.168.1.50:8443
+```
+
+**Trust the server's root certificate.** Copy `labmon-ca.crt` off the
+server the same way the token travels — out of band, by a route that
+reliably delivers the right file — and name where it landed:
+
+```bash
+INFLUXDB_TLS_CA=/etc/labmon/labmon-ca.crt
+```
+
+The server signs its own certificates, and a private root is in no system
+trust store, so without this the sensor refuses to connect rather than
+merely warning. One variable is enough for both directions of traffic:
+the same file is read when writing points and when reading them back. A
+path that does not exist fails at startup with a message naming the
+variable, rather than surfacing later as an apparent problem with the
+server's certificate.
+
+Under Docker the file also has to exist *inside* the container.
+`docker-compose.client.yml` carries a commented-out mount that puts it at
+the same path the variable names, so one value works either way —
+uncomment it along with the variable:
+
+```yaml
+  volumes:
+    - ${INFLUXDB_TLS_CA}:${INFLUXDB_TLS_CA}:ro
+```
+
+A service that declares its own `volumes:` replaces that list rather than
+adding to it, which is why the commented-out `serial-sensor` service
+carries the same line again.
+
+There is no need to move in step with the server. Its 8181 and 3000 stay
+open until its operator closes them, so each client switches over
+whenever it suits.
 
 ## From mock sensor to real hardware
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,10 @@ that does not exist fails at startup rather than at the first write,
 because the TLS layer would otherwise report it as a verification failure
 against the *server*, which reads as a certificate problem rather than as
 a typo in this machine's env file. See
-[`docs/deployment.md`](deployment.md).
+[`docs/client-setup.md`](client-setup.md#connecting-over-tls) for the
+client side and
+[`docs/deployment.md`](deployment.md#encrypting-client-and-viewer-traffic)
+for the server side.
 
 `INFLUXDB_HOST` is set per service in the Compose files rather than in
 `.env`, because one value cannot serve both a container (which needs the
@@ -58,6 +61,9 @@ Only meaningful on the machine running `docker-compose.yml`.
 | `COMPOSE_PROFILES` | *(unset)* | Which optional services start — see below |
 | `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Unset means Grafana needs no network at boot |
 | `LOKI_RETENTION_PERIOD` | `720h` | How long a log line is kept, with the `logs` profile active. Never below `24h` — Loki accepts less and cannot honour it |
+| `LABMON_TLS_INFLUXDB_SITES` | `https://127.0.0.1:8443` | Addresses the proxy answers on for InfluxDB, with the `tls` profile active. Comma-*and-space* separated; each entry a whole `https://host:port` |
+| `LABMON_TLS_GRAFANA_SITES` | `https://127.0.0.1:3443` | The same for Grafana |
+| `LABMON_TLS_DEFAULT_SNI` | `127.0.0.1` | Which certificate to serve when a client sends no server name, which is what dialling a bare IP does |
 
 `COMPOSE_PROFILES` takes a comma-separated list:
 
@@ -66,6 +72,7 @@ Only meaningful on the machine running `docker-compose.yml`.
 | *(unset)* | Nothing — just InfluxDB and Grafana, which is the real-server shape |
 | `demo` | The mock sensors and the simulated board, for a stack with no hardware |
 | `logs` | Loki and Alloy, collecting every container's output |
+| `tls` | A Caddy reverse proxy terminating TLS on 8443 and 3443 — see [`docs/deployment.md`](deployment.md#encrypting-client-and-viewer-traffic) |
 
 The two are independent, so `demo,logs` is valid. A profile is needed to
 *stop* its services as well as start them: `docker compose down` without

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,17 @@ Every sensor needs these, wherever it runs.
 | `INFLUXDB3_AUTH_TOKEN` | *(required)* | InfluxDB API token. No default, and startup fails without it |
 | `INFLUXDB_HOST` | `http://localhost:8181` | Where to write. Containers on the server use `http://influxdb:8181`; a client machine uses the server's address |
 | `INFLUXDB_DATABASE` | `lab` | Database readings are written to |
+| `INFLUXDB_TLS_CA` | *(unset)* | Path to the server's CA certificate, when it runs behind the `tls` profile's proxy. Unset, the client behaves exactly as before |
+
+`INFLUXDB_TLS_CA` is needed only when `INFLUXDB_HOST` is an `https://`
+address served by the stack's own CA, since a private root is in no
+system trust store. One variable covers both directions of traffic — the
+same file is read by the write client and by the query client. A path
+that does not exist fails at startup rather than at the first write,
+because the TLS layer would otherwise report it as a verification failure
+against the *server*, which reads as a certificate problem rather than as
+a typo in this machine's env file. See
+[`docs/deployment.md`](deployment.md).
 
 `INFLUXDB_HOST` is set per service in the Compose files rather than in
 `.env`, because one value cannot serve both a container (which needs the

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,19 +93,108 @@ from the rest of the LAN needs no compose changes, just:
    sudo ufw allow 8181/tcp   # InfluxDB
    sudo ufw allow 3000/tcp   # Grafana
    ```
+   With the `tls` profile on these become 8443 and 3443 — see
+   [Encrypting client and viewer
+   traffic](#encrypting-client-and-viewer-traffic).
 
 Viewers reach Grafana at `http://<server-ip-or-hostname>:3000`; clients
 write to InfluxDB at `http://<server-ip-or-hostname>:8181`.
 
-## Security: plain HTTP, by design (for now)
+## Encrypting client and viewer traffic
 
-This stack talks plain HTTP/gRPC, with no TLS — the same as the local
-demo (see [`docs/grafana.md`](grafana.md)'s note on `insecureGrpc`). On a
-real LAN this means `INFLUXDB3_AUTH_TOKEN` travels unencrypted between
-clients and the server. That's an accepted tradeoff for a trusted lab
-network, not an oversight — TLS (e.g. via a reverse proxy, or InfluxDB's
-own TLS support) is a reasonable future upgrade if the network model ever
-changes, but isn't built here.
+By default the stack talks plain HTTP/gRPC on 8181 and 3000, so
+`INFLUXDB3_AUTH_TOKEN` crosses the LAN in clear text. On a trusted lab
+network that is an accepted tradeoff rather than an oversight, and it
+stays the default.
+
+The `tls` profile removes it. One extra container, a Caddy reverse proxy,
+terminates TLS in front of both services — 8443 for InfluxDB, 3443 for
+Grafana — while the plain ports keep answering exactly as before. Nothing
+about turning it on breaks a client that has not moved yet, so a running
+deployment migrates one machine at a time.
+
+Certificates come from Caddy's own embedded CA rather than from Let's
+Encrypt. A lab server has no public DNS name, so ACME has no way to
+validate it ([#66](https://github.com/quentinmarolleau/labmon/issues/66)
+tracks the case where that changes). Instead the stack signs its own, and
+each client is given one root certificate to trust.
+
+### Turning it on
+
+1. **List the addresses clients use.** A certificate is only valid for the
+   names and addresses it was issued for, so put them in the server's
+   `.env` — one list per port, entries separated by a comma *and* a
+   space:
+
+   ```bash
+   LABMON_TLS_INFLUXDB_SITES="https://192.168.1.50:8443, https://lab-server:8443"
+   LABMON_TLS_GRAFANA_SITES="https://192.168.1.50:3443, https://lab-server:3443"
+   LABMON_TLS_DEFAULT_SNI=192.168.1.50
+   ```
+
+   Set `LABMON_TLS_DEFAULT_SNI` to whichever address clients actually
+   dial. A client connecting to a bare IP sends no server name along with
+   the handshake, leaving the proxy nothing to pick a certificate with —
+   and it then drops the connection, which surfaces as the server being
+   unreachable rather than as a trust problem.
+
+2. **Start the profile and export the root:**
+
+   ```bash
+   COMPOSE_PROFILES=tls docker compose up -d --wait
+   ./scripts/export-ca.sh
+   ```
+
+   Add `tls` to whatever profiles the deployment already uses. The script
+   writes `labmon-ca.crt`. That file is a public certificate, not a
+   secret — the private key stays inside the `caddy-data` volume and
+   never leaves the server — but a *substituted* root is exactly what an
+   interceptor would need, so copy it by a route that reliably delivers
+   the right file.
+
+3. **Point each client at the proxy** and hand it the root — see
+   [`docs/client-setup.md`](client-setup.md#connecting-over-tls).
+
+4. **Send viewers to `https://<server>:3443`.** A browser that has not
+   been given the root treats the site like any other self-signed one and
+   warns before loading it; importing `labmon-ca.crt` into the browser's
+   or the operating system's trust store clears that. Nothing else about
+   Grafana changes.
+
+5. **Move the firewall over.** Open 8443 and 3443; close 8181 and 3000 to
+   the LAN once the last client and viewer has switched.
+
+### What is encrypted, and what is not
+
+The boundary, and only the boundary. Grafana still reaches InfluxDB, and
+Alloy still reaches Loki, over plain HTTP inside the Docker network — one
+bridge on one host, where encryption buys nothing and would mean handing
+trust to every service as well as to every client. That is why
+`insecureGrpc: true` stays in the provisioned datasource with the profile
+on (see [`docs/grafana.md`](grafana.md)).
+
+TLS also does nothing about the token itself. It stops the credential
+being readable in transit; every client still holds an admin credential
+at rest, which is the subject of the next section.
+
+### Certificate lifecycle
+
+Nothing here needs renewing by hand, and nothing needs redistributing
+after the first time:
+
+| | Valid for | Rotated by |
+|---|---|---|
+| Leaf, served to clients | 12 hours | Caddy, automatically |
+| Intermediate | 7 days | Caddy, automatically |
+| Root, distributed to clients | ~10 years | Nothing — it is the anchor |
+
+Clients verify against the root, so the leaf and intermediate churning
+underneath is invisible to them. What matters instead is the `caddy-data`
+volume, which holds the CA's private key. Delete it and Caddy generates a
+fresh root on next start, at which point every client rejects the server
+until it is given the new file. Back it up with the rest of the stack's
+volumes, or accept that losing it means one round of visiting every
+client.
 
 ## One token, and it is an admin token
 
@@ -128,10 +217,9 @@ What follows from that:
 - **Site clients accordingly.** Treat any machine holding the token as
   trusted infrastructure, because it is.
 - **Keep port 8181 off network segments that do not need it.** This is
-  the strongest argument for the reverse proxy in
-  [#52](https://github.com/quentinmarolleau/labmon/issues/52): once
-  clients reach InfluxDB through it, the database's own port need not be
-  reachable at all.
+  the strongest argument for running the `tls` profile: once clients
+  reach InfluxDB through the proxy, the database's own port need not be
+  reachable from the LAN at all.
 - **TLS does not solve this.** It protects the token in transit. Every
   client still holds an admin credential at rest.
 - **Rotate on any suspicion**, using the drill below.

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -43,7 +43,11 @@ and every panel reads empty. See [`docs/logging.md`](logging.md).
 datasource using Grafana's built-in InfluxDB data source in **SQL** mode,
 which talks to InfluxDB 3's Flight SQL (gRPC) interface rather than the
 legacy InfluxQL/Flux modes. Since this stack has no TLS between containers,
-`insecureGrpc: true` tells Grafana not to expect it. The auth token and
+`insecureGrpc: true` tells Grafana not to expect it — and that stays true
+under the `tls` profile, which encrypts the boundary rather than the
+Docker network (see
+[`docs/deployment.md`](deployment.md#what-is-encrypted-and-what-is-not)).
+The auth token and
 database name are injected from the `INFLUXDB3_AUTH_TOKEN` and
 `INFLUXDB_DATABASE` environment variables via provisioning's `${VAR}`
 expansion (confirmed against Grafana's provisioning source — this

--- a/scripts/export-ca.sh
+++ b/scripts/export-ca.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copy the stack's CA root certificate out for distribution to clients.
+#
+# Every client verifies the server against this one file. It is a public
+# certificate, not a secret — the private key stays in the caddy-data
+# volume and never leaves the server — so it can travel by any route that
+# reliably delivers the *right* file. That is the property to protect: a
+# substituted root is what a man-in-the-middle would need.
+#
+# Usage:
+#     ./scripts/export-ca.sh [DESTINATION]
+#
+# Writes ./labmon-ca.crt by default.
+
+set -euo pipefail
+
+DESTINATION="${1:-labmon-ca.crt}"
+
+# Where Caddy's embedded CA keeps the root it signs leaves with. The
+# intermediate beside it is served during the handshake, so clients need
+# only this one.
+ROOT_IN_CONTAINER="/data/caddy/pki/authorities/local/root.crt"
+
+if ! docker compose ps --format '{{.Name}}' | grep -qx caddy; then
+    echo "export-ca: the caddy container is not running." >&2
+    echo "  Start it with COMPOSE_PROFILES=...,tls docker compose up -d" >&2
+    exit 1
+fi
+
+docker compose cp "caddy:${ROOT_IN_CONTAINER}" "$DESTINATION"
+
+# Fail loudly rather than hand over something unusable: a truncated or
+# wrong-format file would only surface later, on a client, as a confusing
+# verification error.
+if ! openssl x509 -in "$DESTINATION" -noout -subject >/dev/null 2>&1; then
+    echo "export-ca: $DESTINATION is not a readable certificate." >&2
+    exit 1
+fi
+
+echo "Wrote $DESTINATION"
+openssl x509 -in "$DESTINATION" -noout -subject -dates
+echo
+echo "Copy it to each client and point INFLUXDB_TLS_CA at it."
+echo "See docs/client-setup.md."

--- a/scripts/export-ca.sh
+++ b/scripts/export-ca.sh
@@ -16,6 +16,20 @@ set -euo pipefail
 
 DESTINATION="${1:-labmon-ca.crt}"
 
+# Resolve the destination against the caller's directory *before* moving,
+# so `../labmon-ca.crt` means what the operator typed rather than
+# something relative to the repository.
+case "$DESTINATION" in
+    /*) ;;
+    *) DESTINATION="$PWD/$DESTINATION" ;;
+esac
+
+# `docker compose` finds the stack by looking for a compose file in the
+# current directory, so run from the repository root. Without this the
+# script works from there and nowhere else, failing with compose's own
+# "no configuration file" rather than with anything said below.
+cd "$(dirname "$0")/.."
+
 # Where Caddy's embedded CA keeps the root it signs leaves with. The
 # intermediate beside it is served during the handshake, so clients need
 # only this one.

--- a/scripts/export-ca.sh
+++ b/scripts/export-ca.sh
@@ -43,6 +43,17 @@ fi
 
 docker compose cp "caddy:${ROOT_IN_CONTAINER}" "$DESTINATION"
 
+# Without openssl there is no way to tell a good export from a truncated
+# one. Say that, rather than reporting a file that is probably fine as
+# unreadable — the check is the optional part here, not the export.
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "Wrote $DESTINATION"
+    echo
+    echo "openssl is not installed, so it could not be checked. Confirm it"
+    echo "looks like a certificate before handing it to a client."
+    exit 0
+fi
+
 # Fail loudly rather than hand over something unusable: a truncated or
 # wrong-format file would only surface later, on a client, as a confusing
 # verification error.

--- a/scripts/smoke_dashboard.py
+++ b/scripts/smoke_dashboard.py
@@ -26,6 +26,7 @@ import base64
 import json
 import os
 import re
+import ssl
 import sys
 import time
 import urllib.error
@@ -36,8 +37,10 @@ from typing import cast
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _DASHBOARD = _REPO_ROOT / "grafana" / "dashboards" / "lab-overview.json"
 
-_GRAFANA_URL = "http://127.0.0.1:3000"
-_QUERY_ENDPOINT = f"{_GRAFANA_URL}/api/ds/query"
+# Where Grafana is by default. `--url` points this at the `tls` profile's
+# proxy instead (https://127.0.0.1:3443), which is the same Grafana reached
+# by the route a viewer actually uses once TLS is on.
+_DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000"
 
 # Grafana blocks an account after five consecutive bad passwords, so retrying
 # one is worse than useless: three minutes of retries would lock the admin out
@@ -106,10 +109,29 @@ def _interpolate(sql: str, variables: dict[str, list[str]]) -> str:
     return _PLAIN_VARIABLE.sub(plain, _FORMATTED_VARIABLE.sub(formatted, sql))
 
 
-def _post(payload: dict[str, object], password: str) -> dict[str, object]:
+def _tls_context(cacert: str | None) -> ssl.SSLContext | None:
+    """A context trusting `cacert`, or None to use the system trust store.
+
+    The stack's own CA signs its certificates, and a private root is in no
+    system store — so without this the proxy is unreachable rather than
+    merely untrusted.
+    """
+    if cacert is None:
+        return None
+    if not Path(cacert).is_file():
+        raise SystemExit(f"--cacert points at {cacert!r}, which is not a file")
+    return ssl.create_default_context(cafile=cacert)
+
+
+def _post(
+    payload: dict[str, object],
+    password: str,
+    endpoint: str,
+    context: ssl.SSLContext | None,
+) -> dict[str, object]:
     credentials = base64.b64encode(f"admin:{password}".encode()).decode()
     request = urllib.request.Request(
-        _QUERY_ENDPOINT,
+        endpoint,
         data=json.dumps(payload).encode(),
         headers={
             "Content-Type": "application/json",
@@ -118,7 +140,8 @@ def _post(payload: dict[str, object], password: str) -> dict[str, object]:
     )
     # urlopen resolves to `Any` here, so both the handle and its read are
     # pinned explicitly rather than letting `Any` leak into the parsing below.
-    with urllib.request.urlopen(request, timeout=30) as response:  # pyright: ignore[reportAny]
+    opened = urllib.request.urlopen(request, timeout=30, context=context)  # pyright: ignore[reportAny]
+    with opened as response:  # pyright: ignore[reportAny]
         body = cast(bytes, response.read())  # pyright: ignore[reportAny]
     return cast(dict[str, object], json.loads(body.decode()))
 
@@ -185,6 +208,8 @@ def _attempt(
     queries: list[tuple[str, dict[str, object]]],
     window: dict[str, str],
     password: str,
+    endpoint: str,
+    context: ssl.SSLContext | None,
 ) -> list[tuple[str, str]]:
     """Run every query once, returning `(panel label, what went wrong)`.
 
@@ -194,7 +219,9 @@ def _attempt(
     failures: list[tuple[str, str]] = []
     for label, query in queries:
         try:
-            response = _post({"queries": [query], **window}, password)
+            response = _post(
+                {"queries": [query], **window}, password, endpoint, context
+            )
         except urllib.error.HTTPError as http_error:
             # The status line alone says nothing useful — a bad column name
             # and a bad token are both "400 Bad Request". The body carries
@@ -252,9 +279,21 @@ def main() -> int:
         default=os.environ.get("GRAFANA_ADMIN_PASSWORD") or "admin",
         help="Grafana admin password; defaults to $GRAFANA_ADMIN_PASSWORD",
     )
+    _ = parser.add_argument(
+        "--url",
+        default=_DEFAULT_GRAFANA_URL,
+        help="Grafana base URL; point at the tls proxy to check that route",
+    )
+    _ = parser.add_argument(
+        "--cacert",
+        default=None,
+        help="CA certificate to verify --url against, for the tls profile",
+    )
     args = parser.parse_args()
     timeout = cast(float, args.timeout)
     password = cast(str, args.password)
+    endpoint = f"{cast(str, args.url).rstrip('/')}/api/ds/query"
+    context = _tls_context(cast("str | None", args.cacert))
 
     # `json.loads` is typed as returning `Any`; nothing here wants that.
     parsed: object = json.loads(_DASHBOARD.read_text("utf-8"))  # pyright: ignore[reportAny]
@@ -269,7 +308,7 @@ def main() -> int:
     while True:
         attempts += 1
         try:
-            failures = _attempt(queries, window, password)
+            failures = _attempt(queries, window, password, endpoint, context)
         except _Rejected as rejected:
             print(f"Grafana rejected the credentials: {rejected}", file=sys.stderr)
             return 1

--- a/scripts/smoke_logs.py
+++ b/scripts/smoke_logs.py
@@ -33,19 +33,21 @@ import argparse
 import base64
 import json
 import os
+import ssl
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import cast
 
-_GRAFANA_URL = "http://127.0.0.1:3000"
+# Where Grafana is by default. `--url` points this at the `tls` profile's
+# proxy instead, which is the route a viewer actually uses once TLS is on.
+_DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000"
 # Grafana proxies to the datasource provisioned under this uid, so the
 # path after it is Loki's own API.
-_LABEL_VALUES = (
-    f"{_GRAFANA_URL}/api/datasources/proxy/uid/loki/loki/api/v1/label/container/values"
-)
+_LABEL_PATH = "/api/datasources/proxy/uid/loki/loki/api/v1/label/container/values"
 
 # Rejecting the credentials will never succeed by waiting, and Grafana
 # blocks an account after five consecutive failures — retrying one would
@@ -97,15 +99,32 @@ def _running_containers() -> set[str]:
     return {name for name in result.stdout.split("\n") if name.strip()}
 
 
-def _collected_containers(password: str) -> set[str]:
+def _tls_context(cacert: str | None) -> ssl.SSLContext | None:
+    """A context trusting `cacert`, or None to use the system trust store.
+
+    The stack's own CA signs its certificates, and a private root is in no
+    system store — so without this the proxy is unreachable rather than
+    merely untrusted.
+    """
+    if cacert is None:
+        return None
+    if not Path(cacert).is_file():
+        raise SystemExit(f"--cacert points at {cacert!r}, which is not a file")
+    return ssl.create_default_context(cafile=cacert)
+
+
+def _collected_containers(
+    password: str, endpoint: str, context: ssl.SSLContext | None
+) -> set[str]:
     """Container names Loki has at least one line for."""
     credentials = base64.b64encode(f"admin:{password}".encode()).decode()
     request = urllib.request.Request(
-        _LABEL_VALUES, headers={"Authorization": f"Basic {credentials}"}
+        endpoint, headers={"Authorization": f"Basic {credentials}"}
     )
     try:
         # urlopen resolves to `Any`; pin the handle and its read explicitly.
-        with urllib.request.urlopen(request, timeout=30) as response:  # pyright: ignore[reportAny]
+        opened = urllib.request.urlopen(request, timeout=30, context=context)  # pyright: ignore[reportAny]
+        with opened as response:  # pyright: ignore[reportAny]
             body = cast(bytes, response.read())  # pyright: ignore[reportAny]
     except urllib.error.HTTPError as error:
         detail = f"{error} — {error.read().decode()[:300]}"
@@ -132,9 +151,21 @@ def main() -> int:
         default=os.environ.get("GRAFANA_ADMIN_PASSWORD") or "admin",
         help="Grafana admin password; defaults to $GRAFANA_ADMIN_PASSWORD",
     )
+    _ = parser.add_argument(
+        "--url",
+        default=_DEFAULT_GRAFANA_URL,
+        help="Grafana base URL; point at the tls proxy to check that route",
+    )
+    _ = parser.add_argument(
+        "--cacert",
+        default=None,
+        help="CA certificate to verify --url against, for the tls profile",
+    )
     args = parser.parse_args()
     timeout = cast(float, args.timeout)
     password = cast(str, args.password)
+    endpoint = f"{cast(str, args.url).rstrip('/')}{_LABEL_PATH}"
+    context = _tls_context(cast("str | None", args.cacert))
 
     try:
         started = _running_containers()
@@ -149,7 +180,7 @@ def main() -> int:
     deadline = time.monotonic() + timeout
     while True:
         try:
-            collected = _collected_containers(password)
+            collected = _collected_containers(password, endpoint, context)
         except _Rejected as rejected:
             print(f"Grafana rejected the credentials: {rejected}", file=sys.stderr)
             return 1

--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -1,6 +1,7 @@
 """Shared InfluxDB connection settings, read from the environment."""
 
 import os
+from pathlib import Path
 
 from influxdb_client_3 import InfluxDBClient3
 
@@ -26,10 +27,36 @@ INFLUXDB_DATABASE = _setting("INFLUXDB_DATABASE", "lab")
 def get_client() -> InfluxDBClient3:
     """Build an InfluxDB client for the configured host and database.
 
-    Raises KeyError if INFLUXDB3_AUTH_TOKEN is not set.
+    Set INFLUXDB_TLS_CA to the certificate a private CA signs the server
+    with, as `scripts/export-ca.sh` produces — needed when the server runs
+    behind the `tls` profile's proxy, since a private root is not in any
+    system trust store. Unset, nothing about the client changes, so a
+    deployment still speaking plain HTTP is unaffected.
+
+    One variable covers both directions of traffic: the same file is read
+    by the HTTP write client and by the Flight SQL query client.
+
+    Raises KeyError if INFLUXDB3_AUTH_TOKEN is not set, and
+    FileNotFoundError if INFLUXDB_TLS_CA names a file that is not there.
     """
+    options: dict[str, str] = {}
+    ca = os.environ.get("INFLUXDB_TLS_CA")
+    if ca:
+        # Checked here rather than left to the TLS layer, which reports a
+        # missing bundle as a verification failure against the server —
+        # sending the reader after a certificate problem that does not
+        # exist, instead of the typo in this machine's env file.
+        if not Path(ca).is_file():
+            raise FileNotFoundError(
+                f"INFLUXDB_TLS_CA points at {ca!r}, which is not a file."
+                + " It should be the CA certificate exported from the server"
+                + " (see scripts/export-ca.sh)."
+            )
+        options["ssl_ca_cert"] = ca
+
     return InfluxDBClient3(
         host=INFLUXDB_HOST,
         token=os.environ["INFLUXDB3_AUTH_TOKEN"],
         database=INFLUXDB_DATABASE,
+        **options,
     )

--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -1,9 +1,12 @@
 """Shared InfluxDB connection settings, read from the environment."""
 
+import logging
 import os
 from pathlib import Path
 
 from influxdb_client_3 import InfluxDBClient3
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def _setting(name: str, default: str) -> str:
@@ -34,7 +37,9 @@ def get_client() -> InfluxDBClient3:
     deployment still speaking plain HTTP is unaffected.
 
     One variable covers both directions of traffic: the same file is read
-    by the HTTP write client and by the Flight SQL query client.
+    by the HTTP write client and by the Flight SQL query client. It only
+    does anything when INFLUXDB_HOST is an https:// address, and says so
+    at WARNING when it is not.
 
     Raises KeyError if INFLUXDB3_AUTH_TOKEN is not set, and
     FileNotFoundError if INFLUXDB_TLS_CA names a file that is not there.
@@ -52,6 +57,18 @@ def get_client() -> InfluxDBClient3:
                 + " It should be the CA certificate exported from the server"
                 + " (see scripts/export-ca.sh)."
             )
+        # A CA against a plain-HTTP host is accepted and then ignored,
+        # which is the one way this setting fails quietly: the operator
+        # believes the link is encrypted and it is not. Warn rather than
+        # raise, because pointing a sensor at a local plain stack while
+        # the shared env file still names a CA is a legitimate thing to
+        # do — it just should not look like it is protected.
+        if not INFLUXDB_HOST.lower().startswith("https://"):
+            logger.warning(
+                "ignoring INFLUXDB_TLS_CA because the host is not https",
+                extra={"host": INFLUXDB_HOST, "ca": ca},
+            )
+
         options["ssl_ca_cert"] = ca
 
     return InfluxDBClient3(

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import pytest
 from influxdb_client_3 import InfluxDBClient3
 
+from labmon import influx
 from labmon.influx import (
     _setting,  # pyright: ignore[reportPrivateUsage]
     get_client,
@@ -49,3 +52,72 @@ def test_get_client_builds_client_with_auth_token(
 
     assert isinstance(client, InfluxDBClient3)
     client.close()
+
+
+# --------------------------------------------------------------------------
+# Verifying the server against a private CA
+# --------------------------------------------------------------------------
+
+
+def test_no_ca_is_passed_when_the_variable_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default path must stay byte-identical to plain HTTP.
+
+    A stack that has not adopted the `tls` profile should be unaffected by
+    this option existing, so nothing is added to the client's arguments
+    unless somebody asked for it.
+    """
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    monkeypatch.delenv("INFLUXDB_TLS_CA", raising=False)
+    captured: dict[str, object] = {}
+
+    def capture(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(influx, "InfluxDBClient3", capture)
+    _ = get_client()
+
+    assert "ssl_ca_cert" not in captured
+
+
+def test_the_ca_is_passed_when_the_variable_names_a_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """One kwarg covers both paths.
+
+    `ssl_ca_cert` is read as a file path by the HTTP write client and by
+    the Flight SQL query client alike, so a single setting is enough to
+    verify the server on both.
+    """
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    ca = tmp_path / "labmon-ca.crt"
+    _ = ca.write_text("-- not parsed here --", encoding="utf-8")
+    monkeypatch.setenv("INFLUXDB_TLS_CA", str(ca))
+    captured: dict[str, object] = {}
+
+    def capture(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(influx, "InfluxDBClient3", capture)
+    _ = get_client()
+
+    assert captured["ssl_ca_cert"] == str(ca)
+
+
+def test_a_missing_ca_file_fails_at_startup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Fail where the mistake is, not on the first write.
+
+    Left to the TLS library, a path that does not exist surfaces as a
+    verification error against the *server* — which reads as a server or
+    certificate problem rather than as a typo in one client's env file.
+    """
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("INFLUXDB_TLS_CA", str(tmp_path / "absent.crt"))
+
+    with pytest.raises(FileNotFoundError, match="INFLUXDB_TLS_CA"):
+        _ = get_client()

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -121,3 +122,48 @@ def test_a_missing_ca_file_fails_at_startup(
 
     with pytest.raises(FileNotFoundError, match="INFLUXDB_TLS_CA"):
         _ = get_client()
+
+
+def _unused_client(**_kwargs: object) -> object:
+    """Stand in for the real client, which these tests never talk to."""
+    return object()
+
+
+def test_a_ca_against_a_plain_http_host_warns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The one way this setting fails quietly.
+
+    A CA is accepted and then ignored when the host is plain HTTP, so the
+    traffic stays in the clear while the operator believes otherwise.
+    """
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    ca = tmp_path / "labmon-ca.crt"
+    _ = ca.write_text("-- not parsed here --", encoding="utf-8")
+    monkeypatch.setenv("INFLUXDB_TLS_CA", str(ca))
+    # The host is a module constant, resolved at import — see #119.
+    monkeypatch.setattr(influx, "INFLUXDB_HOST", "http://localhost:8181")
+    monkeypatch.setattr(influx, "InfluxDBClient3", _unused_client)
+
+    with caplog.at_level(logging.WARNING, logger=influx.__name__):
+        _ = get_client()
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "ignoring INFLUXDB_TLS_CA because the host is not https"
+    ]
+
+
+def test_a_ca_against_an_https_host_is_silent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    ca = tmp_path / "labmon-ca.crt"
+    _ = ca.write_text("-- not parsed here --", encoding="utf-8")
+    monkeypatch.setenv("INFLUXDB_TLS_CA", str(ca))
+    monkeypatch.setattr(influx, "INFLUXDB_HOST", "HTTPS://server:8443")
+    monkeypatch.setattr(influx, "InfluxDBClient3", _unused_client)
+
+    with caplog.at_level(logging.WARNING, logger=influx.__name__):
+        _ = get_client()
+
+    assert caplog.records == []


### PR DESCRIPTION
Closes #52. Unblocks #63.

TLS for the lab LAN via a reverse proxy with an internal CA. **This closes #52.** Loki's push endpoint behind the same proxy is deliberately not here — that is #63's own change, filed separately, and #52 is about InfluxDB, Grafana and `docs/deployment.md`.

Off by default and purely additive: the plain 8181 and 3000 ports keep working exactly as before, so a running deployment adopts TLS on its own schedule rather than at upgrade time.

## Why Caddy

There is no public DNS here, so ACME is not available (#66 stays parked) and certificates have to come from somewhere local. Caddy is the only mainstream proxy with a built-in CA — issuance, storage and renewal live in one container. nginx or Traefik would each need a separate CA tool plus renewal plumbing for the same result.

TLS terminates **at the boundary only**. Grafana still reaches InfluxDB, and Alloy still reaches Loki, over plain HTTP inside the compose network — one Docker bridge on one host, where encryption buys nothing and would mean distributing trust to every service as well as to every client.

## Three things the design did not anticipate

All three were found by running it, and all three fail in ways that would have surfaced late.

**`default_sni` is required.** A client addressing the server by IP sends no SNI, so Caddy has no name to route the connection on and aborts the handshake with an internal-error alert — not a trust error, a connection failure. Since there is no DNS to rely on here, addressing the server by LAN IP is the *normal* case, not an edge one. Without this the feature would have been broken for its primary use.

**The InfluxDB proxy needs `versions h2c 2`.** InfluxDB 3 serves the HTTP write API *and* Flight SQL on one port, and Flight SQL is gRPC — cleartext HTTP/2 against a backend with no TLS of its own. Without it Caddy downgrades to HTTP/1.1 and every Flight call returns 404, so **writes would have worked while queries silently did not** — precisely the kind of half-working state that ships.

**One host list cannot serve two ports.** The first cut interpolated a single `LABMON_TLS_HOSTS` into `{$LABMON_TLS_HOSTS}:8443`, which only ever works for one entry: a Caddyfile site address is written out whole, so two hosts expand to `a, b:8443` — naming a site `a` on the default port and another `b` on 8443. Caddy rejects it before that matters, since a site address cannot contain a comma. Now there is one list per port (`LABMON_TLS_INFLUXDB_SITES`, `LABMON_TLS_GRAFANA_SITES`), each entry a whole `https://host:port`, comma-**and-space** separated. The single-host default happened to work, which is why this survived the first round of live testing — it only appears once a deployment lists its LAN IP alongside a hosts-file name, which is the case the variable existed for.

## Does the CA reach both directions of traffic?

This was the one thing worth checking before building anything, because `influxdb3-python` has form here: `INFLUX_WRITE_NO_SYNC` is a documented case of a kwarg not arriving where the caller expects. If a custom CA reached the write path but not the query path, the feature would half-work.

It does reach both, and a single kwarg covers them. `ssl_ca_cert` goes to the v2 write client via `**kwargs`, and separately becomes `root_certs` on the Flight query builder — which takes a *path* and reads it internally, so the two do not disagree about what the value means. No `SSL_CERT_FILE` fallback is needed.

## What is here

- **`caddy/Caddyfile`** — site addresses taken from the environment, so one file serves any deployment
- **`caddy` service** under `profiles: [tls]`, pinned to `caddy:2.10-alpine`, healthchecked on its admin API
- **`caddy-data` named volume** — the CA must outlive container recreation; losing it means revisiting every client
- **`scripts/export-ca.sh`** — hands the operator the root, and refuses to hand over something unparseable
- **`INFLUXDB_TLS_CA`** on `get_client()`, documented in `docs/configuration.md` and `.env.client.example`
- **A TLS leg in the smoke workflow**, so all of the below is checked on every run rather than by hand
- **`INFLUXDB_TLS_CA` on the client Compose file**, which could not use the profile at all before
- **Documentation** — turning it on, what it does and does not protect, and the certificate lifecycle

A path that does not exist fails at **startup**. Left to the TLS layer, a missing bundle surfaces as a verification failure against the *server*, sending the reader after a certificate problem that does not exist instead of the typo in their env file.

## The TLS leg in CI

Five steps, joining the stack that is already up rather than booting a second one — about forty seconds, not a second cold start. The site lists name `caddy` alongside loopback, which is what lets a container on the compose network reach the proxy under a name the certificate covers.

Two choices worth calling out:

**The negative assertion comes first.** Each port is checked to *refuse* a client with no CA before it is checked to answer one with it. A proxy serving no TLS at all would satisfy every positive assertion in the leg, so without the refusal check the whole thing proves nothing.

**A real sensor does the writing.** `mock-sensor` runs from the shipped image against `https://caddy:8443` with `INFLUXDB_TLS_CA` set, and the row count is then read back out of InfluxDB. A `curl` would only have shown that the proxy answers; this exercises the client-side CA handling over the route a sensor actually takes.

**The query path is covered too, and the guard is proven.** Writes and queries take different routes through the proxy — HTTP for one, Flight SQL over cleartext h2c for the other — and only the query depends on `versions h2c 2`. A separate step runs `get_client().query(...)` from the shipped image against `https://caddy:8443`. Removing `versions h2c 2` from the Caddyfile on a live stack was rehearsed to confirm this is a real guard: the write still returns 204 while the query fails with an HTTP/2 404 through gRPC, and the step exits 1 where the old leg stayed green.

Both smoke scripts gained `--url` and `--cacert` so Grafana's dashboards and the log-collection check re-run against `https://127.0.0.1:3443`, the viewer's route.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 285 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean
- [x] `docker compose config -q` valid with and without the profile
- [x] `caddy` absent from the default config — the profile is genuinely off
- [x] Caddy issues for both a hosts-file name and an IP; leaf SANs checked
- [x] `curl --cacert` succeeds on 8443 and 3443; both are refused without the CA
- [x] Python **write and query** both succeed through the proxy, and both fail without the CA (so verification is genuinely enforced, not silently skipped)
- [x] Plain 8181/3000 still answer — the change is additive
- [x] Root fingerprint unchanged across `--force-recreate`
- [x] **A real `mock-sensor` wrote 12 rows through the proxy** using `INFLUXDB_TLS_CA` — the exact path a client uses
- [x] Missing-CA path fails at startup with a message naming the variable
- [x] Both site lists accept two entries each, and Caddy issues for all four addresses
- [x] Removing `versions h2c 2` makes the smoke leg fail (write 204, query 404) — the regression guard actually guards
- [x] `INFLUXDB_TLS_CA` against an `http://` host warns instead of pretending to protect
- [x] `export-ca.sh` works from outside the repository root, with relative and absolute destinations
- [x] Caddy no longer warns about its own Caddyfile formatting at boot
- [x] Dashboard smoke suite passes through `https://127.0.0.1:3443` with `--cacert`
- [x] `docker-compose.client.yml` validates with the mount uncommented, resolving to the same path inside and out
- [x] Every internal documentation link and anchor resolves
- [x] The smoke workflow's TLS leg passes on a cold CI runner — including the log-collection check that the local rehearsal could not clear, confirming that was a stale-stack artifact rather than a real gap

## Documentation

`deployment.md`'s "Security: plain HTTP, by design (for now)" section is gone, replaced by **Encrypting client and viewer traffic**: a five-step procedure, a statement of what is and is not encrypted, and a certificate lifecycle table. `client-setup.md` gains a section covering both install options, `configuration.md` lists the three server variables and the `tls` profile, and README and `grafana.md` no longer describe the stack as plain-HTTP-only.

The lifetime figures were measured against a running stack rather than quoted from upstream: **12-hour leaf, 7-day intermediate, root good until 2036**. Only the root is ever distributed, so the churn underneath is invisible to clients — what matters instead is the `caddy-data` volume holding the CA key, and the section says plainly that losing it means a new root and a visit to every client.

Two failure modes get their own paragraphs because each presents as something other than what it is. An unset `LABMON_TLS_DEFAULT_SNI` makes the server look **unreachable rather than untrusted**. And a browser that has not been given the root warns like it would on any self-signed site.

## One gap this turned up

`docker-compose.client.yml`'s shared sensor anchor forwarded three environment variables and `INFLUXDB_TLS_CA` was not among them — so **a containerised client could not use the profile at all**, only a bare install could. It now passes through defaulting to empty (which the client reads the same as unset), with the bind mount commented out beside it: an always-on mount whose source is missing does not fail, it has Docker create a *directory* where the certificate should be.

Related trap, documented in both places: `serial-sensor` declares its own `volumes:`, and a YAML merge key makes a service's own list *replace* the anchor's rather than extend it, so uncommenting the anchor alone would silently miss it.

## Out of scope

ACME/public certificates (#66), per-client credentials (#106 — platform-gated), mTLS, and Loki's push endpoint (#63).
