### PR TITLE
refactor: unify the three sensor run loops

### DIFF
--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -1,0 +1,103 @@
+"""The plumbing every sensor loop needs, so none of them writes it again.
+
+Three sensors reach InfluxDB by different routes — a simulated walk, a
+board on a serial line, a vendor API — and all three were separately
+building a writer, installing the same two signal handlers, counting what
+they had written, and emitting the same periodic summary. The summary in
+particular existed twice, verbatim.
+
+What is shared is the plumbing, not the loop. How a reading is obtained
+and how the loop is paced are genuinely different: one sleeps a fixed
+interval, one blocks on a serial read, one backs off when a vendor API
+throws. Those stay with each sensor. What moves here is everything that
+was the same.
+"""
+
+import logging
+import signal
+import sys
+import time
+from collections import Counter
+from types import FrameType
+from typing import Protocol
+
+from influxdb_client_3 import Point
+
+from labmon.influx import get_client
+from labmon.writer import PointWriter
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# How often to report that readings are still arriving. One line per
+# reading is unreadable at any real rate, but silence gives an operator no
+# way to tell "working" from "wedged".
+SUMMARY_INTERVAL_SECONDS = 30.0
+
+
+class Closeable(Protocol):
+    """Anything a sensor holds open that shutdown must release."""
+
+    def close(self) -> None: ...
+
+
+class SensorLoop:
+    """Owns the writer, the shutdown handlers and the periodic summary.
+
+    Constructing one installs SIGINT and SIGTERM handlers, so it belongs
+    in the main thread — which is where a sensor's `run()` already is.
+
+    `closes` is anything else shutdown must release, such as an open
+    serial port. It is closed before the writer, so nothing new arrives
+    while the queue is draining.
+
+    `summary_interval` of None disables the summary, for a sensor that
+    already reports every reading.
+    """
+
+    def __init__(
+        self,
+        *,
+        closes: Closeable | None = None,
+        summary_interval: float | None = SUMMARY_INTERVAL_SECONDS,
+    ) -> None:
+        self.writer: PointWriter[Point] = PointWriter[Point](get_client())
+        self._summary_interval: float | None = summary_interval
+        self._written: Counter[str] = Counter()
+        self._next_summary: float = time.monotonic() + (summary_interval or 0.0)
+
+        def shutdown(_signum: int, _frame: FrameType | None) -> None:
+            if closes is not None:
+                closes.close()
+            self.writer.close()
+            sys.exit(0)
+
+        _ = signal.signal(signal.SIGINT, shutdown)
+        _ = signal.signal(signal.SIGTERM, shutdown)
+
+    def record(self, point: Point, sensor_id: str) -> None:
+        """Queue a point and count it towards the next summary."""
+        self.writer.write(point)
+        self._written[sensor_id] += 1
+
+    def summarise_if_due(self) -> None:
+        """Report what has been written, if the interval has elapsed.
+
+        Called from the sensor's own loop rather than from a timer, so
+        the count is only ever read from the thread that writes it.
+        """
+        if self._summary_interval is None:
+            return
+        now = time.monotonic()
+        if now < self._next_summary:
+            return
+        logger.info(
+            "Wrote %d reading(s) in the last %.0fs (%s)",
+            self._written.total(),
+            self._summary_interval,
+            ", ".join(
+                f"{name} {count}" for name, count in sorted(self._written.items())
+            )
+            or "none",
+        )
+        self._written.clear()
+        self._next_summary = now + self._summary_interval

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -20,17 +20,14 @@ Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
 import argparse
 import math
 import random
-import signal
-import sys
 import time
 from datetime import UTC, datetime
-from types import FrameType
 from typing import cast
 
 from influxdb_client_3 import Point
 
-from labmon.influx import INFLUXDB_DATABASE, get_client
-from labmon.writer import PointWriter
+from labmon.influx import INFLUXDB_DATABASE
+from labmon.sensors.loop import SensorLoop
 
 
 class RandomWalk:
@@ -78,15 +75,10 @@ def run(
     Runs until a SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`) is
     received, at which point the InfluxDB client is closed cleanly.
     """
-    writer: PointWriter[Point] = PointWriter[Point](get_client())
+    # No summary: this sensor already prints every reading, so one would
+    # only repeat what is on the line above it.
+    loop = SensorLoop(summary_interval=None)
     walk = RandomWalk(setpoint=setpoint, noise=noise, log_scale=log_scale)
-
-    def shutdown(_signum: int, _frame: FrameType | None) -> None:
-        writer.close()
-        sys.exit(0)
-
-    _ = signal.signal(signal.SIGINT, shutdown)
-    _ = signal.signal(signal.SIGTERM, shutdown)
 
     unit_suffix = f" {unit}" if unit else ""
     print(
@@ -100,7 +92,7 @@ def run(
         if unit:
             point = point.tag("unit", unit)
         point = point.field(field, reading).time(reading_time, write_precision="ms")
-        writer.write(point)
+        loop.record(point, sensor_id)
         print(f"{sensor_id}: {reading:.4g}{unit_suffix}")
         time.sleep(interval)
 

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -37,18 +37,14 @@ Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
 """
 
 import logging
-import signal
-import sys
 import time
-from collections import Counter
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
-from types import FrameType
 
 from influxdb_client_3 import Point
 
 from labmon.influx import INFLUXDB_DATABASE, get_client
-from labmon.writer import PointWriter
+from labmon.sensors.loop import SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -57,11 +53,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 # recovery is still noticed promptly once it comes back.
 INITIAL_BACKOFF_SECONDS = 1.0
 MAX_BACKOFF_SECONDS = 60.0
-
-# How often to report that readings are still arriving. Matches
-# serial_sensor: one line per reading is unreadable at any real rate, but
-# silence gives an operator no way to tell "working" from "wedged".
-SUMMARY_INTERVAL_SECONDS = 30.0
 
 
 def build_point(
@@ -157,14 +148,7 @@ def poll(
     Runs until SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`), at which
     point queued readings are flushed and the client closed.
     """
-    writer: PointWriter[Point] = PointWriter[Point](get_client())
-
-    def shutdown(_signum: int, _frame: FrameType | None) -> None:
-        writer.close()
-        sys.exit(0)
-
-    _ = signal.signal(signal.SIGINT, shutdown)
-    _ = signal.signal(signal.SIGTERM, shutdown)
+    loop = SensorLoop()
 
     logger.info(
         "Writing '%s' readings for '%s' to %s every %gs",
@@ -174,8 +158,6 @@ def poll(
         interval,
     )
 
-    written: Counter[str] = Counter()
-    next_summary = time.monotonic() + SUMMARY_INTERVAL_SECONDS
     backoff = INITIAL_BACKOFF_SECONDS
 
     while True:
@@ -194,27 +176,16 @@ def poll(
 
         backoff = INITIAL_BACKOFF_SECONDS
         if value is not None:
-            writer.write(
-                build_point(
-                    value,
-                    sensor_id=sensor_id,
-                    measurement=measurement,
-                    unit=unit,
-                    field=field,
-                    tags=tags,
-                )
+            point = build_point(
+                value,
+                sensor_id=sensor_id,
+                measurement=measurement,
+                unit=unit,
+                field=field,
+                tags=tags,
             )
-            written[sensor_id] += 1
+            loop.record(point, sensor_id)
             logger.debug("%s: %.4g %s", sensor_id, value, unit)
 
-        now = time.monotonic()
-        if now >= next_summary:
-            logger.info(
-                "Wrote %d reading(s) in the last %.0fs",
-                written.total(),
-                SUMMARY_INTERVAL_SECONDS,
-            )
-            written.clear()
-            next_summary = now + SUMMARY_INTERVAL_SECONDS
-
+        loop.summarise_if_due()
         time.sleep(interval)

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -21,13 +21,8 @@ Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
 
 import argparse
 import logging
-import signal
-import sys
-import time
-from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
-from types import FrameType
 from typing import cast
 
 from influxdb_client_3 import Point
@@ -40,14 +35,14 @@ from labmon.calibration import (
     raw_to_voltage,
     ureg,
 )
-from labmon.influx import INFLUXDB_DATABASE, get_client
+from labmon.influx import INFLUXDB_DATABASE
+from labmon.sensors.loop import SensorLoop
 from labmon.sensors.serial_source import (
     DEFAULT_BAUDRATE,
     RawSource,
     SerialRawSource,
     open_serial_port,
 )
-from labmon.writer import PointWriter
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -66,14 +61,6 @@ INPUT_FIELD_NAME = "input_volts"
 # field so it can be filtered and grouped on; cardinality stays low
 # because a calibration changes a handful of times over a sensor's life.
 CALIBRATION_ID_TAG = "calibration_id"
-
-# How often to report that readings are still arriving. The per-reading
-# line moved to DEBUG because at 100 Hz across a handful of channels it
-# emits hundreds of lines a second, which costs a fifth of the
-# acquisition loop and buries the warnings worth seeing. This keeps the
-# "it is working" signal an operator actually wants, at a volume a
-# journal can hold.
-SUMMARY_INTERVAL_SECONDS = 30.0
 
 
 def _log_calibrations(calibrations: dict[str, Calibration]) -> None:
@@ -107,15 +94,9 @@ def run(
     received, at which point the serial port and InfluxDB client are
     both closed cleanly.
     """
-    writer: PointWriter[Point] = PointWriter[Point](get_client())
-
-    def shutdown(_signum: int, _frame: FrameType | None) -> None:
-        source.close()
-        writer.close()
-        sys.exit(0)
-
-    _ = signal.signal(signal.SIGINT, shutdown)
-    _ = signal.signal(signal.SIGTERM, shutdown)
+    # The port is closed before the writer, so nothing new arrives while
+    # the queue drains.
+    loop = SensorLoop(closes=source)
 
     logger.info(
         "Writing calibrated readings for channel(s) %s to %s",
@@ -127,9 +108,6 @@ def run(
     # A board may stream channels this host has no calibration for;
     # warn once each rather than on every reading forever.
     warned_channels: set[str] = set()
-
-    written: Counter[str] = Counter()
-    next_summary = time.monotonic() + SUMMARY_INTERVAL_SECONDS
 
     while True:
         reading = source.read()
@@ -164,22 +142,11 @@ def run(
             # correctable after the fact; without it, readings already
             # written can't be recomputed.
             point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
-        writer.write(point)
-        written[calibration.sensor_id] += 1
+        loop.record(point, calibration.sensor_id)
         logger.debug(
             "%s: %.4g %s", calibration.sensor_id, value.magnitude, calibration.unit
         )
-
-        now = time.monotonic()
-        if now >= next_summary:
-            logger.info(
-                "Wrote %d reading(s) in the last %.0fs (%s)",
-                written.total(),
-                SUMMARY_INTERVAL_SECONDS,
-                ", ".join(f"{name} {count}" for name, count in sorted(written.items())),
-            )
-            written.clear()
-            next_summary = now + SUMMARY_INTERVAL_SECONDS
+        loop.summarise_if_due()
 
 
 def main() -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,153 @@
+import logging
+import signal
+import time
+from collections.abc import Callable
+from types import FrameType
+
+import pytest
+from influxdb_client_3 import Point
+
+from labmon.sensors import loop as sensor_loop
+from labmon.sensors.loop import SensorLoop
+
+SignalHandler = Callable[[int, FrameType | None], None]
+
+
+class FakeInfluxClient:
+    def __init__(self) -> None:
+        self.batches: list[list[Point]] = []
+        self.closed: bool = False
+
+    def write(self, batch: list[Point]) -> None:
+        self.batches.append(list(batch))
+
+    def close(self) -> None:
+        self.closed = True
+
+    @property
+    def points(self) -> list[Point]:
+        return [point for batch in self.batches for point in batch]
+
+
+class FakePort:
+    """Something a sensor holds open, recording when it was released."""
+
+    def __init__(self) -> None:
+        self.closed: bool = False
+        self.closed_before_writer: bool | None = None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeInfluxClient:
+    client = FakeInfluxClient()
+    monkeypatch.setattr(sensor_loop, "get_client", lambda: client)
+    return client
+
+
+@pytest.fixture
+def registered_handlers(monkeypatch: pytest.MonkeyPatch) -> dict[int, SignalHandler]:
+    handlers: dict[int, SignalHandler] = {}
+
+    def fake_signal(signalnum: int, handler: SignalHandler) -> None:
+        handlers[signalnum] = handler
+
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    return handlers
+
+
+def _point(value: float) -> Point:
+    return Point("m").tag("sensor_id", "s").field("value", value)
+
+
+@pytest.mark.usefixtures("registered_handlers")
+def test_record_queues_the_point(fake_client: FakeInfluxClient) -> None:
+    loop = SensorLoop()
+
+    loop.record(_point(1.0), "s")
+    loop.writer.close()
+
+    assert len(fake_client.points) == 1
+
+
+@pytest.mark.usefixtures("fake_client")
+def test_both_shutdown_signals_are_registered(
+    registered_handlers: dict[int, SignalHandler],
+) -> None:
+    _ = SensorLoop()
+
+    assert signal.SIGINT in registered_handlers
+    assert signal.SIGTERM in registered_handlers
+
+
+def test_shutdown_closes_the_port_before_the_writer(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """Order matters: nothing new should arrive while the queue drains."""
+    port = FakePort()
+    original_close = FakeInfluxClient.close
+
+    def record_order(client: FakeInfluxClient) -> None:
+        port.closed_before_writer = port.closed
+        original_close(client)
+
+    FakeInfluxClient.close = record_order  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        _ = SensorLoop(closes=port)
+        with pytest.raises(SystemExit) as exit_info:
+            registered_handlers[signal.SIGTERM](signal.SIGTERM, None)
+    finally:
+        FakeInfluxClient.close = original_close
+
+    assert exit_info.value.code == 0
+    assert port.closed is True
+    assert port.closed_before_writer is True
+    assert fake_client.closed is True
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_the_summary_names_each_sensor_and_its_count(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    ticks = iter([0.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    loop.record(_point(1.0), "cryo-77k")
+    loop.record(_point(2.0), "cryo-77k")
+    loop.record(_point(3.0), "room-1")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    assert "Wrote 3 reading(s) in the last 30s (cryo-77k 2, room-1 1)" in caplog.text
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_the_summary_waits_for_its_interval(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    ticks = iter([0.0, 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    loop.record(_point(1.0), "s")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    assert "Wrote" not in caplog.text
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_a_loop_without_a_summary_never_emits_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """For a sensor that already reports every reading, like mock-sensor."""
+    loop = SensorLoop(summary_interval=None)
+    loop.record(_point(1.0), "s")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    assert "Wrote" not in caplog.text

--- a/tests/test_mock_sensor.py
+++ b/tests/test_mock_sensor.py
@@ -8,6 +8,7 @@ from types import FrameType
 import pytest
 from influxdb_client_3 import Point
 
+from labmon.sensors import loop as sensor_loop
 from labmon.sensors import mock_sensor
 from labmon.sensors.mock_sensor import RandomWalk, main, run
 
@@ -68,7 +69,7 @@ def test_run_writes_points_and_shuts_down_cleanly_on_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = FakeInfluxClient()
-    monkeypatch.setattr(mock_sensor, "get_client", lambda: fake_client)
+    monkeypatch.setattr(sensor_loop, "get_client", lambda: fake_client)
 
     registered_handlers: dict[int, SignalHandler] = {}
 
@@ -105,7 +106,7 @@ def test_run_writes_points_with_custom_measurement_field_and_log_scale(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     fake_client = FakeInfluxClient()
-    monkeypatch.setattr(mock_sensor, "get_client", lambda: fake_client)
+    monkeypatch.setattr(sensor_loop, "get_client", lambda: fake_client)
 
     registered_handlers: dict[int, SignalHandler] = {}
 

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -8,6 +8,7 @@ from typing import override
 import pytest
 from influxdb_client_3 import Point
 
+from labmon.sensors import loop as sensor_loop
 from labmon.sensors import polling
 from labmon.sensors.polling import build_point, poll, write_reading
 
@@ -45,6 +46,10 @@ class FakeInfluxClient:
 @pytest.fixture
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeInfluxClient:
     client = FakeInfluxClient()
+    # Two seams: poll() gets its client through SensorLoop, while
+    # write_reading() opens one directly because it must flush before it
+    # returns. Both are patched to the same fake.
+    monkeypatch.setattr(sensor_loop, "get_client", lambda: client)
     monkeypatch.setattr(polling, "get_client", lambda: client)
     return client
 
@@ -328,11 +333,11 @@ def test_poll_summarises_once_the_interval_elapses(
 ) -> None:
     """The per-reading line is DEBUG, so this carries "it is still working"."""
     # The clock passes the summary interval only on the second reading.
-    ticks = iter([0.0, 1.0, polling.SUMMARY_INTERVAL_SECONDS + 1.0])
+    ticks = iter([0.0, 1.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
     monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
 
     with (
-        caplog.at_level(logging.INFO, logger=polling.logger.name),
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
         pytest.raises(_StopLoop),
     ):
         poll(_stop_after([1.0, 2.0]), sensor_id="c", measurement="m")
@@ -342,4 +347,4 @@ def test_poll_summarises_once_the_interval_elapses(
         for record in caplog.records
         if "Wrote" in record.getMessage()
     ]
-    assert summaries == ["Wrote 2 reading(s) in the last 30s"]
+    assert summaries == ["Wrote 2 reading(s) in the last 30s (c 2)"]

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -10,6 +10,7 @@ import pytest
 from influxdb_client_3 import Point
 
 from labmon.calibration import Calibration, LinearConversion, ureg
+from labmon.sensors import loop as sensor_loop
 from labmon.sensors import serial_sensor
 from labmon.sensors.serial_sensor import main, run
 from labmon.sensors.serial_source import RawReading
@@ -61,7 +62,7 @@ def _temperature_calibration(store_input: bool = True) -> Calibration:
 @pytest.fixture
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeInfluxClient:
     client = FakeInfluxClient()
-    monkeypatch.setattr(serial_sensor, "get_client", lambda: client)
+    monkeypatch.setattr(sensor_loop, "get_client", lambda: client)
     return client
 
 
@@ -363,7 +364,7 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     # so exactly one summary covering both should be emitted. Patched on
     # the time module itself, which serial_sensor imports rather than
     # re-exports.
-    ticks = iter([0.0, 1.0, serial_sensor.SUMMARY_INTERVAL_SECONDS + 1.0])
+    ticks = iter([0.0, 1.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
     monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
     source = FakeRawSource(
         [
@@ -373,7 +374,7 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     )
 
     with (
-        caplog.at_level(logging.INFO, logger=serial_sensor.logger.name),
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
         pytest.raises(_StopLoop),
     ):
         run(source=source, calibrations={"A0": _temperature_calibration()})


### PR DESCRIPTION
Closes #47. **Root of stack #78** — #75, #76 and #77 build on this.

`mock_sensor`, `serial_sensor` and `polling` each built a `PointWriter`, installed the same two signal handlers, counted what they had written, and emitted the same periodic summary. The summary existed **twice, verbatim**.

## What moved, and what deliberately did not

`SensorLoop` owns the plumbing: the writer, both shutdown handlers, the per-sensor counter, the summary.

It does **not** own the loop. How a reading is obtained and how the loop is paced are genuinely different — one sleeps a fixed interval, one blocks on a serial read, one backs off when a vendor API throws — so those stay with each sensor. Sharing them would have meant a parameterised super-loop that fits none of the three.

## Two things fell out of sharing it

**The port is now closed before the writer everywhere**, not just in `serial_sensor`, so nothing new arrives while the queue drains. There is a test asserting that ordering; nothing checked it before.

**`polling`'s summary gains the per-sensor breakdown** `serial_sensor` already had. On a live stack:

```
labmon.sensors.loop: Wrote 187 reading(s) in the last 30s
  (beam-x 31, beam-y 31, bias-monitor 31, cryo-diode 32, laser-1 31, pirani-1 31)
```

## Behaviour preserved where it matters

`mock_sensor` passes `summary_interval=None` — it prints every reading, so a summary would only repeat the line above it. Its stdout is byte-identical, which matters because the demo containers' output is exactly what log collection reads.

## What the refactor exposed

The tests patched `get_client` **on each sensor module**. Moving it broke them — not because behaviour changed, but because patching an import site couples a test to *where a name is imported* rather than to what it does. Worth remembering for #75, which moves the logging next.

`polling` keeps its own `get_client` for `write_reading`, which cannot go through `SensorLoop` because it must flush before returning. The test fixture patches both seams, with a comment saying why.

## Test plan

- [x] `uv run pytest --cov=src --cov-fail-under=100` — 140 passed, 100%
- [x] New `tests/test_loop.py` covers the shared module directly, including the close-ordering guarantee and the no-summary case
- [x] Live stack rebuilt: `mock_sensor` output unchanged, `serial_sensor` summary now from `labmon.sensors.loop`, dashboard smoke passes all 14 queries
- [x] `ruff check` · `ruff format --check` · `basedpyright` (0 warnings) · `typos`