### PR TITLE
feat: log in logfmt, with readings at DEBUG

### DIFF
--- a/demo/adc_feeder.py
+++ b/demo/adc_feeder.py
@@ -23,6 +23,8 @@ import random
 import socket
 import sys
 import time
+from datetime import UTC, datetime
+from typing import override
 
 # Loopback by default, so running this directly on a workstation cannot
 # expose the feeder to the network. The demo container overrides it with
@@ -124,6 +126,21 @@ def serve(host: str = HOST, port: int = PORT) -> None:
             logger.info('msg="client gone, waiting"')
 
 
+class _UtcMilliseconds(logging.Formatter):
+    """Stamps a record the way labmon.logs.LogfmtFormatter does.
+
+    `datefmt` cannot express it: %(asctime)s is local time and has no
+    sub-second field, so the feeder's lines would sort against the
+    sensors' by a different clock and a coarser one — in a query that
+    reads both, which is the whole point of collecting them together.
+    """
+
+    @override
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        stamped = datetime.fromtimestamp(record.created, UTC)
+        return stamped.isoformat(timespec="milliseconds")
+
+
 if __name__ == "__main__":
     # The same logfmt shape the sensors emit, spelled out rather than
     # imported: this file is stdlib-only so it can run in the labmon image
@@ -132,11 +149,13 @@ if __name__ == "__main__":
     # halves of the demo read the same way in Grafana.
     for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
         logging.addLevelName(level, logging.getLevelName(level).lower())
-    logging.basicConfig(
-        level=logging.INFO,
-        format="ts=%(asctime)s level=%(levelname)s logger=%(name)s %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        _UtcMilliseconds(
+            "ts=%(asctime)s level=%(levelname)s logger=%(name)s %(message)s"
+        )
     )
+    logging.basicConfig(level=logging.INFO, handlers=[handler])
     try:
         serve()
     except KeyboardInterrupt:

--- a/demo/adc_feeder.py
+++ b/demo/adc_feeder.py
@@ -16,6 +16,7 @@ conversions per reading rather than sending one snapshot.
 Stdlib only, so it runs in the labmon image as-is.
 """
 
+import logging
 import math
 import os
 import random
@@ -37,6 +38,8 @@ FULL_SCALE = (1 << RESOLUTION_BITS) - 1
 VREF = 3.3
 
 SAMPLE_INTERVAL_SECONDS = 1.0
+
+logger: logging.Logger = logging.getLogger("adc-feeder")
 
 
 def _counts(volts: float) -> float:
@@ -102,12 +105,12 @@ def serve(host: str = HOST, port: int = PORT) -> None:
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     listener.bind((host, port))
     listener.listen(1)
-    print(f"adc-feeder listening on {host}:{port}", flush=True)
+    logger.info("msg=listening host=%s port=%d", host, port)
 
     started = time.monotonic()
     while True:
         client, address = listener.accept()
-        print(f"adc-feeder: {address[0]} connected", flush=True)
+        logger.info('msg="client connected" peer=%s', address[0])
         try:
             with client:
                 while True:
@@ -118,10 +121,22 @@ def serve(host: str = HOST, port: int = PORT) -> None:
                     time.sleep(SAMPLE_INTERVAL_SECONDS)
         except (BrokenPipeError, ConnectionResetError):
             # serial-sensor restarted; wait for it to come back.
-            print("adc-feeder: client gone, waiting", flush=True)
+            logger.info('msg="client gone, waiting"')
 
 
 if __name__ == "__main__":
+    # The same logfmt shape the sensors emit, spelled out rather than
+    # imported: this file is stdlib-only so it can run in the labmon image
+    # without being part of the package.
+    # Lower-case level names, matching what labmon.logs emits so both
+    # halves of the demo read the same way in Grafana.
+    for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
+        logging.addLevelName(level, logging.getLevelName(level).lower())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="ts=%(asctime)s level=%(levelname)s logger=%(name)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
     try:
         serve()
     except KeyboardInterrupt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
         chown 472:0 /repo/.grafana/data
         chown 10001:10001 /repo/.loki/data
         chmod 755 /repo/.influxdb3/data /repo/.grafana/data /repo/.loki/data
-        echo "state directories ready"
+        echo 'level=info logger=init-state-dirs msg="state directories ready"'
 
   influxdb:
     image: influxdb:3-core

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -64,6 +64,42 @@ Retention only works because `loki/config.yaml` enables the compactor.
 With `retention_enabled` off — Loki's default — the retention period is
 silently ignored and logs accumulate until the disk fills.
 
+## What a sensor line looks like
+
+Sensors emit [logfmt](https://brandur.org/logfmt): named fields rather
+than prose, so a collector can pick out what it needs and a person can
+still read the line.
+
+```
+ts=2026-08-04T09:31:07.412+00:00 level=info logger=labmon.sensors.loop \
+  msg="wrote readings" readings=7 sensor_id=room-1 window_s=30
+```
+
+Query on the fields in Grafana:
+
+```logql
+{container=~".+"} | logfmt | level="warning"
+{container=~".+"} | logfmt | sensor_id="cryo-77k"
+```
+
+### What is logged, and at what level
+
+**Readings are DEBUG, and off by default.** At 100 Hz across a handful of
+channels they are hundreds of lines a second, and Loki would end up
+storing a second copy of what InfluxDB already holds far more compactly.
+
+**Events are INFO**, each carrying `sensor_id`: startup, the periodic
+summary every 30s, every warning and every error. Those are what you
+correlate against a flat trace — "why did this stop" is answered by a
+warning, not by the last normal reading.
+
+To see every reading while bringing a board up:
+
+```bash
+uv run mock-sensor --log-level debug
+uv run serial-sensor --port … --calibration … --log-level debug
+```
+
 ## Where it collects from
 
 Alloy reads container output through the Docker API. That means anything a

--- a/src/labmon/logs.py
+++ b/src/labmon/logs.py
@@ -1,0 +1,95 @@
+"""Emit logs as logfmt, so a collector can read them as fields.
+
+Sensor output used to be free text — and in two of the four emitters,
+bare `print()`, which carries no level at all. Grafana showed those lines
+as `detected_level: unknown`, so "show me the warnings" was not a query
+anyone could write.
+
+logfmt fixes both halves. Every line carries its level, and the fields a
+collector cares about — `sensor_id` above all — are named rather than
+embedded in prose:
+
+    ts=2026-08-04T09:31:07Z level=info logger=labmon.sensors.loop
+      msg="wrote 30 readings in 30s" sensor_id=cryo-77k
+
+Chosen over JSON because a human reads these too. A JSON line is machine
+readable and miserable to skim in a terminal at three in the morning,
+which is exactly when a sensor log gets read.
+
+Fields come from `extra=`, so a call site names its data instead of
+formatting it into a sentence:
+
+    logger.warning("read failed", extra={"sensor_id": "laser-1"})
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import cast, override
+
+# Attributes the logging module puts on every record. Anything else a
+# caller passed through `extra=` is ours, and becomes a logfmt field.
+_STANDARD_FIELDS = frozenset(
+    logging.LogRecord("", 0, "", 0, "", None, None).__dict__
+) | {"message", "asctime", "taskName"}
+
+# Characters that force a value to be quoted. A bare `=` would look like
+# the start of another field, and whitespace would split one field in two.
+_NEEDS_QUOTING = frozenset(' \t\n"=')
+
+
+def quote(value: object) -> str:
+    """Render a value as a logfmt token, quoting only when it must."""
+    text = str(value)
+    if text == "":
+        return '""'
+    if any(character in text for character in _NEEDS_QUOTING):
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        return f'"{escaped}"'
+    return text
+
+
+class LogfmtFormatter(logging.Formatter):
+    """Renders a record as `key=value` pairs, extras included."""
+
+    @override
+    def format(self, record: logging.LogRecord) -> str:
+        timestamp = datetime.fromtimestamp(record.created, UTC).isoformat(
+            timespec="milliseconds"
+        )
+        fields: list[tuple[str, object]] = [
+            ("ts", timestamp),
+            ("level", record.levelname.lower()),
+            ("logger", record.name),
+            ("msg", record.getMessage()),
+        ]
+
+        # `__dict__` is typed as holding Any; nothing here wants that,
+        # since every value is about to become a string anyway.
+        attributes = cast(dict[str, object], record.__dict__)
+        extras = {
+            key: value
+            for key, value in attributes.items()
+            if key not in _STANDARD_FIELDS
+        }
+        # Sorted so a given call site always renders its fields in the
+        # same order, which makes the lines diffable and greppable.
+        fields.extend(sorted(extras.items()))
+
+        rendered = " ".join(f"{key}={quote(value)}" for key, value in fields)
+        if record.exc_info:
+            # The traceback goes after the fields rather than inside one:
+            # it is multi-line by nature, and mangling it into a quoted
+            # value would make it unreadable for the person who needs it.
+            rendered = f"{rendered}\n{self.formatException(record.exc_info)}"
+        return rendered
+
+
+def configure(level: int = logging.INFO) -> None:
+    """Send this process's logs to stderr as logfmt.
+
+    Called by each sensor's `main()`. A library should not configure
+    logging on import, so nothing here runs until an entry point asks.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(LogfmtFormatter())
+    logging.basicConfig(level=level, handlers=[handler], force=True)

--- a/src/labmon/logs.py
+++ b/src/labmon/logs.py
@@ -84,6 +84,22 @@ class LogfmtFormatter(logging.Formatter):
         return rendered
 
 
+# The levels an entry point offers on its command line, in order of
+# increasing severity. Spelled out so argparse can reject anything else:
+# resolving a level name with a default silently turns `--log-level DEGUB`
+# into INFO, and the missing DEBUG lines then read as a code problem
+# rather than as the typo they are.
+LEVEL_NAMES = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def level_from_name(name: str) -> int:
+    """Translate a `--log-level` value into a logging level.
+
+    Raises KeyError on anything unknown, which is the point.
+    """
+    return logging.getLevelNamesMapping()[name.upper()]
+
+
 def configure(level: int = logging.INFO) -> None:
     """Send this process's logs to stderr as logfmt.
 

--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -90,14 +90,17 @@ class SensorLoop:
         now = time.monotonic()
         if now < self._next_summary:
             return
-        logger.info(
-            "Wrote %d reading(s) in the last %.0fs (%s)",
-            self._written.total(),
-            self._summary_interval,
-            ", ".join(
-                f"{name} {count}" for name, count in sorted(self._written.items())
+        # One line per sensor rather than one line listing all of them:
+        # each carries its own sensor_id field, so a collector can label
+        # it and a query for one instrument returns only its own lines.
+        for sensor_id, count in sorted(self._written.items()):
+            logger.info(
+                "wrote readings",
+                extra={
+                    "sensor_id": sensor_id,
+                    "readings": count,
+                    "window_s": f"{self._summary_interval:.0f}",
+                },
             )
-            or "none",
-        )
         self._written.clear()
         self._next_summary = now + self._summary_interval

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -18,6 +18,7 @@ Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
 """
 
 import argparse
+import logging
 import math
 import random
 import time
@@ -26,8 +27,11 @@ from typing import cast
 
 from influxdb_client_3 import Point
 
+from labmon import logs
 from labmon.influx import INFLUXDB_DATABASE
 from labmon.sensors.loop import SensorLoop
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class RandomWalk:
@@ -75,15 +79,20 @@ def run(
     Runs until a SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`) is
     received, at which point the InfluxDB client is closed cleanly.
     """
-    # No summary: this sensor already prints every reading, so one would
-    # only repeat what is on the line above it.
-    loop = SensorLoop(summary_interval=None)
+    # The summary is on now that per-reading lines are DEBUG. Without it a
+    # sensor at the default level would say nothing at all after startup,
+    # and silence is indistinguishable from a wedged process.
+    loop = SensorLoop()
     walk = RandomWalk(setpoint=setpoint, noise=noise, log_scale=log_scale)
 
-    unit_suffix = f" {unit}" if unit else ""
-    print(
-        f"Writing mock '{measurement}' readings for '{sensor_id}' to "
-        + f"{INFLUXDB_DATABASE} every {interval}s"
+    logger.info(
+        "writing simulated readings",
+        extra={
+            "sensor_id": sensor_id,
+            "measurement": measurement,
+            "database": INFLUXDB_DATABASE,
+            "interval_s": interval,
+        },
     )
     while True:
         reading_time = datetime.now(UTC)
@@ -93,7 +102,11 @@ def run(
             point = point.tag("unit", unit)
         point = point.field(field, reading).time(reading_time, write_precision="ms")
         loop.record(point, sensor_id)
-        print(f"{sensor_id}: {reading:.4g}{unit_suffix}")
+        logger.debug(
+            "reading",
+            extra={"sensor_id": sensor_id, "value": f"{reading:.4g}", "unit": unit},
+        )
+        loop.summarise_if_due()
         time.sleep(interval)
 
 
@@ -142,7 +155,14 @@ def main() -> None:
         help="Unit of the reading (e.g. '°C', 'K', 'mbar'). Written as an "
         + "InfluxDB tag (when set) and shown in the console output.",
     )
+    _ = parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="DEBUG shows every reading; INFO shows startup and the summary",
+    )
     args = parser.parse_args()
+
+    logs.configure(getattr(logging, cast(str, args.log_level).upper(), logging.INFO))
 
     sensor_id = cast(str, args.sensor_id)
     interval = cast(float, args.interval)

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -158,11 +158,13 @@ def main() -> None:
     _ = parser.add_argument(
         "--log-level",
         default="INFO",
+        choices=logs.LEVEL_NAMES,
+        type=str.upper,
         help="DEBUG shows every reading; INFO shows startup and the summary",
     )
     args = parser.parse_args()
 
-    logs.configure(getattr(logging, cast(str, args.log_level).upper(), logging.INFO))
+    logs.configure(logs.level_from_name(cast(str, args.log_level)))
 
     sensor_id = cast(str, args.sensor_id)
     interval = cast(float, args.interval)

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -151,11 +151,13 @@ def poll(
     loop = SensorLoop()
 
     logger.info(
-        "Writing '%s' readings for '%s' to %s every %gs",
-        measurement,
-        sensor_id,
-        INFLUXDB_DATABASE,
-        interval,
+        "writing readings",
+        extra={
+            "sensor_id": sensor_id,
+            "measurement": measurement,
+            "database": INFLUXDB_DATABASE,
+            "interval_s": interval,
+        },
     )
 
     backoff = INITIAL_BACKOFF_SECONDS
@@ -165,9 +167,8 @@ def poll(
             value = read()
         except Exception:
             logger.warning(
-                "Reading '%s' failed; retrying in %.0fs",
-                sensor_id,
-                backoff,
+                "read failed",
+                extra={"sensor_id": sensor_id, "retry_in_s": f"{backoff:.0f}"},
                 exc_info=True,
             )
             time.sleep(backoff)
@@ -185,7 +186,14 @@ def poll(
                 tags=tags,
             )
             loop.record(point, sensor_id)
-            logger.debug("%s: %.4g %s", sensor_id, value, unit)
+            logger.debug(
+                "reading",
+                extra={
+                    "sensor_id": sensor_id,
+                    "value": f"{value:.4g}",
+                    "unit": unit,
+                },
+            )
 
         loop.summarise_if_due()
         time.sleep(interval)

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -27,6 +27,7 @@ from typing import cast
 
 from influxdb_client_3 import Point
 
+from labmon import logs
 from labmon.calibration import (
     ADC_RESOLUTION_BITS,
     ADC_VREF_VOLTS,
@@ -74,11 +75,13 @@ def _log_calibrations(calibrations: dict[str, Calibration]) -> None:
             f"{key}={value!r}" for key, value in calibration.provenance.items()
         )
         logger.info(
-            "Channel %s: %s calibration %s%s",
-            channel,
-            calibration.sensor_id,
-            calibration.calibration_id,
-            f" ({details})" if details else "",
+            "calibration in force",
+            extra={
+                "channel": channel,
+                "sensor_id": calibration.sensor_id,
+                "calibration_id": calibration.calibration_id,
+                "provenance": details or "-",
+            },
         )
 
 
@@ -99,9 +102,11 @@ def run(
     loop = SensorLoop(closes=source)
 
     logger.info(
-        "Writing calibrated readings for channel(s) %s to %s",
-        ", ".join(sorted(calibrations)) or "(none configured)",
-        INFLUXDB_DATABASE,
+        "writing calibrated readings",
+        extra={
+            "channels": ",".join(sorted(calibrations)) or "-",
+            "database": INFLUXDB_DATABASE,
+        },
     )
     _log_calibrations(calibrations)
 
@@ -119,8 +124,8 @@ def run(
             if reading.channel not in warned_channels:
                 warned_channels.add(reading.channel)
                 logger.warning(
-                    "No calibration for channel %r; ignoring its readings",
-                    reading.channel,
+                    "no calibration for channel; ignoring its readings",
+                    extra={"channel": reading.channel},
                 )
             continue
 
@@ -144,7 +149,12 @@ def run(
             point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
         loop.record(point, calibration.sensor_id)
         logger.debug(
-            "%s: %.4g %s", calibration.sensor_id, value.magnitude, calibration.unit
+            "reading",
+            extra={
+                "sensor_id": calibration.sensor_id,
+                "value": f"{value.magnitude:.4g}",
+                "unit": calibration.unit,
+            },
         )
         loop.summarise_if_due()
 
@@ -182,6 +192,11 @@ def main() -> None:
         default=ADC_VREF_VOLTS,
         help="ADC reference voltage (default suits a 3.3V part)",
     )
+    _ = parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="DEBUG shows every reading; INFO shows startup and the summary",
+    )
     args = parser.parse_args()
 
     port = cast(str, args.port)
@@ -190,9 +205,7 @@ def main() -> None:
     resolution_bits = cast(int, args.resolution_bits)
     v_ref = cast(float, args.vref)
 
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
-    )
+    logs.configure(getattr(logging, cast(str, args.log_level).upper(), logging.INFO))
 
     # Load the calibration before opening the port: a bad config should
     # fail immediately rather than after touching the hardware.

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -195,6 +195,8 @@ def main() -> None:
     _ = parser.add_argument(
         "--log-level",
         default="INFO",
+        choices=logs.LEVEL_NAMES,
+        type=str.upper,
         help="DEBUG shows every reading; INFO shows startup and the summary",
     )
     args = parser.parse_args()
@@ -205,7 +207,7 @@ def main() -> None:
     resolution_bits = cast(int, args.resolution_bits)
     v_ref = cast(float, args.vref)
 
-    logs.configure(getattr(logging, cast(str, args.log_level).upper(), logging.INFO))
+    logs.configure(logs.level_from_name(cast(str, args.log_level)))
 
     # Load the calibration before opening the port: a bad config should
     # fail immediately rather than after touching the hardware.

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,0 +1,108 @@
+import logging
+
+import pytest
+
+from labmon.logs import LogfmtFormatter, configure, quote
+
+
+def _record(message: str = "hello", **extra: object) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="labmon.test",
+        level=logging.INFO,
+        pathname="x.py",
+        lineno=1,
+        msg=message,
+        args=None,
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+# --------------------------------------------------------------------------
+# quoting
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("plain", "plain"),
+        ("cryo-77k", "cryo-77k"),
+        (42, "42"),
+        (1.5, "1.5"),
+        # A space would otherwise split one field into two.
+        ("two words", '"two words"'),
+        # A bare `=` reads as the start of another field.
+        ("a=b", '"a=b"'),
+        ("", '""'),
+        ('say "hi"', '"say \\"hi\\""'),
+        ("line\nbreak", '"line\\nbreak"'),
+        ("back\\slash", "back\\slash"),
+    ],
+)
+def test_quote_only_when_it_must(value: object, expected: str) -> None:
+    assert quote(value) == expected
+
+
+# --------------------------------------------------------------------------
+# formatting
+# --------------------------------------------------------------------------
+
+
+def test_a_line_carries_level_logger_and_message() -> None:
+    line = LogfmtFormatter().format(_record("writing readings"))
+
+    assert "level=info" in line
+    assert "logger=labmon.test" in line
+    assert 'msg="writing readings"' in line
+    assert line.startswith("ts=")
+
+
+def test_extras_become_fields() -> None:
+    line = LogfmtFormatter().format(
+        _record("reading", sensor_id="cryo-77k", value=77.3)
+    )
+
+    assert "sensor_id=cryo-77k" in line
+    assert "value=77.3" in line
+
+
+def test_fields_are_ordered_so_lines_stay_diffable() -> None:
+    """A given call site should always render its fields the same way."""
+    line = LogfmtFormatter().format(_record("m", zebra=1, alpha=2, middle=3))
+
+    assert line.index("alpha=") < line.index("middle=") < line.index("zebra=")
+
+
+def test_a_field_needing_quotes_gets_them() -> None:
+    line = LogfmtFormatter().format(_record("m", provenance="date='2026-07-28'"))
+
+    assert "provenance=\"date='2026-07-28'\"" in line
+
+
+def test_a_traceback_follows_the_fields_rather_than_hiding_in_one() -> None:
+    """Mangling it into a quoted value makes it unreadable when needed."""
+    try:
+        raise ValueError("device busy")
+    except ValueError:
+        import sys
+
+        record = _record("read failed")
+        record.exc_info = sys.exc_info()
+
+    line = LogfmtFormatter().format(record)
+    first, _, traceback = line.partition("\n")
+
+    assert 'msg="read failed"' in first
+    assert "ValueError: device busy" in traceback
+
+
+def test_configure_installs_the_formatter(capsys: pytest.CaptureFixture[str]) -> None:
+    configure(logging.DEBUG)
+    logging.getLogger("labmon.test").debug("hello", extra={"sensor_id": "s"})
+
+    captured = capsys.readouterr().err
+    assert "level=debug" in captured
+    assert "msg=hello sensor_id=s" in captured

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -2,7 +2,13 @@ import logging
 
 import pytest
 
-from labmon.logs import LogfmtFormatter, configure, quote
+from labmon.logs import (
+    LEVEL_NAMES,
+    LogfmtFormatter,
+    configure,
+    level_from_name,
+    quote,
+)
 
 
 def _record(message: str = "hello", **extra: object) -> logging.LogRecord:
@@ -106,3 +112,29 @@ def test_configure_installs_the_formatter(capsys: pytest.CaptureFixture[str]) ->
     captured = capsys.readouterr().err
     assert "level=debug" in captured
     assert "msg=hello sensor_id=s" in captured
+
+
+# --------------------------------------------------------------------------
+# --log-level must fail loudly on a typo
+# --------------------------------------------------------------------------
+
+
+def test_every_advertised_level_resolves() -> None:
+    """The choices argparse offers must all be levels logging knows."""
+    assert [level_from_name(name) for name in LEVEL_NAMES] == [
+        logging.DEBUG,
+        logging.INFO,
+        logging.WARNING,
+        logging.ERROR,
+        logging.CRITICAL,
+    ]
+
+
+def test_a_level_name_is_case_insensitive() -> None:
+    assert level_from_name("debug") == logging.DEBUG
+
+
+def test_an_unknown_level_name_raises_rather_than_defaulting() -> None:
+    """Silently falling back to INFO hides the typo that caused it."""
+    with pytest.raises(KeyError):
+        _ = level_from_name("verbose")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -13,6 +13,15 @@ from labmon.sensors.loop import SensorLoop
 SignalHandler = Callable[[int, FrameType | None], None]
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class FakeInfluxClient:
     def __init__(self) -> None:
         self.batches: list[list[Point]] = []
@@ -121,7 +130,14 @@ def test_the_summary_names_each_sensor_and_its_count(
     with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
         loop.summarise_if_due()
 
-    assert "Wrote 3 reading(s) in the last 30s (cryo-77k 2, room-1 1)" in caplog.text
+    # One record per sensor, each naming its own — so a collector can
+    # label them individually rather than parsing one combined sentence.
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [(_field(r, "sensor_id"), _field(r, "readings")) for r in summaries] == [
+        ("cryo-77k", 2),
+        ("room-1", 1),
+    ]
+    assert all(_field(r, "window_s") == "30" for r in summaries)
 
 
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
@@ -136,7 +152,7 @@ def test_the_summary_waits_for_its_interval(
     with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
         loop.summarise_if_due()
 
-    assert "Wrote" not in caplog.text
+    assert "wrote readings" not in caplog.text
 
 
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
@@ -150,4 +166,4 @@ def test_a_loop_without_a_summary_never_emits_one(
     with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
         loop.summarise_if_due()
 
-    assert "Wrote" not in caplog.text
+    assert "wrote readings" not in caplog.text

--- a/tests/test_mock_sensor.py
+++ b/tests/test_mock_sensor.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import signal
 import sys
@@ -246,3 +247,28 @@ def test_main_parses_pressure_gauge_arguments(monkeypatch: pytest.MonkeyPatch) -
             "unit": "mbar",
         }
     ]
+
+
+def test_an_unknown_log_level_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo must fail at the command line, not quietly become INFO."""
+    monkeypatch.setattr(sys, "argv", ["mock-sensor", "--log-level", "DEGUB"])
+
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+
+    assert exit_info.value.code == 2
+
+
+def test_a_lower_case_log_level_is_accepted(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(mock_sensor, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["mock-sensor", "--log-level", "debug"])
+
+    main()
+
+    assert logging.getLogger().level == logging.DEBUG
+    assert len(calls) == 1

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -15,6 +15,15 @@ from labmon.sensors.polling import build_point, poll, write_reading
 SignalHandler = Callable[[int, FrameType | None], None]
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class _StopLoop(BaseException):
     """Breaks out of poll()'s infinite loop.
 
@@ -342,9 +351,7 @@ def test_poll_summarises_once_the_interval_elapses(
     ):
         poll(_stop_after([1.0, 2.0]), sensor_id="c", measurement="m")
 
-    summaries = [
-        record.getMessage()
-        for record in caplog.records
-        if "Wrote" in record.getMessage()
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [(_field(r, "sensor_id"), _field(r, "readings")) for r in summaries] == [
+        ("c", 2)
     ]
-    assert summaries == ["Wrote 2 reading(s) in the last 30s (c 2)"]

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -401,3 +401,26 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     assert [(_field(r, "sensor_id"), _field(r, "readings")) for r in summaries] == [
         ("cryo-77k", 2)
     ]
+
+
+def test_an_unknown_log_level_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo must fail at the command line, not quietly become INFO."""
+    _ = _patch_main_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "serial-sensor",
+            "--port",
+            "/dev/labmon-due",
+            "--calibration",
+            "cal.toml",
+            "--log-level",
+            "DEGUB",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        main()
+
+    assert exit_info.value.code == 2

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -18,6 +18,15 @@ from labmon.sensors.serial_source import RawReading
 SignalHandler = Callable[[int, FrameType | None], None]
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class _StopLoop(Exception):
     pass
 
@@ -175,8 +184,10 @@ def test_run_logs_the_calibration_and_provenance_of_every_channel(
     with caplog.at_level(logging.INFO), pytest.raises(_StopLoop):
         run(source=FakeRawSource([]), calibrations={"A0": calibration})
 
-    assert f"calibration {calibration.calibration_id}" in caplog.text
-    assert "Lakeshore 336" in caplog.text
+    [record] = [r for r in caplog.records if r.getMessage() == "calibration in force"]
+    assert _field(record, "calibration_id") == calibration.calibration_id
+    assert _field(record, "sensor_id") == "cryo-77k"
+    assert "Lakeshore 336" in str(_field(record, "provenance"))
 
 
 @pytest.mark.usefixtures("fake_client")
@@ -240,8 +251,13 @@ def test_run_warns_once_per_uncalibrated_channel(
         registered_handlers[signal.SIGINT](signal.SIGINT, None)
 
     # A board streaming an unmapped channel shouldn't flood the log.
-    assert caplog.text.count("No calibration for channel") == 1
-    assert "A7" in caplog.text
+    warnings = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "no calibration for channel; ignoring its readings"
+    ]
+    assert len(warnings) == 1
+    assert _field(warnings[0], "channel") == "A7"
     [batch] = fake_client.batches
     assert len(batch) == 1
 
@@ -348,10 +364,12 @@ def test_per_reading_lines_are_debug_not_info(
     ):
         run(source=source, calibrations={"A0": _temperature_calibration()})
 
-    reading_lines = [
-        record for record in caplog.records if "140.2" in record.getMessage()
-    ]
-    assert [record.levelno for record in reading_lines] == [logging.DEBUG]
+    reading_lines = [r for r in caplog.records if r.getMessage() == "reading"]
+    assert [r.levelno for r in reading_lines] == [logging.DEBUG]
+    # The value travels as a field, not inside the sentence — which is
+    # what lets a collector pick it out.
+    assert _field(reading_lines[0], "sensor_id") == "cryo-77k"
+    assert str(_field(reading_lines[0], "value")).startswith("140.2")
 
 
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
@@ -379,9 +397,7 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     ):
         run(source=source, calibrations={"A0": _temperature_calibration()})
 
-    summaries = [
-        record.getMessage()
-        for record in caplog.records
-        if "Wrote" in record.getMessage()
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [(_field(r, "sensor_id"), _field(r, "readings")) for r in summaries] == [
+        ("cryo-77k", 2)
     ]
-    assert summaries == ["Wrote 2 reading(s) in the last 30s (cryo-77k 2)"]


### PR DESCRIPTION
Closes #57. Stacked on #74 (`refactor/unify-sensor-run-loops`), which is where the shared loop lives.

## The problem

Two of the four things that emit sensor output used bare `print()`. A `print()` carries no level, so Grafana labelled those lines `detected_level: unknown` and "show me the warnings across every sensor" was not a query anyone could write. The other two used `logging` but formatted their data into sentences — `"wrote 30 readings in 30s"` — so `sensor_id` was not something a collector could match on either.

That matters more now than it did before the `logs` profile landed: the lines are being stored and queried, not just watched scrolling past.

## What this does

Adds `labmon.logs`, a logfmt formatter, and moves all four emitters onto it:

```
ts=2026-08-04T09:31:07.412+00:00 level=info logger=labmon.sensors.loop msg="wrote readings" readings=7 sensor_id=room-1 window_s=30
```

Fields come from `extra=`, so a call site names its data rather than writing a sentence around it:

```python
logger.warning("read failed", extra={"sensor_id": sensor_id})
```

which makes these queries work:

```logql
{container=~".+"} | logfmt | level="warning"
{container=~".+"} | logfmt | sensor_id="cryo-77k"
```

logfmt rather than JSON because a person reads these too — `docker compose logs` at three in the morning is the actual use case, and a JSON line is machine-readable and miserable to skim.

## Readings drop to DEBUG

`mock-sensor` printed every reading. At 100 Hz across a handful of channels that is hundreds of lines a second, and Loki would end up holding a second, far bulkier copy of what InfluxDB already stores. So readings are `DEBUG` and off by default; every emitter takes `--log-level debug` to turn them back on while bringing a board up.

The consequence is that an idle `mock-sensor` container would have gone silent, which reads as "hung" — so it gains the 30-second summary the other two paths already had.

## Also

- `demo/adc_feeder.py` moves to `logging` with inline logfmt fields. It stays stdlib-only (it runs as a bare script in the image), so it formats its own line rather than importing `labmon.logs`.
- The `init-state-dirs` echo in `docker-compose.yml` becomes a logfmt line — it is the one emitter that is not Python, and it was the only remaining unstructured line in the stack.
- `docs/logging.md` gains the line format, the queries it enables, and the DEBUG/INFO split with its reasoning.

## Unblocks

#64 (alerting on sensor failures) needs a level to alert on. This is that.

## Review follow-ups

Two things this PR left behind, fixed in `17835ba`:

- `--log-level` resolved its value with a default, so `--log-level DEGUB` silently selected INFO and the missing DEBUG lines read as a code problem rather than as the typo they were. argparse now offers the five levels as `choices` and rejects anything else, lower case included. `logs.LEVEL_NAMES` and `logs.level_from_name` keep both entry points spelling it the same way.
- The demo feeder stamped its lines from `datefmt`, which is local time and has no sub-second field, so its output sorted against the sensors' by a different clock and a coarser one — in exactly the queries that read both. It now formats the timestamp the way `LogfmtFormatter` does. Verified live: feeder `ts=2026-08-05T15:27:46.506+00:00` against sensor `ts=2026-08-05T15:27:46.542+00:00`.

The `init-state-dirs` echo still carries no `ts=`. Left alone deliberately: it is one line per stack start from a shell, Loki timestamps it on ingestion, and `date -u` formatting in that entrypoint would cost more than it returns.

## Test plan

- [x] 162 tests, 100% coverage, `basedpyright` 0 errors 0 warnings, `ruff` and `typos` clean
- [x] Quoting verified against a table of cases: spaces, `=`, embedded quotes, newlines, empty string
- [x] Tracebacks placed after the fields rather than inside a quoted value, and asserted on
- [x] Field order asserted stable, so lines stay diffable and greppable
- [x] Existing sensor tests rewritten to assert on structured fields rather than substring-matching prose — each verified to fail if the field is dropped
- [x] Live run of the full stack: INFO shows startup, summary and errors; `--log-level debug` shows per-reading lines; nothing unstructured left in `docker compose logs`
