### PR TITLE
feat: stop recording a signal while its instrument is off

### DIFF
--- a/calibration.example.toml
+++ b/calibration.example.toml
@@ -78,6 +78,28 @@ mode = "expression"
 expression = "10**(1.667*v - 11.33)"       # a typical Pirani gauge curve
 value_unit = "mbar"
 
+# --- record_when: stop recording while the instrument is off -------------
+# Optional, one table per channel. A signal that is only meaningful while
+# its instrument is running — a photodiode watching a laser, a gauge on a
+# chamber that gets vented — otherwise records noise at full rate,
+# stretching dashboard axes and dragging every average computed over it.
+#
+# Conservative about stopping, eager about resuming: `for` delays a stop
+# so a brief dip costs nothing, while a resume is always immediate so the
+# turn-on transient is not swallowed. Nothing is written while the gate
+# is closed, so the trace shows a gap; the transition is logged once,
+# which is what makes that gap readable.
+#
+# `above` and `below` are the two directions, and a channel uses one.
+# Thresholds are dimensioned and checked against what the channel
+# produces, so a wrong unit fails at startup. See docs/serial-sensor.md.
+[channels.A0.record_when]
+above = "1.0 mW"           # below this, the laser is off
+for = "30s"                # a brief dip does not stop recording
+resume_above = "10.0 mW"   # deadband, so a value sitting at the
+                           # threshold does not flap between gap
+                           # and fragment
+
 # --- provenance: how a calibration was obtained -------------------------
 # Optional, free-form, one table per channel. Logged at startup and never
 # written to InfluxDB, so it documents the file without touching the

--- a/calibration.example.toml
+++ b/calibration.example.toml
@@ -78,27 +78,39 @@ mode = "expression"
 expression = "10**(1.667*v - 11.33)"       # a typical Pirani gauge curve
 value_unit = "mbar"
 
-# --- record_when: stop recording while the instrument is off -------------
+# --- stop_recording_when: take a channel out of service while its -------
+# --- instrument is off --------------------------------------------------
 # Optional, one table per channel. A signal that is only meaningful while
 # its instrument is running — a photodiode watching a laser, a gauge on a
 # chamber that gets vented — otherwise records noise at full rate,
 # stretching dashboard axes and dragging every average computed over it.
 #
-# Conservative about stopping, eager about resuming: `for` delays a stop
-# so a brief dip costs nothing, while a resume is always immediate so the
-# turn-on transient is not swallowed. Nothing is written while the gate
-# is closed, so the trace shows a gap; the transition is logged once,
-# which is what makes that gap readable.
+# Written as what STOPS the recording, so `for` reads on the clause it
+# governs: stop recording once the power has stayed below 1 mW for 30
+# seconds. Conservative about stopping, eager about resuming — a resume
+# is always immediate, so the turn-on transient is not swallowed.
+# Nothing is written while the gate is closed, so the trace shows a gap;
+# the transition is logged once, which is what makes that gap readable.
 #
-# `above` and `below` are the two directions, and a channel uses one.
-# Thresholds are dimensioned and checked against what the channel
-# produces, so a wrong unit fails at startup. See docs/serial-sensor.md.
-[channels.A0.record_when]
-above = "1.0 mW"           # below this, the laser is off
+# `below` and `above` are the bounds; set either or both, and everything
+# between them is recorded. They are dimensioned and checked against what
+# the channel produces, so a wrong unit fails at startup.
+[channels.A0.stop_recording_when]
+below = "1.0 mW"           # under this, the laser is off
 for = "30s"                # a brief dip does not stop recording
-resume_above = "10.0 mW"   # deadband, so a value sitting at the
-                           # threshold does not flap between gap
-                           # and fragment
+resume_above = "10.0 mW"   # deadband, so a value sitting at the bound
+                           # does not flap between gap and fragment
+
+# The two-sided form, gating on the raw input rather than the converted
+# value: an open input at one end, a railed amplifier at the other. The
+# bounds are then in volts whatever the channel converts to, and must
+# read below <= resume_above < resume_below <= above.
+# [channels.A1.stop_recording_when]
+# raw_voltage = true
+# below = "100 mV"
+# above = "3.0 V"
+# for = "1 min"                     # 'm' would be metres
+# resume_below = "2.9 V"
 
 # --- provenance: how a calibration was obtained -------------------------
 # Optional, free-form, one table per channel. Logged at startup and never

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -160,7 +160,8 @@ a vented chamber reads atmosphere. Recorded at full rate those readings
 cost storage, stretch dashboard axes, and drag every average and alert
 threshold computed over the series.
 
-An optional `record_when` table gates a channel on its own value:
+An optional `stop_recording_when` table says what takes a channel out of
+service:
 
 ```toml
 [channels.A3]
@@ -168,15 +169,41 @@ sensor_id = "laser-1"
 measurement = "power"
 conversion_factor = "50.0 mW / volt"
 
-[channels.A3.record_when]
-above = "1.0 mW"          # below this, the laser is off
+[channels.A3.stop_recording_when]
+below = "1 mW"            # under this, the laser is off
 for = "30s"               # ... but only once it has stayed there
-resume_above = "10.0 mW"  # resume above this, immediately
+resume_above = "10 mW"    # back over this, resume immediately
 ```
 
-`above` and `below` are the two directions; a channel uses one or the
-other. Both are dimensioned and checked against what the channel actually
-produces at startup, so a threshold in the wrong unit is a config error
+The table is written as the conditions that **stop** recording, because
+that is the decision being made: the state being excluded is the one
+worth naming, and `for` then reads on the clause it actually governs —
+"stop recording when the power stays below 1 mW for 30 seconds".
+
+`below` and `above` are the two bounds. A channel may set either, or
+both, and everything between them is recorded:
+
+```toml
+[channels.A4.stop_recording_when]
+raw_voltage = true
+below = "100 mV"
+above = "3.0 V"
+for = "1 min"
+resume_below = "2.9 V"
+```
+
+That channel stops recording once its input has sat outside 100 mV–3.0 V
+for a minute — open input at one end, railed amplifier at the other —
+and resumes as soon as the input is back under 2.9 V.
+
+`raw_voltage = true` compares the bounds against the voltage at the ADC
+input rather than against the converted value, for a channel whose off
+state is better recognised before the conversion: a railed amplifier, or
+a conversion characterised over only part of the input range. The bounds
+are then written in volts whatever the channel converts to.
+
+Every bound is dimensioned and checked at startup against the quantity
+it will be compared to, so a bound in the wrong unit is a config error
 rather than a comparison that silently means something else.
 
 Nothing is written while the gate is closed — not even `input_volts`.
@@ -189,15 +216,27 @@ The two directions are deliberately asymmetric, because their costs are.
 Stopping wrongly loses real data; resuming wrongly costs a handful of
 junk samples.
 
-- `for` is an optional dwell, and applies to **stopping only**. A brief
-  dip below the threshold does not stop recording. Without it, the first
-  reading past the threshold does.
+- `for` is an optional dwell, written as a duration (`"30s"`, `"1 min"`
+  — `"1m"` is one *metre*, and is rejected at startup), and applies to
+  **stopping only**. A brief
+  excursion past a bound does not stop recording. Without it, the first
+  reading outside the band does. A reading that leaves by one bound and
+  comes back inside by way of the other never resets the dwell — outside
+  is outside.
 - Resuming is **always immediate**. Waiting would swallow the turn-on
   transient, which is often the most interesting part of the trace.
-- `resume_above` / `resume_below` are optional. Without one, the stop
-  threshold is reused and there is no deadband. A value hovering right at
-  the threshold will then alternate between gaps and fragments, which is
-  what a deadband exists to prevent.
+- `resume_above` and `resume_below` are optional deadbands on `below`
+  and `above` respectively. Without them the stop bounds are reused and
+  there is no deadband, so a value hovering right at a bound alternates
+  between gaps and fragments — which is what a deadband exists to
+  prevent.
+
+The four bounds have to read `below <= resume_above < resume_below <=
+above`, and anything else is rejected at startup: the resume band nests
+inside the band recording stops outside of, and bounds that cross
+describe a gate that would flap, or one that would never record at all.
+A deadband without the bound it widens (`resume_above` with no `below`)
+is rejected too, rather than looking configured while doing nothing.
 
 A gate starts out recording, so a misconfigured one errs towards keeping
 data.
@@ -205,10 +244,11 @@ data.
 #### Reading the gap
 
 Each transition is logged once — never per reading, which at 100 Hz
-would be unreadable — carrying the value that caused it:
+would be unreadable — carrying the value that caused it and the bound it
+crossed:
 
 ```
-level=info logger=labmon.gate msg="recording stopped" sensor_id=laser-1 threshold="1 mW" value="0.03 mW"
+level=info logger=labmon.gate msg="recording stopped" sensor_id=laser-1 limit="below 1 mW" value="0.03 mW"
 ```
 
 That line is what makes the gap interpretable. With the `logs` profile

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -231,6 +231,12 @@ junk samples.
   between gaps and fragments — which is what a deadband exists to
   prevent.
 
+Every comparison is strict, so each key means what it says: a reading of
+exactly 3 V is not *above* 3 V and does not stop a channel bounded there,
+and the same at every other bound. A reading sitting exactly on one is
+therefore neither stopping nor resuming, and the gate holds the state it
+was already in.
+
 The four bounds have to read `below <= resume_above < resume_below <=
 above`, and anything else is rejected at startup: the resume band nests
 inside the band recording stops outside of, and bounds that cross

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -152,6 +152,71 @@ Any keys are accepted; nothing is required. Only the table's presence is
 validated, so a bare `provenance = "..."` string is rejected rather than
 silently ignored.
 
+### Not recording while the instrument is off
+
+Some signals are only meaningful while the instrument producing them is
+running. A photodiode watching a laser reads noise overnight; a gauge on
+a vented chamber reads atmosphere. Recorded at full rate those readings
+cost storage, stretch dashboard axes, and drag every average and alert
+threshold computed over the series.
+
+An optional `record_when` table gates a channel on its own value:
+
+```toml
+[channels.A3]
+sensor_id = "laser-1"
+measurement = "power"
+conversion_factor = "50.0 mW / volt"
+
+[channels.A3.record_when]
+above = "1.0 mW"          # below this, the laser is off
+for = "30s"               # ... but only once it has stayed there
+resume_above = "10.0 mW"  # resume above this, immediately
+```
+
+`above` and `below` are the two directions; a channel uses one or the
+other. Both are dimensioned and checked against what the channel actually
+produces at startup, so a threshold in the wrong unit is a config error
+rather than a comparison that silently means something else.
+
+Nothing is written while the gate is closed — not even `input_volts`.
+The gap in the trace is the honest signal, and it is what makes the
+storage saving real.
+
+#### Conservative about stopping, eager about resuming
+
+The two directions are deliberately asymmetric, because their costs are.
+Stopping wrongly loses real data; resuming wrongly costs a handful of
+junk samples.
+
+- `for` is an optional dwell, and applies to **stopping only**. A brief
+  dip below the threshold does not stop recording. Without it, the first
+  reading past the threshold does.
+- Resuming is **always immediate**. Waiting would swallow the turn-on
+  transient, which is often the most interesting part of the trace.
+- `resume_above` / `resume_below` are optional. Without one, the stop
+  threshold is reused and there is no deadband. A value hovering right at
+  the threshold will then alternate between gaps and fragments, which is
+  what a deadband exists to prevent.
+
+A gate starts out recording, so a misconfigured one errs towards keeping
+data.
+
+#### Reading the gap
+
+Each transition is logged once — never per reading, which at 100 Hz
+would be unreadable — carrying the value that caused it:
+
+```
+level=info logger=labmon.gate msg="recording stopped" sensor_id=laser-1 threshold="1 mW" value="0.03 mW"
+```
+
+That line is what makes the gap interpretable. With the `logs` profile
+(see [logging.md](logging.md)) it sits next to the series in Grafana, so
+a flat trace reads as "laser off at 19:42" rather than "sensor died at
+some point last night". Without it, an instrument being off and an
+acquisition crashing look identical in the data.
+
 ### Choosing between `spline` and `piecewise_linear`
 
 Both take the same measured `voltages`/`values` points, which must be

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -42,6 +42,8 @@ from typing import Protocol, cast, override
 import pint
 from asteval import Interpreter
 
+from labmon.gate import RecordingRule
+
 ureg: pint.UnitRegistry = pint.UnitRegistry()
 
 # Defaults describing a common 3.3V, 12-bit ADC. Nothing here is tied to
@@ -75,6 +77,21 @@ CALIBRATION_ID_LENGTH = 8
 # any two real calibrations apart, few enough that unit conversion noise
 # doesn't invent a new id (see _quantity_key).
 FINGERPRINT_SIGNIFICANT_DIGITS = 12
+
+# Optional per-channel table saying when a reading is worth recording,
+# for a signal that is only meaningful while its instrument is on. See
+# labmon.gate.
+RECORD_WHEN_KEY = "record_when"
+
+# `for` is a Python keyword, so the parsed field is named `dwell_seconds`;
+# the TOML key stays `for` because that is how the setting reads.
+DWELL_KEY = "for"
+
+# Which stop threshold pairs with which resume threshold. Naming them
+# apart keeps a config from saying `above` and `resume_below`, which
+# would be two different gates in one table.
+_STOP_KEYS = {"above": True, "below": False}
+_RESUME_KEYS = {"above": "resume_above", "below": "resume_below"}
 
 # Free-form documentation about how a calibration was obtained. Read and
 # logged at startup, never written to InfluxDB, and excluded from the
@@ -233,6 +250,9 @@ class Calibration:
     conversion: Conversion
     store_input: bool = DEFAULT_STORE_INPUT
     provenance: Mapping[str, object] = NO_PROVENANCE
+    # None means record everything, which is the default: a gate is a
+    # deliberate decision to leave gaps in a series.
+    record_when: RecordingRule | None = None
 
     @functools.cached_property
     def calibration_id(self) -> str:
@@ -334,6 +354,7 @@ def _parse_channel(
         conversion=conversion,
         store_input=_optional_bool(where, fields, "store_input", default_store_input),
         provenance=_optional_provenance(where, fields),
+        record_when=_optional_recording_rule(where, fields, conversion),
     )
 
 
@@ -477,6 +498,126 @@ def _optional_provenance(
             + f" (a [channels.<name>.{PROVENANCE_KEY}] section)"
         )
     return MappingProxyType(dict(cast(dict[str, object], value)))
+
+
+def _optional_recording_rule(
+    where: Location, fields: dict[str, object], conversion: Conversion
+) -> RecordingRule | None:
+    """Parse a [channels.<name>.record_when] table, if there is one.
+
+    Everything checkable is checked here rather than on the first reading:
+    a threshold in the wrong dimension, a resume threshold on the side
+    that would flap, a misspelled key. A gate that silently does nothing
+    is worse than no gate, since it looks configured.
+    """
+    if RECORD_WHEN_KEY not in fields:
+        return None
+
+    entry = fields[RECORD_WHEN_KEY]
+    if not isinstance(entry, dict):
+        raise CalibrationError(
+            f"{where} key '{RECORD_WHEN_KEY}' must be a table"
+            + f" (a [channels.<name>.{RECORD_WHEN_KEY}] section)"
+        )
+    gate = cast(dict[str, object], entry)
+    gate_where = Location(where.path, f"{where.channel}.{RECORD_WHEN_KEY}")
+
+    stop_keys = [key for key in _STOP_KEYS if key in gate]
+    if len(stop_keys) > 1:
+        raise CalibrationError(
+            f"{gate_where} sets both 'above' and 'below'; a gate has one"
+            + " threshold, not both"
+        )
+    if not stop_keys:
+        raise CalibrationError(f"{gate_where} needs 'above' or 'below'")
+
+    stop_key = stop_keys[0]
+    resume_key = _RESUME_KEYS[stop_key]
+    known = {stop_key, resume_key, DWELL_KEY}
+    unknown = sorted(set(gate) - known)
+    if unknown:
+        wrong_pair = _RESUME_KEYS["below" if stop_key == "above" else "above"]
+        if wrong_pair in unknown:
+            raise CalibrationError(
+                f"{gate_where} sets '{wrong_pair}' alongside '{stop_key}';"
+                + f" '{resume_key}' goes with '{stop_key}'"
+            )
+        raise CalibrationError(
+            f"{gate_where} has unknown key {unknown[0]!r};"
+            + f" expected one of {', '.join(sorted(known))}"
+        )
+
+    value_unit = conversion.apply(ONE_VOLT).units
+    threshold = _require_comparable(gate_where, gate, stop_key, value_unit)
+    resume = (
+        _require_comparable(gate_where, gate, resume_key, value_unit)
+        if resume_key in gate
+        else threshold
+    )
+    _check_resume_side(gate_where, stop_key, threshold, resume)
+
+    return RecordingRule(
+        threshold=threshold,
+        resume_threshold=resume,
+        record_above=_STOP_KEYS[stop_key],
+        dwell_seconds=_optional_dwell(gate_where, gate),
+    )
+
+
+def _require_comparable(
+    where: Location, fields: dict[str, object], key: str, value_unit: pint.Unit
+) -> pint.Quantity:
+    """Read a threshold, rejecting one the channel's readings can't be compared to."""
+    quantity = _require_quantity(where, fields, key)
+    try:
+        # The result is discarded: this asks pint whether the comparison
+        # is meaningful at all, which is the whole point of a dimensioned
+        # threshold over a bare number.
+        _ = quantity.to(value_unit)
+    except pint.DimensionalityError as error:
+        raise CalibrationError(
+            f"{where} produces {value_unit:~}, so key '{key}' cannot be"
+            + f" '{quantity:~}'"
+        ) from error
+    return quantity
+
+
+def _check_resume_side(
+    where: Location, stop_key: str, threshold: pint.Quantity, resume: pint.Quantity
+) -> None:
+    """Reject a resume threshold on the wrong side of the stop threshold.
+
+    Between the two the gate would stop and immediately resume — the
+    flapping hysteresis exists to prevent.
+    """
+    # Compared as magnitudes in a common unit rather than as quantities,
+    # so "1000 uW" and "1 mW" order correctly.
+    resume_magnitude = float(resume.to(threshold.units).magnitude)
+    stop_magnitude = float(threshold.magnitude)
+
+    if stop_key == "above" and resume_magnitude < stop_magnitude:
+        raise CalibrationError(
+            f"{where} resumes at {resume:~} but stops below {threshold:~};"
+            + " a resume threshold must be at or above the stop threshold"
+        )
+    if stop_key == "below" and resume_magnitude > stop_magnitude:
+        raise CalibrationError(
+            f"{where} resumes at {resume:~} but stops above {threshold:~};"
+            + " a resume threshold must be at or below the stop threshold"
+        )
+
+
+def _optional_dwell(where: Location, fields: dict[str, object]) -> float:
+    """Read `for` as a duration in seconds, defaulting to no dwell."""
+    if DWELL_KEY not in fields:
+        return 0.0
+    dwell = _require_quantity(where, fields, DWELL_KEY)
+    try:
+        return float(dwell.to(ureg.second).magnitude)
+    except pint.DimensionalityError as error:
+        raise CalibrationError(
+            f"{where} key '{DWELL_KEY}' must be a duration, not '{dwell:~}'"
+        ) from error
 
 
 def _optional_bool(

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -42,7 +42,7 @@ from typing import Protocol, cast, override
 import pint
 from asteval import Interpreter
 
-from labmon.gate import RecordingRule
+from labmon.gate import StopRecordingRule
 
 ureg: pint.UnitRegistry = pint.UnitRegistry()
 
@@ -78,20 +78,33 @@ CALIBRATION_ID_LENGTH = 8
 # doesn't invent a new id (see _quantity_key).
 FINGERPRINT_SIGNIFICANT_DIGITS = 12
 
-# Optional per-channel table saying when a reading is worth recording,
-# for a signal that is only meaningful while its instrument is on. See
+# Optional per-channel table saying what stops a channel recording, for a
+# signal that is only meaningful while its instrument is on. See
 # labmon.gate.
-RECORD_WHEN_KEY = "record_when"
+STOP_RECORDING_WHEN_KEY = "stop_recording_when"
 
 # `for` is a Python keyword, so the parsed field is named `dwell_seconds`;
 # the TOML key stays `for` because that is how the setting reads.
 DWELL_KEY = "for"
 
-# Which stop threshold pairs with which resume threshold. Naming them
-# apart keeps a config from saying `above` and `resume_below`, which
-# would be two different gates in one table.
-_STOP_KEYS = {"above": True, "below": False}
-_RESUME_KEYS = {"above": "resume_above", "below": "resume_below"}
+# Compares the bounds against the voltage at the ADC input rather than
+# against the converted value.
+RAW_VOLTAGE_KEY = "raw_voltage"
+
+# The four bounds, in the order a valid table has to put them in:
+# recording stops outside the outer pair and resumes inside the inner one.
+_BOUND_KEYS = ("below", "resume_above", "resume_below", "above")
+
+# The two that stop recording; a table needs at least one of them.
+_STOP_KEYS = ("below", "above")
+
+# Which deadband widens which stop bound. A `resume_above` without a
+# `below` deadbands nothing, so it is a config error rather than a no-op.
+_RESUME_PARTNERS = {"resume_above": "below", "resume_below": "above"}
+
+# Stated in full whenever bounds are out of order, since the fix is
+# usually obvious once the required ordering is written down.
+_BAND_ORDER = "below <= resume_above < resume_below <= above"
 
 # Free-form documentation about how a calibration was obtained. Read and
 # logged at startup, never written to InfluxDB, and excluded from the
@@ -252,7 +265,7 @@ class Calibration:
     provenance: Mapping[str, object] = NO_PROVENANCE
     # None means record everything, which is the default: a gate is a
     # deliberate decision to leave gaps in a series.
-    record_when: RecordingRule | None = None
+    stop_recording_when: StopRecordingRule | None = None
 
     @functools.cached_property
     def calibration_id(self) -> str:
@@ -354,7 +367,7 @@ def _parse_channel(
         conversion=conversion,
         store_input=_optional_bool(where, fields, "store_input", default_store_input),
         provenance=_optional_provenance(where, fields),
-        record_when=_optional_recording_rule(where, fields, conversion),
+        stop_recording_when=_optional_stop_rule(where, fields, conversion),
     )
 
 
@@ -500,111 +513,150 @@ def _optional_provenance(
     return MappingProxyType(dict(cast(dict[str, object], value)))
 
 
-def _optional_recording_rule(
+def _optional_stop_rule(
     where: Location, fields: dict[str, object], conversion: Conversion
-) -> RecordingRule | None:
-    """Parse a [channels.<name>.record_when] table, if there is one.
+) -> StopRecordingRule | None:
+    """Parse a [channels.<name>.stop_recording_when] table, if there is one.
 
     Everything checkable is checked here rather than on the first reading:
-    a threshold in the wrong dimension, a resume threshold on the side
-    that would flap, a misspelled key. A gate that silently does nothing
-    is worse than no gate, since it looks configured.
+    a bound in the wrong dimension, a deadband on the side that would
+    flap, a misspelled key. A gate that silently does nothing is worse
+    than no gate, since it looks configured.
     """
-    if RECORD_WHEN_KEY not in fields:
+    if STOP_RECORDING_WHEN_KEY not in fields:
         return None
 
-    entry = fields[RECORD_WHEN_KEY]
+    entry = fields[STOP_RECORDING_WHEN_KEY]
     if not isinstance(entry, dict):
         raise CalibrationError(
-            f"{where} key '{RECORD_WHEN_KEY}' must be a table"
-            + f" (a [channels.<name>.{RECORD_WHEN_KEY}] section)"
+            f"{where} key '{STOP_RECORDING_WHEN_KEY}' must be a table"
+            + f" (a [channels.<name>.{STOP_RECORDING_WHEN_KEY}] section)"
         )
     gate = cast(dict[str, object], entry)
-    gate_where = Location(where.path, f"{where.channel}.{RECORD_WHEN_KEY}")
+    gate_where = Location(where.path, f"{where.channel}.{STOP_RECORDING_WHEN_KEY}")
 
-    stop_keys = [key for key in _STOP_KEYS if key in gate]
-    if len(stop_keys) > 1:
-        raise CalibrationError(
-            f"{gate_where} sets both 'above' and 'below'; a gate has one"
-            + " threshold, not both"
-        )
-    if not stop_keys:
-        raise CalibrationError(f"{gate_where} needs 'above' or 'below'")
+    _check_gate_keys(gate_where, gate)
 
-    stop_key = stop_keys[0]
-    resume_key = _RESUME_KEYS[stop_key]
-    known = {stop_key, resume_key, DWELL_KEY}
+    raw_voltage = _optional_bool(gate_where, gate, RAW_VOLTAGE_KEY, False)
+    # What the bounds are compared against, and how to say so in an error.
+    if raw_voltage:
+        reference = ureg.volt
+        subject = f"gates on the raw voltage in {reference:~}"
+    else:
+        reference = conversion.apply(ONE_VOLT).units
+        subject = f"produces {reference:~}"
+
+    bounds = {
+        key: _require_comparable(gate_where, gate, key, reference, subject)
+        for key in _BOUND_KEYS
+        if key in gate
+    }
+    rule = StopRecordingRule(
+        below=bounds.get("below"),
+        above=bounds.get("above"),
+        resume_above=bounds.get("resume_above"),
+        resume_below=bounds.get("resume_below"),
+        dwell_seconds=_optional_dwell(gate_where, gate),
+        raw_voltage=raw_voltage,
+    )
+    _check_band_order(gate_where, rule)
+    return rule
+
+
+def _check_gate_keys(where: Location, gate: dict[str, object]) -> None:
+    """Reject a table that names nothing to stop on, or names it wrongly."""
+    known = set(_BOUND_KEYS) | {DWELL_KEY, RAW_VOLTAGE_KEY}
     unknown = sorted(set(gate) - known)
     if unknown:
-        wrong_pair = _RESUME_KEYS["below" if stop_key == "above" else "above"]
-        if wrong_pair in unknown:
-            raise CalibrationError(
-                f"{gate_where} sets '{wrong_pair}' alongside '{stop_key}';"
-                + f" '{resume_key}' goes with '{stop_key}'"
-            )
         raise CalibrationError(
-            f"{gate_where} has unknown key {unknown[0]!r};"
+            f"{where} has unknown key {unknown[0]!r};"
             + f" expected one of {', '.join(sorted(known))}"
         )
 
-    value_unit = conversion.apply(ONE_VOLT).units
-    threshold = _require_comparable(gate_where, gate, stop_key, value_unit)
-    resume = (
-        _require_comparable(gate_where, gate, resume_key, value_unit)
-        if resume_key in gate
-        else threshold
-    )
-    _check_resume_side(gate_where, stop_key, threshold, resume)
+    if not any(key in gate for key in _STOP_KEYS):
+        raise CalibrationError(
+            f"{where} needs '{_STOP_KEYS[0]}' or '{_STOP_KEYS[1]}' (or both);"
+            + " without one, nothing would ever stop the recording"
+        )
 
-    return RecordingRule(
-        threshold=threshold,
-        resume_threshold=resume,
-        record_above=_STOP_KEYS[stop_key],
-        dwell_seconds=_optional_dwell(gate_where, gate),
-    )
+    for resume_key, stop_key in _RESUME_PARTNERS.items():
+        if resume_key in gate and stop_key not in gate:
+            raise CalibrationError(
+                f"{where} sets '{resume_key}' without '{stop_key}';"
+                + f" '{resume_key}' is the deadband on '{stop_key}',"
+                + " so on its own it deadbands nothing"
+            )
 
 
 def _require_comparable(
-    where: Location, fields: dict[str, object], key: str, value_unit: pint.Unit
+    where: Location,
+    fields: dict[str, object],
+    key: str,
+    reference: pint.Unit,
+    subject: str,
 ) -> pint.Quantity:
-    """Read a threshold, rejecting one the channel's readings can't be compared to."""
+    """Read a bound, rejecting one the gated quantity can't be compared to."""
     quantity = _require_quantity(where, fields, key)
     try:
         # The result is discarded: this asks pint whether the comparison
         # is meaningful at all, which is the whole point of a dimensioned
-        # threshold over a bare number.
-        _ = quantity.to(value_unit)
+        # bound over a bare number.
+        _ = quantity.to(reference)
     except pint.DimensionalityError as error:
         raise CalibrationError(
-            f"{where} produces {value_unit:~}, so key '{key}' cannot be"
-            + f" '{quantity:~}'"
+            f"{where} {subject}, so key '{key}' cannot be '{quantity:~}'"
         ) from error
     return quantity
 
 
-def _check_resume_side(
-    where: Location, stop_key: str, threshold: pint.Quantity, resume: pint.Quantity
-) -> None:
-    """Reject a resume threshold on the wrong side of the stop threshold.
+def _check_band_order(where: Location, rule: StopRecordingRule) -> None:
+    """Reject bounds that don't nest the resume band inside the stop band.
 
-    Between the two the gate would stop and immediately resume — the
-    flapping hysteresis exists to prevent.
+    Anywhere the two bands cross, the gate would stop and immediately
+    resume — the flapping a deadband exists to prevent — or, where the
+    stop bounds themselves cross, would never record at all.
     """
+    if rule.below is not None and rule.resume_above is not None:
+        _require_ordered(
+            where, ("below", rule.below), ("resume_above", rule.resume_above)
+        )
+    if rule.above is not None and rule.resume_below is not None:
+        _require_ordered(
+            where, ("resume_below", rule.resume_below), ("above", rule.above)
+        )
+
+    # The resume band has to have room in it. Named for the keys actually
+    # written, since either edge may be a stop bound standing in for a
+    # deadband the file never set.
+    floor, ceiling = rule.resume_floor, rule.resume_ceiling
+    if floor is None or ceiling is None:
+        return
+    floor_key = "below" if rule.resume_above is None else "resume_above"
+    ceiling_key = "above" if rule.resume_below is None else "resume_below"
+    _require_ordered(where, (floor_key, floor), (ceiling_key, ceiling), strict=True)
+
+
+def _require_ordered(
+    where: Location,
+    lower: tuple[str, pint.Quantity],
+    upper: tuple[str, pint.Quantity],
+    *,
+    strict: bool = False,
+) -> None:
+    """Check one adjacent pair of bounds, naming both if they are inverted."""
+    lower_key, lower_bound = lower
+    upper_key, upper_bound = upper
     # Compared as magnitudes in a common unit rather than as quantities,
     # so "1000 uW" and "1 mW" order correctly.
-    resume_magnitude = float(resume.to(threshold.units).magnitude)
-    stop_magnitude = float(threshold.magnitude)
-
-    if stop_key == "above" and resume_magnitude < stop_magnitude:
-        raise CalibrationError(
-            f"{where} resumes at {resume:~} but stops below {threshold:~};"
-            + " a resume threshold must be at or above the stop threshold"
-        )
-    if stop_key == "below" and resume_magnitude > stop_magnitude:
-        raise CalibrationError(
-            f"{where} resumes at {resume:~} but stops above {threshold:~};"
-            + " a resume threshold must be at or below the stop threshold"
-        )
+    low = float(lower_bound.to(upper_bound.units).magnitude)
+    high = float(upper_bound.magnitude)
+    if low < high or (low == high and not strict):
+        return
+    raise CalibrationError(
+        f"{where} has '{lower_key}' = {lower_bound:~} and"
+        + f" '{upper_key}' = {upper_bound:~};"
+        + f" the bounds must read {_BAND_ORDER}"
+    )
 
 
 def _optional_dwell(where: Location, fields: dict[str, object]) -> float:
@@ -616,7 +668,11 @@ def _optional_dwell(where: Location, fields: dict[str, object]) -> float:
         return float(dwell.to(ureg.second).magnitude)
     except pint.DimensionalityError as error:
         raise CalibrationError(
-            f"{where} key '{DWELL_KEY}' must be a duration, not '{dwell:~}'"
+            f"{where} key '{DWELL_KEY}' must be a duration, not '{dwell:~}'."
+            # '1m' is the one people reach for, and it is a metre. Worth
+            # saying outright rather than leaving a dimensionality error
+            # to be puzzled over.
+            + " Note that 'm' is metres; minutes are 'min'."
         ) from error
 
 

--- a/src/labmon/gate.py
+++ b/src/labmon/gate.py
@@ -2,14 +2,20 @@
 
 Some signals are only meaningful while their instrument is running. A
 photodiode watching a laser reads noise overnight; a gauge on a vented
-chamber reads atmosphere. Recorded at full rate those readings cost
-storage, stretch dashboard axes, and drag every average and alert
-threshold computed over the series.
+chamber reads atmosphere; a channel whose amplifier has railed reads the
+supply. Recorded at full rate those readings cost storage, stretch
+dashboard axes, and drag every average and alert threshold computed over
+the series.
 
-A gate is a per-channel threshold that suppresses them. The gap it leaves
-is the honest signal, and the transition is logged so the gap can be read:
-with the `logs` profile a flat trace says "laser off at 19:42" rather than
-"sensor died at some point last night".
+A rule here is a band the readings must stay inside. It is written as the
+conditions that *stop* recording — below a level, above a level, or both
+— because that is the decision being made: the interesting instrument
+state is the one being excluded. Everything between the bounds is
+recorded; anything outside them stops the channel until it comes back.
+
+The gap that leaves is the honest signal, and the transition is logged so
+the gap can be read: with the `logs` profile a flat trace says "laser off
+at 19:42" rather than "sensor died at some point last night".
 
 The two directions are deliberately asymmetric, because their costs are.
 Stopping wrongly loses real data, so it can be made conservative with a
@@ -31,43 +37,96 @@ logger: logging.Logger = logging.getLogger(__name__)
 _VALUE_DIGITS = 4
 
 
+def _above(value: pint.Quantity, limit: pint.Quantity) -> bool:
+    """Whether `value` is strictly above `limit`.
+
+    Converted to the limit's unit and compared as magnitudes, so a
+    reading arriving in W is gated correctly by a bound written in mW.
+    """
+    return float(value.to(limit.units).magnitude) > float(limit.magnitude)
+
+
+def _describe_band(floor: pint.Quantity | None, ceiling: pint.Quantity | None) -> str:
+    """Phrase a band for a log line, naming only the bounds it has."""
+    edges: list[str] = []
+    if floor is not None:
+        edges.append(f"above {floor:~}")
+    if ceiling is not None:
+        edges.append(f"below {ceiling:~}")
+    return " and ".join(edges)
+
+
 @dataclass(frozen=True)
-class RecordingRule:
-    """When a channel's readings are worth recording.
+class StopRecordingRule:
+    """The band a channel's readings must stay inside to be recorded.
 
-    `record_above` picks the direction: True records while the value is
-    above `threshold` (a photodiode), False while it is below (a pressure
-    gauge). `resume_threshold` equal to `threshold` means no hysteresis.
+    `below` and `above` are the levels that stop recording; either may be
+    absent, giving a one-sided rule. A reading is recorded while it sits
+    between them.
 
-    Both thresholds are dimensioned, so a comparison against a reading in
+    `resume_above` and `resume_below` bound the narrower band a reading
+    must come back into before recording restarts, each defaulting to the
+    stop level it deadbands. Written apart from the stop levels because
+    they answer a different question: how far back inside the band the
+    signal has to get before the instrument counts as on again.
+
+    `raw_voltage` gates on the voltage at the ADC input rather than on
+    the converted value, for a channel whose off state is better
+    recognised before the conversion — a railed amplifier, or a
+    conversion that is only characterised over part of the input range.
+
+    Every bound is dimensioned, so a comparison against a reading in
     another unit converts rather than silently comparing magnitudes.
     """
 
-    threshold: pint.Quantity
-    resume_threshold: pint.Quantity
-    record_above: bool
+    below: pint.Quantity | None = None
+    above: pint.Quantity | None = None
+    resume_above: pint.Quantity | None = None
+    resume_below: pint.Quantity | None = None
     dwell_seconds: float = 0.0
+    raw_voltage: bool = False
 
-    def _passes(self, value: pint.Quantity, limit: pint.Quantity) -> bool:
-        # Converted to the limit's unit and compared as magnitudes, so a
-        # reading arriving in W is gated correctly by a threshold in mW.
-        measured = float(value.to(limit.units).magnitude)
-        boundary = float(limit.magnitude)
-        return measured > boundary if self.record_above else measured < boundary
+    @property
+    def resume_floor(self) -> pint.Quantity | None:
+        """Lower edge of the resume band; `below` when there is no deadband."""
+        return self.below if self.resume_above is None else self.resume_above
 
-    def keeps_recording(self, value: pint.Quantity) -> bool:
-        """Whether a reading is on the recording side of the stop threshold."""
-        return self._passes(value, self.threshold)
+    @property
+    def resume_ceiling(self) -> pint.Quantity | None:
+        """Upper edge of the resume band; `above` when there is no deadband."""
+        return self.above if self.resume_below is None else self.resume_below
 
-    def starts_recording(self, value: pint.Quantity) -> bool:
-        """Whether a reading is far enough past the threshold to resume."""
-        return self._passes(value, self.resume_threshold)
+    @property
+    def resume_band(self) -> str:
+        """The resume band, phrased for the line that logs a resume."""
+        return _describe_band(self.resume_floor, self.resume_ceiling)
+
+    def breach(self, value: pint.Quantity) -> str | None:
+        """How a reading falls outside the recording band, or None if it doesn't.
+
+        Returns the phrase rather than a bare bool so the bound that was
+        crossed reaches the log without being worked out twice — on a
+        two-sided rule, "below 100 mV" and "above 3 V" are very different
+        faults to read about at 03:00.
+        """
+        if self.below is not None and not _above(value, self.below):
+            return _describe_band(None, self.below)
+        if self.above is not None and _above(value, self.above):
+            return _describe_band(self.above, None)
+        return None
+
+    def resumes(self, value: pint.Quantity) -> bool:
+        """Whether a reading is back inside the resume band."""
+        floor, ceiling = self.resume_floor, self.resume_ceiling
+        clears_floor = floor is None or _above(value, floor)
+        clears_ceiling = ceiling is None or not _above(value, ceiling)
+        return clears_floor and clears_ceiling
 
 
 class RecordingGate:
-    """Applies a `RecordingRule` over time, with its dwell and hysteresis.
+    """Applies a `StopRecordingRule` over time, with its dwell and deadband.
 
-    Stateful by nature — hysteresis is a memory of what happened last —
+    Stateful by nature — a deadband is a memory of what happened last —
     so the rule stays a frozen value and only the two things that
     genuinely change over time live here.
 
@@ -76,16 +135,22 @@ class RecordingGate:
     the whole asymmetry of this module.
     """
 
-    def __init__(self, rule: RecordingRule, sensor_id: str) -> None:
-        self._rule: RecordingRule = rule
+    def __init__(self, rule: StopRecordingRule, sensor_id: str) -> None:
+        self._rule: StopRecordingRule = rule
         self._sensor_id: str = sensor_id
         self._recording: bool = True
-        # When the value first fell to the wrong side, or None while it
-        # is on the right side. The dwell is measured from here.
+        # When the value first strayed outside the band, or None while it
+        # is inside. The dwell is measured from here.
         self._failing_since: float | None = None
 
-    def admits(self, value: pint.Quantity, now: float | None = None) -> bool:
+    def admits(
+        self, value: pint.Quantity, voltage: pint.Quantity, now: float | None = None
+    ) -> bool:
         """Whether this reading should be written, updating the gate's state.
+
+        Both quantities are passed because the rule decides which one it
+        gates on; picking here would put `raw_voltage` in the acquisition
+        loop, where it does not belong.
 
         `now` is injectable for tests; the sensor loop passes nothing and
         gets the monotonic clock, which is immune to the wall clock
@@ -94,44 +159,44 @@ class RecordingGate:
         if now is None:
             now = time.monotonic()
 
+        measured = voltage if self._rule.raw_voltage else value
         if self._recording:
-            return self._while_recording(value, now)
+            return self._while_recording(measured, now)
         # No `now`: resuming never consults the clock, which is the
         # asymmetry this module exists for.
-        return self._while_stopped(value)
+        return self._while_stopped(measured)
 
-    def _while_recording(self, value: pint.Quantity, now: float) -> bool:
-        if self._rule.keeps_recording(value):
-            # A dip that resolved: the clock restarts rather than
-            # accumulating across separate excursions.
+    def _while_recording(self, measured: pint.Quantity, now: float) -> bool:
+        breach = self._rule.breach(measured)
+        if breach is None:
+            # An excursion that resolved: the clock restarts rather than
+            # accumulating across separate ones.
             self._failing_since = None
             return True
 
         if self._failing_since is None:
             self._failing_since = now
         if now - self._failing_since < self._rule.dwell_seconds:
-            # Still inside the dwell, so keep recording. A brief dip
-            # costs nothing; stopping on it would lose real data.
+            # Still inside the dwell, so keep recording. A brief
+            # excursion costs nothing; stopping on it would lose real data.
             return True
 
         self._recording = False
-        self._log("recording stopped", value, self._rule.threshold)
+        self._log("recording stopped", measured, breach)
         return False
 
-    def _while_stopped(self, value: pint.Quantity) -> bool:
-        if not self._rule.starts_recording(value):
+    def _while_stopped(self, measured: pint.Quantity) -> bool:
+        if not self._rule.resumes(measured):
             return False
 
         self._recording = True
-        # A later drop serves the full dwell again rather than inheriting
-        # the clock that stopped it the first time.
+        # A later excursion serves the full dwell again rather than
+        # inheriting the clock that stopped it the first time.
         self._failing_since = None
-        self._log("recording resumed", value, self._rule.resume_threshold)
+        self._log("recording resumed", measured, self._rule.resume_band)
         return True
 
-    def _log(
-        self, message: str, value: pint.Quantity, threshold: pint.Quantity
-    ) -> None:
+    def _log(self, message: str, measured: pint.Quantity, limit: str) -> None:
         """Report a transition, never a reading.
 
         At 100 Hz a per-reading line would be unreadable, and the
@@ -141,8 +206,7 @@ class RecordingGate:
             message,
             extra={
                 "sensor_id": self._sensor_id,
-                "value": f"{value.magnitude:.{_VALUE_DIGITS}g} {value.units:~}",
-                "threshold": f"{threshold.magnitude:.{_VALUE_DIGITS}g}"
-                + f" {threshold.units:~}",
+                "value": f"{measured.magnitude:.{_VALUE_DIGITS}g} {measured.units:~}",
+                "limit": limit,
             },
         )

--- a/src/labmon/gate.py
+++ b/src/labmon/gate.py
@@ -37,13 +37,30 @@ logger: logging.Logger = logging.getLogger(__name__)
 _VALUE_DIGITS = 4
 
 
-def _above(value: pint.Quantity, limit: pint.Quantity) -> bool:
-    """Whether `value` is strictly above `limit`.
+def _magnitudes(value: pint.Quantity, limit: pint.Quantity) -> tuple[float, float]:
+    """The pair to compare, in the limit's unit.
 
-    Converted to the limit's unit and compared as magnitudes, so a
-    reading arriving in W is gated correctly by a bound written in mW.
+    Converting rather than comparing quantities directly is what lets a
+    reading arriving in W be gated by a bound written in mW.
     """
-    return float(value.to(limit.units).magnitude) > float(limit.magnitude)
+    return float(value.to(limit.units).magnitude), float(limit.magnitude)
+
+
+def _above(value: pint.Quantity, limit: pint.Quantity) -> bool:
+    """Whether `value` is strictly above `limit`."""
+    measured, boundary = _magnitudes(value, limit)
+    return measured > boundary
+
+
+def _below(value: pint.Quantity, limit: pint.Quantity) -> bool:
+    """Whether `value` is strictly below `limit`.
+
+    The mirror of `_above` rather than its negation: a reading sitting
+    exactly on a bound is neither above nor below it, which is what keeps
+    `below` and `above` meaning what they say at their own boundary.
+    """
+    measured, boundary = _magnitudes(value, limit)
+    return measured < boundary
 
 
 def _describe_band(floor: pint.Quantity | None, ceiling: pint.Quantity | None) -> str:
@@ -108,18 +125,28 @@ class StopRecordingRule:
         crossed reaches the log without being worked out twice — on a
         two-sided rule, "below 100 mV" and "above 3 V" are very different
         faults to read about at 03:00.
+
+        Both tests are strict, so each key means exactly what it says: a
+        reading of exactly 3 V is not above 3 V and does not stop a
+        channel bounded there.
         """
-        if self.below is not None and not _above(value, self.below):
+        if self.below is not None and _below(value, self.below):
             return _describe_band(None, self.below)
         if self.above is not None and _above(value, self.above):
             return _describe_band(self.above, None)
         return None
 
     def resumes(self, value: pint.Quantity) -> bool:
-        """Whether a reading is back inside the resume band."""
+        """Whether a reading is back inside the resume band.
+
+        Strict at both edges too, which leaves a reading sitting exactly
+        on a bound neither stopping nor resuming: the gate holds whatever
+        state it was in, rather than the two directions disagreeing about
+        who owns the boundary.
+        """
         floor, ceiling = self.resume_floor, self.resume_ceiling
         clears_floor = floor is None or _above(value, floor)
-        clears_ceiling = ceiling is None or not _above(value, ceiling)
+        clears_ceiling = ceiling is None or _below(value, ceiling)
         return clears_floor and clears_ceiling
 
 

--- a/src/labmon/gate.py
+++ b/src/labmon/gate.py
@@ -1,0 +1,148 @@
+"""Stop recording a signal while the instrument producing it is off.
+
+Some signals are only meaningful while their instrument is running. A
+photodiode watching a laser reads noise overnight; a gauge on a vented
+chamber reads atmosphere. Recorded at full rate those readings cost
+storage, stretch dashboard axes, and drag every average and alert
+threshold computed over the series.
+
+A gate is a per-channel threshold that suppresses them. The gap it leaves
+is the honest signal, and the transition is logged so the gap can be read:
+with the `logs` profile a flat trace says "laser off at 19:42" rather than
+"sensor died at some point last night".
+
+The two directions are deliberately asymmetric, because their costs are.
+Stopping wrongly loses real data, so it can be made conservative with a
+dwell. Resuming wrongly costs a handful of junk samples, so it is always
+immediate — waiting would swallow the turn-on transient, which is often
+the most interesting part of the trace.
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+
+import pint
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Digits kept when a transition reports the value that caused it. Enough
+# to recognise the reading, few enough to stay readable in a log line.
+_VALUE_DIGITS = 4
+
+
+@dataclass(frozen=True)
+class RecordingRule:
+    """When a channel's readings are worth recording.
+
+    `record_above` picks the direction: True records while the value is
+    above `threshold` (a photodiode), False while it is below (a pressure
+    gauge). `resume_threshold` equal to `threshold` means no hysteresis.
+
+    Both thresholds are dimensioned, so a comparison against a reading in
+    another unit converts rather than silently comparing magnitudes.
+    """
+
+    threshold: pint.Quantity
+    resume_threshold: pint.Quantity
+    record_above: bool
+    dwell_seconds: float = 0.0
+
+    def _passes(self, value: pint.Quantity, limit: pint.Quantity) -> bool:
+        # Converted to the limit's unit and compared as magnitudes, so a
+        # reading arriving in W is gated correctly by a threshold in mW.
+        measured = float(value.to(limit.units).magnitude)
+        boundary = float(limit.magnitude)
+        return measured > boundary if self.record_above else measured < boundary
+
+    def keeps_recording(self, value: pint.Quantity) -> bool:
+        """Whether a reading is on the recording side of the stop threshold."""
+        return self._passes(value, self.threshold)
+
+    def starts_recording(self, value: pint.Quantity) -> bool:
+        """Whether a reading is far enough past the threshold to resume."""
+        return self._passes(value, self.resume_threshold)
+
+
+class RecordingGate:
+    """Applies a `RecordingRule` over time, with its dwell and hysteresis.
+
+    Stateful by nature — hysteresis is a memory of what happened last —
+    so the rule stays a frozen value and only the two things that
+    genuinely change over time live here.
+
+    Starts out recording. A gate that has seen nothing yet has no reason
+    to believe the instrument is off, and erring towards keeping data is
+    the whole asymmetry of this module.
+    """
+
+    def __init__(self, rule: RecordingRule, sensor_id: str) -> None:
+        self._rule: RecordingRule = rule
+        self._sensor_id: str = sensor_id
+        self._recording: bool = True
+        # When the value first fell to the wrong side, or None while it
+        # is on the right side. The dwell is measured from here.
+        self._failing_since: float | None = None
+
+    def admits(self, value: pint.Quantity, now: float | None = None) -> bool:
+        """Whether this reading should be written, updating the gate's state.
+
+        `now` is injectable for tests; the sensor loop passes nothing and
+        gets the monotonic clock, which is immune to the wall clock
+        stepping mid-run.
+        """
+        if now is None:
+            now = time.monotonic()
+
+        if self._recording:
+            return self._while_recording(value, now)
+        # No `now`: resuming never consults the clock, which is the
+        # asymmetry this module exists for.
+        return self._while_stopped(value)
+
+    def _while_recording(self, value: pint.Quantity, now: float) -> bool:
+        if self._rule.keeps_recording(value):
+            # A dip that resolved: the clock restarts rather than
+            # accumulating across separate excursions.
+            self._failing_since = None
+            return True
+
+        if self._failing_since is None:
+            self._failing_since = now
+        if now - self._failing_since < self._rule.dwell_seconds:
+            # Still inside the dwell, so keep recording. A brief dip
+            # costs nothing; stopping on it would lose real data.
+            return True
+
+        self._recording = False
+        self._log("recording stopped", value, self._rule.threshold)
+        return False
+
+    def _while_stopped(self, value: pint.Quantity) -> bool:
+        if not self._rule.starts_recording(value):
+            return False
+
+        self._recording = True
+        # A later drop serves the full dwell again rather than inheriting
+        # the clock that stopped it the first time.
+        self._failing_since = None
+        self._log("recording resumed", value, self._rule.resume_threshold)
+        return True
+
+    def _log(
+        self, message: str, value: pint.Quantity, threshold: pint.Quantity
+    ) -> None:
+        """Report a transition, never a reading.
+
+        At 100 Hz a per-reading line would be unreadable, and the
+        transition is the event worth seeing anyway.
+        """
+        logger.info(
+            message,
+            extra={
+                "sensor_id": self._sensor_id,
+                "value": f"{value.magnitude:.{_VALUE_DIGITS}g} {value.units:~}",
+                "threshold": f"{threshold.magnitude:.{_VALUE_DIGITS}g}"
+                + f" {threshold.units:~}",
+            },
+        )

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -115,14 +115,14 @@ def run(
     # warn once each rather than on every reading forever.
     warned_channels: set[str] = set()
 
-    # One gate per channel, since each carries its own hysteresis state:
+    # One gate per channel, since each carries its own deadband state:
     # sharing one would let an instrument being off silence a channel
-    # that is still running. Channels without a `record_when` table are
-    # absent here and record everything.
+    # that is still running. Channels without a `stop_recording_when`
+    # table are absent here and record everything.
     gates = {
-        channel: RecordingGate(calibration.record_when, calibration.sensor_id)
+        channel: RecordingGate(calibration.stop_recording_when, calibration.sensor_id)
         for channel, calibration in calibrations.items()
-        if calibration.record_when is not None
+        if calibration.stop_recording_when is not None
     }
 
     while True:
@@ -144,7 +144,7 @@ def run(
         value = calibration.conversion.apply(voltage)
 
         gate = gates.get(reading.channel)
-        if gate is not None and not gate.admits(value):
+        if gate is not None and not gate.admits(value, voltage):
             # Nothing is written at all, not even input_volts: a
             # half-populated series is harder to read than a gap, and the
             # transition the gate logged is the evidence for the gap.

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -36,6 +36,7 @@ from labmon.calibration import (
     raw_to_voltage,
     ureg,
 )
+from labmon.gate import RecordingGate
 from labmon.influx import INFLUXDB_DATABASE
 from labmon.sensors.loop import SensorLoop
 from labmon.sensors.serial_source import (
@@ -114,6 +115,16 @@ def run(
     # warn once each rather than on every reading forever.
     warned_channels: set[str] = set()
 
+    # One gate per channel, since each carries its own hysteresis state:
+    # sharing one would let an instrument being off silence a channel
+    # that is still running. Channels without a `record_when` table are
+    # absent here and record everything.
+    gates = {
+        channel: RecordingGate(calibration.record_when, calibration.sensor_id)
+        for channel, calibration in calibrations.items()
+        if calibration.record_when is not None
+    }
+
     while True:
         reading = source.read()
         if reading is None:
@@ -131,6 +142,13 @@ def run(
 
         voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)
         value = calibration.conversion.apply(voltage)
+
+        gate = gates.get(reading.channel)
+        if gate is not None and not gate.admits(value):
+            # Nothing is written at all, not even input_volts: a
+            # half-populated series is harder to read than a gap, and the
+            # transition the gate logged is the evidence for the gap.
+            continue
 
         # The board has no clock, so the host stamps the reading on
         # arrival; serial transit is negligible next to sample rates here.

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -965,3 +965,193 @@ def test_unit_matches_what_a_reading_actually_carries() -> None:
     converted = calibration.conversion.apply(2.0 * ureg.volt)
 
     assert calibration.unit == f"{converted.units:~}"
+
+
+# --------------------------------------------------------------------------
+# record_when — the per-channel recording gate
+# --------------------------------------------------------------------------
+
+
+_GATED_CHANNEL = """
+[channels.A0]
+sensor_id = "laser-1"
+measurement = "power"
+conversion_factor = "50.0 mW / volt"
+
+[channels.A0.record_when]
+"""
+
+
+def test_a_channel_without_record_when_has_no_rule(tmp_path: Path) -> None:
+    """The gate is opt-in: an unconfigured channel records everything."""
+    channels = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "laser-1"
+            measurement = "power"
+            conversion_factor = "50.0 mW / volt"
+            """,
+        )
+    )
+
+    assert channels["A0"].record_when is None
+
+
+def test_above_records_while_the_value_is_above_it(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\n')
+    )
+    rule = channels["A0"].record_when
+
+    assert rule is not None
+    assert rule.record_above
+    assert rule.threshold == ureg("1.0 mW")
+    # No resume threshold given, so there is no deadband.
+    assert rule.resume_threshold == ureg("1.0 mW")
+    assert rule.dwell_seconds == 0.0
+
+
+def test_below_records_while_the_value_is_below_it(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'below = "1.0 mW"\n')
+    )
+    rule = channels["A0"].record_when
+
+    assert rule is not None
+    assert not rule.record_above
+
+
+def test_for_sets_the_dwell(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\nfor = "5 min"\n')
+    )
+    rule = channels["A0"].record_when
+
+    assert rule is not None
+    assert rule.dwell_seconds == 300.0
+
+
+def test_resume_above_sets_the_deadband(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(
+            tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\nresume_above = "10.0 mW"\n'
+        )
+    )
+    rule = channels["A0"].record_when
+
+    assert rule is not None
+    assert rule.resume_threshold == ureg("10.0 mW")
+
+
+def test_a_threshold_in_the_wrong_dimension_is_rejected(tmp_path: Path) -> None:
+    """The channel produces milliwatts; a threshold in kelvin cannot gate it."""
+    with pytest.raises(CalibrationError, match="produces mW"):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 kelvin"\n')
+        )
+
+
+def test_a_bare_number_is_rejected(tmp_path: Path) -> None:
+    """Dimensioned, so it cannot silently mean the wrong unit."""
+    with pytest.raises(CalibrationError, match="must be a string"):
+        _ = load_calibration(_write_config(tmp_path, _GATED_CHANNEL + "above = 1.0\n"))
+
+
+def test_record_when_needs_a_threshold(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="needs 'above' or 'below'"):
+        _ = load_calibration(_write_config(tmp_path, _GATED_CHANNEL + 'for = "30s"\n'))
+
+
+def test_above_and_below_together_are_rejected(tmp_path: Path) -> None:
+    """A band is a different feature; accepting both would guess which was meant."""
+    with pytest.raises(CalibrationError, match="not both"):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nbelow = "9 mW"\n')
+        )
+
+
+def test_a_mismatched_resume_key_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="'resume_below' goes with 'below'"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nresume_above = "9 mW"\n'
+            )
+        )
+
+
+def test_a_resume_threshold_on_the_wrong_side_is_rejected(tmp_path: Path) -> None:
+    """Below the stop threshold it would flap, which is what it exists to prevent."""
+    with pytest.raises(CalibrationError, match="at or above"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                _GATED_CHANNEL + 'above = "10.0 mW"\nresume_above = "1.0 mW"\n',
+            )
+        )
+
+
+def test_a_resume_threshold_below_the_stop_threshold_is_rejected(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(CalibrationError, match="at or below"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                _GATED_CHANNEL + 'below = "1.0 mW"\nresume_below = "10.0 mW"\n',
+            )
+        )
+
+
+def test_a_dwell_that_is_not_a_time_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="a duration"):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nfor = "30 mW"\n')
+        )
+
+
+def test_record_when_must_be_a_table(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="must be a table"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                """
+                [channels.A0]
+                sensor_id = "laser-1"
+                measurement = "power"
+                conversion_factor = "50.0 mW / volt"
+                record_when = "above 1 mW"
+                """,
+            )
+        )
+
+
+def test_an_unknown_key_in_record_when_is_rejected(tmp_path: Path) -> None:
+    """A typo'd 'resume' would otherwise silently mean no hysteresis at all."""
+    with pytest.raises(CalibrationError, match="unknown key"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nresume = "9 mW"\n'
+            )
+        )
+
+
+def test_the_gate_is_not_part_of_the_calibration_id(tmp_path: Path) -> None:
+    """Changing when to record does not change how a reading was converted."""
+    ungated = load_calibration(
+        _write_config(
+            tmp_path / "plain",
+            """
+            [channels.A0]
+            sensor_id = "laser-1"
+            measurement = "power"
+            conversion_factor = "50.0 mW / volt"
+            """,
+        )
+    )
+    gated = load_calibration(
+        _write_config(tmp_path / "gated", _GATED_CHANNEL + 'above = "1.0 mW"\n')
+    )
+
+    assert gated["A0"].calibration_id == ungated["A0"].calibration_id

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import cast
 
@@ -5,6 +6,7 @@ import pint
 import pytest
 
 from labmon.calibration import (
+    _BAND_ORDER,  # pyright: ignore[reportPrivateUsage]
     AffineConversion,
     Calibration,
     CalibrationError,
@@ -968,7 +970,7 @@ def test_unit_matches_what_a_reading_actually_carries() -> None:
 
 
 # --------------------------------------------------------------------------
-# record_when — the per-channel recording gate
+# stop_recording_when — the per-channel recording gate
 # --------------------------------------------------------------------------
 
 
@@ -978,11 +980,11 @@ sensor_id = "laser-1"
 measurement = "power"
 conversion_factor = "50.0 mW / volt"
 
-[channels.A0.record_when]
+[channels.A0.stop_recording_when]
 """
 
 
-def test_a_channel_without_record_when_has_no_rule(tmp_path: Path) -> None:
+def test_a_channel_without_stop_recording_when_has_no_rule(tmp_path: Path) -> None:
     """The gate is opt-in: an unconfigured channel records everything."""
     channels = load_calibration(
         _write_config(
@@ -996,110 +998,244 @@ def test_a_channel_without_record_when_has_no_rule(tmp_path: Path) -> None:
         )
     )
 
-    assert channels["A0"].record_when is None
+    assert channels["A0"].stop_recording_when is None
 
 
-def test_above_records_while_the_value_is_above_it(tmp_path: Path) -> None:
-    channels = load_calibration(
-        _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\n')
-    )
-    rule = channels["A0"].record_when
-
-    assert rule is not None
-    assert rule.record_above
-    assert rule.threshold == ureg("1.0 mW")
-    # No resume threshold given, so there is no deadband.
-    assert rule.resume_threshold == ureg("1.0 mW")
-    assert rule.dwell_seconds == 0.0
-
-
-def test_below_records_while_the_value_is_below_it(tmp_path: Path) -> None:
+def test_below_stops_recording_under_it(tmp_path: Path) -> None:
     channels = load_calibration(
         _write_config(tmp_path, _GATED_CHANNEL + 'below = "1.0 mW"\n')
     )
-    rule = channels["A0"].record_when
+    rule = channels["A0"].stop_recording_when
 
     assert rule is not None
-    assert not rule.record_above
+    assert rule.below == ureg("1.0 mW")
+    assert rule.above is None
+    # No deadband given, so the stop bound stands in for one.
+    assert rule.resume_floor == ureg("1.0 mW")
+    assert rule.resume_ceiling is None
+    assert rule.dwell_seconds == 0.0
+    assert not rule.raw_voltage
+
+
+def test_above_stops_recording_over_it(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'above = "9.0 mW"\n')
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.below is None
+    assert rule.above == ureg("9.0 mW")
+
+
+def test_both_bounds_make_a_band(tmp_path: Path) -> None:
+    """A channel can be meaningless at both ends: dark at one, railed at the other."""
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nabove = "9 mW"\n')
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.below == ureg("1 mW")
+    assert rule.above == ureg("9 mW")
 
 
 def test_for_sets_the_dwell(tmp_path: Path) -> None:
     channels = load_calibration(
-        _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\nfor = "5 min"\n')
+        _write_config(tmp_path, _GATED_CHANNEL + 'below = "1.0 mW"\nfor = "5 min"\n')
     )
-    rule = channels["A0"].record_when
+    rule = channels["A0"].stop_recording_when
 
     assert rule is not None
     assert rule.dwell_seconds == 300.0
 
 
-def test_resume_above_sets_the_deadband(tmp_path: Path) -> None:
+def test_resume_above_sets_the_deadband_on_below(tmp_path: Path) -> None:
     channels = load_calibration(
         _write_config(
-            tmp_path, _GATED_CHANNEL + 'above = "1.0 mW"\nresume_above = "10.0 mW"\n'
+            tmp_path, _GATED_CHANNEL + 'below = "1.0 mW"\nresume_above = "10.0 mW"\n'
         )
     )
-    rule = channels["A0"].record_when
+    rule = channels["A0"].stop_recording_when
 
     assert rule is not None
-    assert rule.resume_threshold == ureg("10.0 mW")
+    assert rule.resume_floor == ureg("10.0 mW")
 
 
-def test_a_threshold_in_the_wrong_dimension_is_rejected(tmp_path: Path) -> None:
-    """The channel produces milliwatts; a threshold in kelvin cannot gate it."""
+def test_resume_below_sets_the_deadband_on_above(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(
+            tmp_path, _GATED_CHANNEL + 'above = "10.0 mW"\nresume_below = "9.0 mW"\n'
+        )
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.resume_ceiling == ureg("9.0 mW")
+
+
+def test_raw_voltage_gates_before_the_conversion(tmp_path: Path) -> None:
+    """The bounds are then in volts, whatever the channel converts to."""
+    channels = load_calibration(
+        _write_config(
+            tmp_path,
+            _GATED_CHANNEL + 'raw_voltage = true\nbelow = "100 mV"\nabove = "3.0 V"\n',
+        )
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.raw_voltage
+    assert rule.below == ureg("100 mV")
+
+
+def test_raw_voltage_must_be_a_boolean(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="must be true or false"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path, _GATED_CHANNEL + 'raw_voltage = "yes"\nbelow = "1 mW"\n'
+            )
+        )
+
+
+def test_a_bound_in_the_wrong_dimension_is_rejected(tmp_path: Path) -> None:
+    """The channel produces milliwatts; a bound in kelvin cannot gate it."""
     with pytest.raises(CalibrationError, match="produces mW"):
         _ = load_calibration(
-            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1.0 kelvin"\n')
+            _write_config(tmp_path, _GATED_CHANNEL + 'below = "1.0 kelvin"\n')
+        )
+
+
+def test_a_raw_voltage_bound_must_be_a_voltage(tmp_path: Path) -> None:
+    """The channel's own unit is irrelevant once the gate reads the input."""
+    with pytest.raises(CalibrationError, match="gates on the raw voltage"):
+        _ = load_calibration(
+            _write_config(
+                tmp_path, _GATED_CHANNEL + 'raw_voltage = true\nbelow = "1.0 mW"\n'
+            )
         )
 
 
 def test_a_bare_number_is_rejected(tmp_path: Path) -> None:
     """Dimensioned, so it cannot silently mean the wrong unit."""
     with pytest.raises(CalibrationError, match="must be a string"):
-        _ = load_calibration(_write_config(tmp_path, _GATED_CHANNEL + "above = 1.0\n"))
+        _ = load_calibration(_write_config(tmp_path, _GATED_CHANNEL + "below = 1.0\n"))
 
 
-def test_record_when_needs_a_threshold(tmp_path: Path) -> None:
-    with pytest.raises(CalibrationError, match="needs 'above' or 'below'"):
+def test_stop_recording_when_needs_a_bound(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match="needs 'below' or 'above'"):
         _ = load_calibration(_write_config(tmp_path, _GATED_CHANNEL + 'for = "30s"\n'))
 
 
-def test_above_and_below_together_are_rejected(tmp_path: Path) -> None:
-    """A band is a different feature; accepting both would guess which was meant."""
-    with pytest.raises(CalibrationError, match="not both"):
-        _ = load_calibration(
-            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nbelow = "9 mW"\n')
-        )
-
-
-def test_a_mismatched_resume_key_is_rejected(tmp_path: Path) -> None:
-    with pytest.raises(CalibrationError, match="'resume_below' goes with 'below'"):
+def test_a_deadband_without_its_stop_bound_is_rejected(tmp_path: Path) -> None:
+    """Alone it deadbands nothing, so it reads as configured while doing nothing."""
+    with pytest.raises(CalibrationError, match="'resume_above' without 'below'"):
         _ = load_calibration(
             _write_config(
-                tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nresume_above = "9 mW"\n'
+                tmp_path, _GATED_CHANNEL + 'above = "9 mW"\nresume_above = "1 mW"\n'
             )
         )
 
 
-def test_a_resume_threshold_on_the_wrong_side_is_rejected(tmp_path: Path) -> None:
-    """Below the stop threshold it would flap, which is what it exists to prevent."""
-    with pytest.raises(CalibrationError, match="at or above"):
+def test_a_deadband_inside_its_own_stop_bound_is_rejected(tmp_path: Path) -> None:
+    """Below the level it deadbands, the gate would resume the moment it stopped."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
         _ = load_calibration(
             _write_config(
                 tmp_path,
-                _GATED_CHANNEL + 'above = "10.0 mW"\nresume_above = "1.0 mW"\n',
+                _GATED_CHANNEL + 'below = "10.0 mW"\nresume_above = "1.0 mW"\n',
             )
         )
 
 
-def test_a_resume_threshold_below_the_stop_threshold_is_rejected(
-    tmp_path: Path,
-) -> None:
-    with pytest.raises(CalibrationError, match="at or below"):
+def test_a_deadband_outside_its_own_stop_bound_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
         _ = load_calibration(
             _write_config(
                 tmp_path,
-                _GATED_CHANNEL + 'below = "1.0 mW"\nresume_below = "10.0 mW"\n',
+                _GATED_CHANNEL + 'above = "1.0 mW"\nresume_below = "10.0 mW"\n',
+            )
+        )
+
+
+def test_stop_bounds_that_leave_no_band_are_rejected(tmp_path: Path) -> None:
+    """Nothing is inside a band whose floor is above its ceiling."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'below = "9 mW"\nabove = "1 mW"\n')
+        )
+
+
+def test_a_band_of_zero_width_is_rejected(tmp_path: Path) -> None:
+    """Equal bounds are not a degenerate case to allow: nothing is inside them."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nabove = "1 mW"\n')
+        )
+
+
+def test_deadbands_that_meet_are_rejected(tmp_path: Path) -> None:
+    """A resume band with no width leaves nothing to come back into."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                _GATED_CHANNEL
+                + 'below = "1 mW"\nabove = "9 mW"\n'
+                + 'resume_above = "5 mW"\nresume_below = "5 mW"\n',
+            )
+        )
+
+
+def test_a_deadband_equal_to_its_stop_bound_is_accepted(tmp_path: Path) -> None:
+    """Which is exactly what an omitted deadband means, written out."""
+    channels = load_calibration(
+        _write_config(
+            tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nresume_above = "1 mW"\n'
+        )
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.resume_floor == ureg("1 mW")
+
+
+def test_deadbands_that_cross_each_other_are_rejected(tmp_path: Path) -> None:
+    """Individually inside their stop bounds, but with no room left to resume in."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                _GATED_CHANNEL
+                + 'below = "1 mW"\nabove = "9 mW"\n'
+                + 'resume_above = "8 mW"\nresume_below = "2 mW"\n',
+            )
+        )
+
+
+def test_a_full_ordering_is_accepted(tmp_path: Path) -> None:
+    """below <= resume_above < resume_below <= above, all four written out."""
+    channels = load_calibration(
+        _write_config(
+            tmp_path,
+            _GATED_CHANNEL
+            + 'below = "1 mW"\nresume_above = "2 mW"\n'
+            + 'resume_below = "8 mW"\nabove = "9 mW"\n',
+        )
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert (rule.resume_floor, rule.resume_ceiling) == (ureg("2 mW"), ureg("8 mW"))
+
+
+def test_bounds_are_ordered_across_units(tmp_path: Path) -> None:
+    """'1000 uW' and '1 mW' are the same level however they are written."""
+    with pytest.raises(CalibrationError, match=re.escape(_BAND_ORDER)):
+        _ = load_calibration(
+            _write_config(
+                tmp_path,
+                _GATED_CHANNEL + 'below = "1 mW"\nresume_above = "900 uW"\n',
             )
         )
 
@@ -1107,11 +1243,29 @@ def test_a_resume_threshold_below_the_stop_threshold_is_rejected(
 def test_a_dwell_that_is_not_a_time_is_rejected(tmp_path: Path) -> None:
     with pytest.raises(CalibrationError, match="a duration"):
         _ = load_calibration(
-            _write_config(tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nfor = "30 mW"\n')
+            _write_config(tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nfor = "30 mW"\n')
         )
 
 
-def test_record_when_must_be_a_table(tmp_path: Path) -> None:
+def test_a_dwell_written_as_1m_says_that_m_is_metres(tmp_path: Path) -> None:
+    """The obvious way to write one minute, and it parses as a length."""
+    with pytest.raises(CalibrationError, match="minutes are 'min'"):
+        _ = load_calibration(
+            _write_config(tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nfor = "1m"\n')
+        )
+
+
+def test_a_dwell_in_minutes_is_converted_to_seconds(tmp_path: Path) -> None:
+    channels = load_calibration(
+        _write_config(tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nfor = "1 min"\n')
+    )
+    rule = channels["A0"].stop_recording_when
+
+    assert rule is not None
+    assert rule.dwell_seconds == 60.0
+
+
+def test_stop_recording_when_must_be_a_table(tmp_path: Path) -> None:
     with pytest.raises(CalibrationError, match="must be a table"):
         _ = load_calibration(
             _write_config(
@@ -1121,18 +1275,18 @@ def test_record_when_must_be_a_table(tmp_path: Path) -> None:
                 sensor_id = "laser-1"
                 measurement = "power"
                 conversion_factor = "50.0 mW / volt"
-                record_when = "above 1 mW"
+                stop_recording_when = "below 1 mW"
                 """,
             )
         )
 
 
-def test_an_unknown_key_in_record_when_is_rejected(tmp_path: Path) -> None:
-    """A typo'd 'resume' would otherwise silently mean no hysteresis at all."""
+def test_an_unknown_key_in_stop_recording_when_is_rejected(tmp_path: Path) -> None:
+    """A typo'd 'resume' would otherwise silently mean no deadband at all."""
     with pytest.raises(CalibrationError, match="unknown key"):
         _ = load_calibration(
             _write_config(
-                tmp_path, _GATED_CHANNEL + 'above = "1 mW"\nresume = "9 mW"\n'
+                tmp_path, _GATED_CHANNEL + 'below = "1 mW"\nresume = "9 mW"\n'
             )
         )
 
@@ -1151,7 +1305,7 @@ def test_the_gate_is_not_part_of_the_calibration_id(tmp_path: Path) -> None:
         )
     )
     gated = load_calibration(
-        _write_config(tmp_path / "gated", _GATED_CHANNEL + 'above = "1.0 mW"\n')
+        _write_config(tmp_path / "gated", _GATED_CHANNEL + 'below = "1.0 mW"\n')
     )
 
     assert gated["A0"].calibration_id == ungated["A0"].calibration_id

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,216 @@
+import logging
+
+import pytest
+
+from labmon.calibration import ureg
+from labmon.gate import RecordingGate, RecordingRule
+
+
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
+def _rule(
+    *,
+    record_above: bool = True,
+    threshold: str = "1.0 mW",
+    resume: str | None = None,
+    dwell_seconds: float = 0.0,
+) -> RecordingRule:
+    return RecordingRule(
+        threshold=ureg(threshold),
+        resume_threshold=ureg(resume if resume is not None else threshold),
+        record_above=record_above,
+        dwell_seconds=dwell_seconds,
+    )
+
+
+def _gate(**kwargs: object) -> RecordingGate:
+    return RecordingGate(_rule(**kwargs), sensor_id="laser-1")  # pyright: ignore[reportArgumentType]
+
+
+# --------------------------------------------------------------------------
+# the threshold itself
+# --------------------------------------------------------------------------
+
+
+def test_a_reading_above_the_threshold_is_recorded() -> None:
+    gate = _gate()
+
+    assert gate.admits(ureg("5.0 mW"), now=0.0)
+
+
+def test_a_reading_below_the_threshold_is_not() -> None:
+    gate = _gate()
+
+    assert not gate.admits(ureg("0.2 mW"), now=0.0)
+
+
+def test_the_mirror_case_records_below_instead() -> None:
+    """A gauge on a vented chamber is meaningless *above* a pressure."""
+    gate = _gate(record_above=False, threshold="1e-3 mbar")
+
+    assert gate.admits(ureg("1e-7 mbar"), now=0.0)
+    assert not gate.admits(ureg("1.0 mbar"), now=0.0)
+
+
+def test_the_comparison_converts_units() -> None:
+    """A threshold in mW must gate a reading arriving in W."""
+    gate = _gate(threshold="1.0 mW")
+
+    assert gate.admits(ureg("0.005 W"), now=0.0)
+    assert not gate.admits(ureg("0.0002 W"), now=0.0)
+
+
+def test_a_gate_starts_out_recording() -> None:
+    """Erring towards keeping data: stopping is the decision that costs."""
+    gate = _gate(dwell_seconds=30.0)
+
+    # Below the threshold from the very first reading, but the dwell has
+    # not elapsed, so this is still recorded.
+    assert gate.admits(ureg("0.0 mW"), now=0.0)
+
+
+# --------------------------------------------------------------------------
+# dwell — conservative about stopping
+# --------------------------------------------------------------------------
+
+
+def test_a_brief_dip_does_not_stop_recording() -> None:
+    gate = _gate(dwell_seconds=30.0)
+
+    assert gate.admits(ureg("5.0 mW"), now=0.0)
+    assert gate.admits(ureg("0.1 mW"), now=10.0)
+    assert gate.admits(ureg("0.1 mW"), now=20.0)
+    assert gate.admits(ureg("5.0 mW"), now=25.0)
+    # The dip resolved, so the clock restarts: 40s is well past the dwell
+    # counted from t=10, and must not stop anything.
+    assert gate.admits(ureg("0.1 mW"), now=40.0)
+
+
+def test_a_sustained_drop_stops_recording_once_the_dwell_elapses() -> None:
+    gate = _gate(dwell_seconds=30.0)
+
+    assert gate.admits(ureg("0.1 mW"), now=100.0)
+    assert gate.admits(ureg("0.1 mW"), now=129.9)
+    assert not gate.admits(ureg("0.1 mW"), now=130.0)
+
+
+def test_without_a_dwell_the_first_low_reading_stops_it() -> None:
+    gate = _gate()
+
+    assert not gate.admits(ureg("0.1 mW"), now=0.0)
+
+
+# --------------------------------------------------------------------------
+# resume — eager
+# --------------------------------------------------------------------------
+
+
+def test_resuming_is_immediate_even_with_a_dwell() -> None:
+    """Waiting would swallow the turn-on transient, which is the interesting part."""
+    gate = _gate(dwell_seconds=30.0)
+
+    assert gate.admits(ureg("0.1 mW"), now=0.0)
+    assert not gate.admits(ureg("0.1 mW"), now=60.0)
+    assert gate.admits(ureg("5.0 mW"), now=61.0)
+
+
+def test_hysteresis_keeps_a_hovering_value_from_flapping() -> None:
+    gate = _gate(threshold="1.0 mW", resume="10.0 mW")
+
+    assert not gate.admits(ureg("0.9 mW"), now=0.0)
+    # Above the stop threshold but below the resume threshold: still off.
+    assert not gate.admits(ureg("5.0 mW"), now=1.0)
+    assert gate.admits(ureg("11.0 mW"), now=2.0)
+
+
+def test_without_a_resume_threshold_there_is_no_deadband() -> None:
+    gate = _gate(threshold="1.0 mW")
+
+    assert not gate.admits(ureg("0.9 mW"), now=0.0)
+    assert gate.admits(ureg("1.1 mW"), now=1.0)
+
+
+def test_the_dwell_clock_restarts_after_a_resume() -> None:
+    gate = _gate(dwell_seconds=30.0)
+
+    assert gate.admits(ureg("0.1 mW"), now=0.0)
+    assert not gate.admits(ureg("0.1 mW"), now=30.0)
+    assert gate.admits(ureg("5.0 mW"), now=31.0)
+    # A fresh drop must serve the full dwell again rather than inheriting
+    # the clock that stopped it the first time.
+    assert gate.admits(ureg("0.1 mW"), now=32.0)
+    assert not gate.admits(ureg("0.1 mW"), now=62.0)
+
+
+# --------------------------------------------------------------------------
+# transitions are logged, readings are not
+# --------------------------------------------------------------------------
+
+
+def test_stopping_logs_the_value_that_triggered_it(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = _gate()
+
+    with caplog.at_level(logging.INFO):
+        _ = gate.admits(ureg("0.2 mW"), now=0.0)
+
+    (record,) = caplog.records
+    assert record.message == "recording stopped"
+    assert _field(record, "sensor_id") == "laser-1"
+    assert "0.2" in str(_field(record, "value"))
+
+
+def test_resuming_logs_too(caplog: pytest.LogCaptureFixture) -> None:
+    gate = _gate()
+
+    with caplog.at_level(logging.INFO):
+        _ = gate.admits(ureg("0.2 mW"), now=0.0)
+        _ = gate.admits(ureg("5.0 mW"), now=1.0)
+
+    assert [record.message for record in caplog.records] == [
+        "recording stopped",
+        "recording resumed",
+    ]
+
+
+def test_a_steady_state_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    """At 100 Hz a per-reading line would be unreadable."""
+    gate = _gate()
+
+    with caplog.at_level(logging.INFO):
+        for tick in range(100):
+            _ = gate.admits(ureg("5.0 mW"), now=float(tick))
+
+    assert caplog.records == []
+
+
+def test_a_sustained_outage_logs_once_rather_than_per_reading(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = _gate()
+
+    with caplog.at_level(logging.INFO):
+        for tick in range(100):
+            _ = gate.admits(ureg("0.1 mW"), now=float(tick))
+
+    assert len(caplog.records) == 1
+
+
+# --------------------------------------------------------------------------
+# the clock
+# --------------------------------------------------------------------------
+
+
+def test_now_defaults_to_the_monotonic_clock() -> None:
+    """Callers in the sensor loop do not pass a time."""
+    gate = _gate(dwell_seconds=30.0)
+
+    assert gate.admits(ureg("0.1 mW"))

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -225,6 +225,64 @@ def test_a_two_sided_resume_needs_the_reading_inside_both_edges() -> None:
     assert not _admits(gate, "50 mV", now=3.0)
 
 
+def test_a_value_still_past_the_far_bound_does_not_resume() -> None:
+    """resume_above < resume_below < value is outside the resume band, not inside it."""
+    gate = RecordingGate(
+        _rule(below="100 mV", above="3.0 V", resume_below="2.9 V"),
+        sensor_id="quadrant-1",
+    )
+
+    assert not _admits(gate, "3.2 V", now=0.0)
+    # Still above the resume ceiling, whether or not it is back under the
+    # stop bound. Clearing the floor alone must not be enough.
+    assert not _admits(gate, "3.5 V", now=1.0)
+    assert not _admits(gate, "2.95 V", now=2.0)
+    assert _admits(gate, "2.85 V", now=3.0)
+
+
+def test_the_mirror_case_does_not_resume_under_the_resume_floor() -> None:
+    gate = _gate(below="1.0 mW", resume_above="10.0 mW")
+
+    assert not _admits(gate, "0.9 mW", now=0.0)
+    assert not _admits(gate, "0.1 mW", now=1.0)
+    assert not _admits(gate, "5.0 mW", now=2.0)
+    assert _admits(gate, "11.0 mW", now=3.0)
+
+
+# --------------------------------------------------------------------------
+# the bounds themselves are outside the band, in both directions
+# --------------------------------------------------------------------------
+
+
+def test_a_reading_exactly_on_a_stop_bound_keeps_recording() -> None:
+    """3 V is not above 3 V, and 1 mW is not below 1 mW."""
+    gate = RecordingGate(_rule(below="1.0 mW", above="3.0 mW"), sensor_id="quadrant-1")
+
+    assert _admits(gate, "3.0 mW", now=0.0)
+    assert _admits(gate, "1.0 mW", now=1.0)
+
+
+def test_a_reading_exactly_on_a_resume_bound_holds_the_gate_stopped() -> None:
+    """Neither direction owns the boundary, so the gate keeps its state."""
+    gate = _gate(below="1.0 mW", resume_above="10.0 mW")
+
+    assert not _admits(gate, "0.5 mW", now=0.0)
+    assert not _admits(gate, "10.0 mW", now=1.0)
+    assert _admits(gate, "10.001 mW", now=2.0)
+
+
+def test_the_boundary_convention_is_the_same_at_the_upper_edge() -> None:
+    """The mirror of the case above, which used to disagree with it."""
+    gate = RecordingGate(
+        _rule(below="100 mV", above="3.0 V", resume_below="2.9 V"),
+        sensor_id="quadrant-1",
+    )
+
+    assert not _admits(gate, "3.2 V", now=0.0)
+    assert not _admits(gate, "2.9 V", now=1.0)
+    assert _admits(gate, "2.899 V", now=2.0)
+
+
 def test_the_dwell_clock_restarts_after_a_resume() -> None:
     gate = _gate(dwell_seconds=30.0)
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from labmon.calibration import ureg
-from labmon.gate import RecordingGate, RecordingRule
+from labmon.gate import RecordingGate, StopRecordingRule
 
 
 def _field(record: logging.LogRecord, name: str) -> object:
@@ -17,63 +17,123 @@ def _field(record: logging.LogRecord, name: str) -> object:
 
 def _rule(
     *,
-    record_above: bool = True,
-    threshold: str = "1.0 mW",
-    resume: str | None = None,
+    below: str | None = None,
+    above: str | None = None,
+    resume_above: str | None = None,
+    resume_below: str | None = None,
     dwell_seconds: float = 0.0,
-) -> RecordingRule:
-    return RecordingRule(
-        threshold=ureg(threshold),
-        resume_threshold=ureg(resume if resume is not None else threshold),
-        record_above=record_above,
+    raw_voltage: bool = False,
+) -> StopRecordingRule:
+    return StopRecordingRule(
+        below=None if below is None else ureg(below),
+        above=None if above is None else ureg(above),
+        resume_above=None if resume_above is None else ureg(resume_above),
+        resume_below=None if resume_below is None else ureg(resume_below),
         dwell_seconds=dwell_seconds,
+        raw_voltage=raw_voltage,
     )
 
 
 def _gate(**kwargs: object) -> RecordingGate:
+    """A gate on a photodiode, stopping below 1 mW unless told otherwise."""
+    _ = kwargs.setdefault("below", "1.0 mW")
     return RecordingGate(_rule(**kwargs), sensor_id="laser-1")  # pyright: ignore[reportArgumentType]
 
 
+def _admits(
+    gate: RecordingGate, value: str, now: float, voltage: str = "0.0 V"
+) -> bool:
+    return gate.admits(ureg(value), ureg(voltage), now=now)
+
+
 # --------------------------------------------------------------------------
-# the threshold itself
+# the bounds themselves
 # --------------------------------------------------------------------------
 
 
-def test_a_reading_above_the_threshold_is_recorded() -> None:
+def test_a_reading_inside_the_band_is_recorded() -> None:
     gate = _gate()
 
-    assert gate.admits(ureg("5.0 mW"), now=0.0)
+    assert _admits(gate, "5.0 mW", now=0.0)
 
 
-def test_a_reading_below_the_threshold_is_not() -> None:
+def test_a_reading_below_the_lower_bound_is_not() -> None:
     gate = _gate()
 
-    assert not gate.admits(ureg("0.2 mW"), now=0.0)
+    assert not _admits(gate, "0.2 mW", now=0.0)
 
 
-def test_the_mirror_case_records_below_instead() -> None:
+def test_the_mirror_case_stops_above_instead() -> None:
     """A gauge on a vented chamber is meaningless *above* a pressure."""
-    gate = _gate(record_above=False, threshold="1e-3 mbar")
+    gate = RecordingGate(_rule(above="1e-3 mbar"), sensor_id="chamber-1")
 
-    assert gate.admits(ureg("1e-7 mbar"), now=0.0)
-    assert not gate.admits(ureg("1.0 mbar"), now=0.0)
+    assert _admits(gate, "1e-7 mbar", now=0.0)
+    assert not _admits(gate, "1.0 mbar", now=0.0)
+
+
+def test_both_bounds_make_a_band_recording_has_to_stay_inside() -> None:
+    gate = RecordingGate(_rule(below="100 mV", above="3.0 V"), sensor_id="quadrant-1")
+
+    assert _admits(gate, "1.5 V", now=0.0)
+    assert not _admits(gate, "50 mV", now=1.0)
+
+
+def test_a_two_sided_band_stops_at_its_upper_bound_too() -> None:
+    """A railed amplifier is as much an outage as a dark photodiode."""
+    gate = RecordingGate(_rule(below="100 mV", above="3.0 V"), sensor_id="quadrant-1")
+
+    assert not _admits(gate, "3.2 V", now=0.0)
 
 
 def test_the_comparison_converts_units() -> None:
-    """A threshold in mW must gate a reading arriving in W."""
-    gate = _gate(threshold="1.0 mW")
+    """A bound in mW must gate a reading arriving in W."""
+    gate = _gate(below="1.0 mW")
 
-    assert gate.admits(ureg("0.005 W"), now=0.0)
-    assert not gate.admits(ureg("0.0002 W"), now=0.0)
+    assert _admits(gate, "0.005 W", now=0.0)
+    assert not _admits(gate, "0.0002 W", now=0.0)
 
 
 def test_a_gate_starts_out_recording() -> None:
     """Erring towards keeping data: stopping is the decision that costs."""
     gate = _gate(dwell_seconds=30.0)
 
-    # Below the threshold from the very first reading, but the dwell has
-    # not elapsed, so this is still recorded.
-    assert gate.admits(ureg("0.0 mW"), now=0.0)
+    # Outside the band from the very first reading, but the dwell has not
+    # elapsed, so this is still recorded.
+    assert _admits(gate, "0.0 mW", now=0.0)
+
+
+# --------------------------------------------------------------------------
+# raw_voltage — gating before the conversion
+# --------------------------------------------------------------------------
+
+
+def test_raw_voltage_gates_on_the_voltage_not_the_value() -> None:
+    gate = RecordingGate(_rule(above="3.0 V", raw_voltage=True), sensor_id="quadrant-1")
+
+    # The converted value is far outside a millivolt band; only the
+    # voltage is consulted, and 1.5 V is comfortably inside.
+    assert _admits(gate, "500 mW", now=0.0, voltage="1.5 V")
+    assert not _admits(gate, "500 mW", now=1.0, voltage="3.2 V")
+
+
+def test_without_raw_voltage_the_voltage_is_ignored() -> None:
+    gate = _gate(below="1.0 mW")
+
+    # A voltage that would breach a volt-denominated bound, alongside a
+    # value that is fine: the value is what this rule gates on.
+    assert _admits(gate, "5.0 mW", now=0.0, voltage="0.0 V")
+
+
+def test_raw_voltage_reports_the_voltage_in_the_transition(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = RecordingGate(_rule(above="3.0 V", raw_voltage=True), sensor_id="quadrant-1")
+
+    with caplog.at_level(logging.INFO):
+        _ = _admits(gate, "500 mW", now=0.0, voltage="3.2 V")
+
+    (record,) = caplog.records
+    assert "3.2 V" in str(_field(record, "value"))
 
 
 # --------------------------------------------------------------------------
@@ -84,27 +144,41 @@ def test_a_gate_starts_out_recording() -> None:
 def test_a_brief_dip_does_not_stop_recording() -> None:
     gate = _gate(dwell_seconds=30.0)
 
-    assert gate.admits(ureg("5.0 mW"), now=0.0)
-    assert gate.admits(ureg("0.1 mW"), now=10.0)
-    assert gate.admits(ureg("0.1 mW"), now=20.0)
-    assert gate.admits(ureg("5.0 mW"), now=25.0)
+    assert _admits(gate, "5.0 mW", now=0.0)
+    assert _admits(gate, "0.1 mW", now=10.0)
+    assert _admits(gate, "0.1 mW", now=20.0)
+    assert _admits(gate, "5.0 mW", now=25.0)
     # The dip resolved, so the clock restarts: 40s is well past the dwell
     # counted from t=10, and must not stop anything.
-    assert gate.admits(ureg("0.1 mW"), now=40.0)
+    assert _admits(gate, "0.1 mW", now=40.0)
 
 
 def test_a_sustained_drop_stops_recording_once_the_dwell_elapses() -> None:
     gate = _gate(dwell_seconds=30.0)
 
-    assert gate.admits(ureg("0.1 mW"), now=100.0)
-    assert gate.admits(ureg("0.1 mW"), now=129.9)
-    assert not gate.admits(ureg("0.1 mW"), now=130.0)
+    assert _admits(gate, "0.1 mW", now=100.0)
+    assert _admits(gate, "0.1 mW", now=129.9)
+    assert not _admits(gate, "0.1 mW", now=130.0)
 
 
-def test_without_a_dwell_the_first_low_reading_stops_it() -> None:
+def test_the_dwell_spans_an_excursion_that_changes_side() -> None:
+    """Outside the band is outside the band, whichever bound it left by."""
+    gate = RecordingGate(
+        _rule(below="100 mV", above="3.0 V", dwell_seconds=30.0),
+        sensor_id="quadrant-1",
+    )
+
+    assert _admits(gate, "3.2 V", now=0.0)
+    assert _admits(gate, "50 mV", now=20.0)
+    # Never back inside the band, so the dwell runs from t=0 rather than
+    # restarting when the reading crossed to the other side.
+    assert not _admits(gate, "50 mV", now=30.0)
+
+
+def test_without_a_dwell_the_first_reading_outside_stops_it() -> None:
     gate = _gate()
 
-    assert not gate.admits(ureg("0.1 mW"), now=0.0)
+    assert not _admits(gate, "0.1 mW", now=0.0)
 
 
 # --------------------------------------------------------------------------
@@ -116,37 +190,51 @@ def test_resuming_is_immediate_even_with_a_dwell() -> None:
     """Waiting would swallow the turn-on transient, which is the interesting part."""
     gate = _gate(dwell_seconds=30.0)
 
-    assert gate.admits(ureg("0.1 mW"), now=0.0)
-    assert not gate.admits(ureg("0.1 mW"), now=60.0)
-    assert gate.admits(ureg("5.0 mW"), now=61.0)
+    assert _admits(gate, "0.1 mW", now=0.0)
+    assert not _admits(gate, "0.1 mW", now=60.0)
+    assert _admits(gate, "5.0 mW", now=61.0)
 
 
-def test_hysteresis_keeps_a_hovering_value_from_flapping() -> None:
-    gate = _gate(threshold="1.0 mW", resume="10.0 mW")
+def test_a_deadband_keeps_a_hovering_value_from_flapping() -> None:
+    gate = _gate(below="1.0 mW", resume_above="10.0 mW")
 
-    assert not gate.admits(ureg("0.9 mW"), now=0.0)
-    # Above the stop threshold but below the resume threshold: still off.
-    assert not gate.admits(ureg("5.0 mW"), now=1.0)
-    assert gate.admits(ureg("11.0 mW"), now=2.0)
+    assert not _admits(gate, "0.9 mW", now=0.0)
+    # Back above the stop bound but below the resume bound: still off.
+    assert not _admits(gate, "5.0 mW", now=1.0)
+    assert _admits(gate, "11.0 mW", now=2.0)
 
 
-def test_without_a_resume_threshold_there_is_no_deadband() -> None:
-    gate = _gate(threshold="1.0 mW")
+def test_without_a_deadband_the_stop_bound_is_reused() -> None:
+    gate = _gate(below="1.0 mW")
 
-    assert not gate.admits(ureg("0.9 mW"), now=0.0)
-    assert gate.admits(ureg("1.1 mW"), now=1.0)
+    assert not _admits(gate, "0.9 mW", now=0.0)
+    assert _admits(gate, "1.1 mW", now=1.0)
+
+
+def test_a_two_sided_resume_needs_the_reading_inside_both_edges() -> None:
+    gate = RecordingGate(
+        _rule(below="100 mV", above="3.0 V", resume_below="2.9 V"),
+        sensor_id="quadrant-1",
+    )
+
+    assert not _admits(gate, "3.2 V", now=0.0)
+    # Under the stop bound but not yet under the resume bound.
+    assert not _admits(gate, "2.95 V", now=1.0)
+    assert _admits(gate, "2.5 V", now=2.0)
+    # And the other edge still applies once recording again.
+    assert not _admits(gate, "50 mV", now=3.0)
 
 
 def test_the_dwell_clock_restarts_after_a_resume() -> None:
     gate = _gate(dwell_seconds=30.0)
 
-    assert gate.admits(ureg("0.1 mW"), now=0.0)
-    assert not gate.admits(ureg("0.1 mW"), now=30.0)
-    assert gate.admits(ureg("5.0 mW"), now=31.0)
+    assert _admits(gate, "0.1 mW", now=0.0)
+    assert not _admits(gate, "0.1 mW", now=30.0)
+    assert _admits(gate, "5.0 mW", now=31.0)
     # A fresh drop must serve the full dwell again rather than inheriting
     # the clock that stopped it the first time.
-    assert gate.admits(ureg("0.1 mW"), now=32.0)
-    assert not gate.admits(ureg("0.1 mW"), now=62.0)
+    assert _admits(gate, "0.1 mW", now=32.0)
+    assert not _admits(gate, "0.1 mW", now=62.0)
 
 
 # --------------------------------------------------------------------------
@@ -154,31 +242,63 @@ def test_the_dwell_clock_restarts_after_a_resume() -> None:
 # --------------------------------------------------------------------------
 
 
-def test_stopping_logs_the_value_that_triggered_it(
+def test_stopping_logs_the_value_and_the_bound_it_crossed(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     gate = _gate()
 
     with caplog.at_level(logging.INFO):
-        _ = gate.admits(ureg("0.2 mW"), now=0.0)
+        _ = _admits(gate, "0.2 mW", now=0.0)
 
     (record,) = caplog.records
     assert record.message == "recording stopped"
     assert _field(record, "sensor_id") == "laser-1"
     assert "0.2" in str(_field(record, "value"))
+    assert _field(record, "limit") == "below 1.0 mW"
 
 
-def test_resuming_logs_too(caplog: pytest.LogCaptureFixture) -> None:
-    gate = _gate()
+def test_a_two_sided_gate_names_which_bound_stopped_it(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """'below 100 mV' and 'above 3 V' are very different faults to read about."""
+    gate = RecordingGate(_rule(below="100 mV", above="3.0 V"), sensor_id="quadrant-1")
 
     with caplog.at_level(logging.INFO):
-        _ = gate.admits(ureg("0.2 mW"), now=0.0)
-        _ = gate.admits(ureg("5.0 mW"), now=1.0)
+        _ = _admits(gate, "3.2 V", now=0.0)
 
-    assert [record.message for record in caplog.records] == [
-        "recording stopped",
-        "recording resumed",
-    ]
+    (record,) = caplog.records
+    assert _field(record, "limit") == "above 3.0 V"
+
+
+def test_resuming_logs_the_band_it_came_back_into(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = _gate(below="1.0 mW", resume_above="10.0 mW")
+
+    with caplog.at_level(logging.INFO):
+        _ = _admits(gate, "0.2 mW", now=0.0)
+        _ = _admits(gate, "11.0 mW", now=1.0)
+
+    stopped, resumed = caplog.records
+    assert stopped.message == "recording stopped"
+    assert resumed.message == "recording resumed"
+    assert _field(resumed, "limit") == "above 10.0 mW"
+
+
+def test_a_two_sided_resume_band_names_both_edges(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = RecordingGate(
+        _rule(below="100 mV", above="3.0 V", resume_below="2.9 V"),
+        sensor_id="quadrant-1",
+    )
+
+    with caplog.at_level(logging.INFO):
+        _ = _admits(gate, "3.2 V", now=0.0)
+        _ = _admits(gate, "2.5 V", now=1.0)
+
+    _, resumed = caplog.records
+    assert _field(resumed, "limit") == "above 100 mV and below 2.9 V"
 
 
 def test_a_steady_state_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
@@ -187,7 +307,7 @@ def test_a_steady_state_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
 
     with caplog.at_level(logging.INFO):
         for tick in range(100):
-            _ = gate.admits(ureg("5.0 mW"), now=float(tick))
+            _ = _admits(gate, "5.0 mW", now=float(tick))
 
     assert caplog.records == []
 
@@ -199,7 +319,7 @@ def test_a_sustained_outage_logs_once_rather_than_per_reading(
 
     with caplog.at_level(logging.INFO):
         for tick in range(100):
-            _ = gate.admits(ureg("0.1 mW"), now=float(tick))
+            _ = _admits(gate, "0.1 mW", now=float(tick))
 
     assert len(caplog.records) == 1
 
@@ -213,4 +333,4 @@ def test_now_defaults_to_the_monotonic_clock() -> None:
     """Callers in the sensor loop do not pass a time."""
     gate = _gate(dwell_seconds=30.0)
 
-    assert gate.admits(ureg("0.1 mW"))
+    assert gate.admits(ureg("0.1 mW"), ureg("0.0 V"))

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -10,7 +10,7 @@ import pytest
 from influxdb_client_3 import Point
 
 from labmon.calibration import Calibration, LinearConversion, ureg
-from labmon.gate import RecordingRule
+from labmon.gate import StopRecordingRule
 from labmon.sensors import loop as sensor_loop
 from labmon.sensors import serial_sensor
 from labmon.sensors.serial_sensor import main, run
@@ -433,16 +433,13 @@ def test_an_unknown_log_level_is_rejected(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def _gated_calibration(dwell_seconds: float = 0.0) -> Calibration:
-    """A photodiode reading 42.5 mW per volt, gated below 1 mW."""
+    """A photodiode reading 42.5 mW per volt, stopping below 1 mW."""
     return Calibration(
         sensor_id="laser-1",
         measurement="power",
         conversion=LinearConversion(factor=ureg("42.5 mW / volt")),
-        record_when=RecordingRule(
-            threshold=ureg("1.0 mW"),
-            resume_threshold=ureg("1.0 mW"),
-            record_above=True,
-            dwell_seconds=dwell_seconds,
+        stop_recording_when=StopRecordingRule(
+            below=ureg("1.0 mW"), dwell_seconds=dwell_seconds
         ),
     )
 
@@ -450,7 +447,7 @@ def _gated_calibration(dwell_seconds: float = 0.0) -> Calibration:
 def test_a_gated_out_reading_is_not_written(
     fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
 ) -> None:
-    # Count 1 is ~0.8 mV, so ~0.035 mW — well below the 1 mW threshold.
+    # Count 1 is ~0.8 mV, so ~0.035 mW — well below the 1 mW bound.
     source = FakeRawSource([RawReading(channel="A0", raw_count=1)])
 
     with pytest.raises(_StopLoop):
@@ -463,7 +460,7 @@ def test_a_gated_out_reading_is_not_written(
     assert fake_client.batches == []
 
 
-def test_a_reading_above_the_threshold_still_reaches_influx(
+def test_a_reading_inside_the_band_still_reaches_influx(
     fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
 ) -> None:
     source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
@@ -547,6 +544,28 @@ def test_the_transition_names_the_sensor_that_stopped(
 
     [stopped] = [r for r in caplog.records if r.message == "recording stopped"]
     assert _field(stopped, "sensor_id") == "laser-1"
+
+
+def test_a_raw_voltage_gate_sees_the_voltage_the_loop_measured(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """Count 4095 is 3.3 V, which is outside the band whatever it converts to."""
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+    calibration = Calibration(
+        sensor_id="quadrant-1",
+        measurement="position",
+        conversion=LinearConversion(factor=ureg("42.5 mW / volt")),
+        stop_recording_when=StopRecordingRule(above=ureg("3.0 V"), raw_voltage=True),
+    )
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": calibration})
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    assert fake_client.batches == []
 
 
 def test_each_channel_gets_its_own_gate_state(

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -10,6 +10,7 @@ import pytest
 from influxdb_client_3 import Point
 
 from labmon.calibration import Calibration, LinearConversion, ureg
+from labmon.gate import RecordingRule
 from labmon.sensors import loop as sensor_loop
 from labmon.sensors import serial_sensor
 from labmon.sensors.serial_sensor import main, run
@@ -424,3 +425,150 @@ def test_an_unknown_log_level_is_rejected(monkeypatch: pytest.MonkeyPatch) -> No
         main()
 
     assert exit_info.value.code == 2
+
+
+# --------------------------------------------------------------------------
+# the recording gate
+# --------------------------------------------------------------------------
+
+
+def _gated_calibration(dwell_seconds: float = 0.0) -> Calibration:
+    """A photodiode reading 42.5 mW per volt, gated below 1 mW."""
+    return Calibration(
+        sensor_id="laser-1",
+        measurement="power",
+        conversion=LinearConversion(factor=ureg("42.5 mW / volt")),
+        record_when=RecordingRule(
+            threshold=ureg("1.0 mW"),
+            resume_threshold=ureg("1.0 mW"),
+            record_above=True,
+            dwell_seconds=dwell_seconds,
+        ),
+    )
+
+
+def test_a_gated_out_reading_is_not_written(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # Count 1 is ~0.8 mV, so ~0.035 mW — well below the 1 mW threshold.
+    source = FakeRawSource([RawReading(channel="A0", raw_count=1)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _gated_calibration()})
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    assert fake_client.batches == []
+
+
+def test_a_reading_above_the_threshold_still_reaches_influx(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _gated_calibration()})
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    assert len(batch) == 1
+
+
+def test_a_gated_channel_leaves_an_ungated_one_alone(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """The gate is per channel, so one instrument going off silences only itself."""
+    source = FakeRawSource(
+        [
+            RawReading(channel="A0", raw_count=1),
+            RawReading(channel="A1", raw_count=1),
+        ]
+    )
+
+    with pytest.raises(_StopLoop):
+        run(
+            source=source,
+            calibrations={
+                "A0": _gated_calibration(),
+                "A1": _temperature_calibration(),
+            },
+        )
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "sensor_id=cryo-77k" in point.to_line_protocol()
+
+
+@pytest.mark.usefixtures("fake_client")
+def test_a_gated_out_reading_is_not_counted_in_the_summary(
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The summary reports what was written; a gap must not read as activity."""
+    monkeypatch.setattr(sensor_loop, "SUMMARY_INTERVAL_SECONDS", 0.0)
+    source = FakeRawSource([RawReading(channel="A0", raw_count=1)])
+
+    with caplog.at_level(logging.INFO), pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _gated_calibration()})
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    assert [
+        record for record in caplog.records if record.message == "wrote readings"
+    ] == []
+
+
+@pytest.mark.usefixtures("fake_client")
+def test_the_transition_names_the_sensor_that_stopped(
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The log line is what makes the gap in the trace interpretable."""
+    source = FakeRawSource([RawReading(channel="A0", raw_count=1)])
+
+    with caplog.at_level(logging.INFO), pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _gated_calibration()})
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    [stopped] = [r for r in caplog.records if r.message == "recording stopped"]
+    assert _field(stopped, "sensor_id") == "laser-1"
+
+
+def test_each_channel_gets_its_own_gate_state(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """Two gated channels sharing one gate would have one silence the other."""
+    source = FakeRawSource(
+        [
+            RawReading(channel="A0", raw_count=1),
+            RawReading(channel="A1", raw_count=4095),
+        ]
+    )
+
+    with pytest.raises(_StopLoop):
+        run(
+            source=source,
+            calibrations={"A0": _gated_calibration(), "A1": _gated_calibration()},
+        )
+
+    shutdown = registered_handlers[signal.SIGINT]
+    with pytest.raises(SystemExit):
+        shutdown(signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    assert len(batch) == 1


### PR DESCRIPTION
Closes #56. Stacked on #75 (`feat/structured-sensor-logging`), whose logfmt fields the transition lines use.

## The problem

Some signals are only meaningful while the instrument producing them is running. A photodiode watching a laser reads noise overnight; a gauge on a vented chamber reads atmosphere; a channel whose amplifier has railed reads the supply. Recorded at full rate those readings cost storage, stretch dashboard axes, and drag every average and alert threshold computed over the series.

## The shape

An optional `stop_recording_when` table on any channel:

```toml
[channels.A3]
sensor_id = "laser-1"
measurement = "power"
conversion_factor = "50.0 mW / volt"

[channels.A3.stop_recording_when]
below = "1 mW"            # under this, the laser is off
for = "30s"               # ... but only once it has stayed there
resume_above = "10 mW"    # back over this, resume immediately
```

The table is named and written for what **stops** the recording. That is the decision actually being made — the instrument state being excluded is the one worth naming — and it puts `for` on the clause it governs: "stop recording when the power stays below 1 mW for 30 seconds". Phrased the other way round, `for` reads as a condition on recording rather than on stopping, which is the opposite of what it does.

`below` and `above` are the two bounds. A channel may set either or both, and everything between them is recorded:

```toml
[channels.A4.stop_recording_when]
raw_voltage = true
below = "100 mV"
above = "3.0 V"
for = "1 min"
resume_below = "2.9 V"
```

That channel stops once its input has sat outside 100 mV–3.0 V for a minute — open input at one end, railed amplifier at the other — and resumes as soon as the input is back under 2.9 V.

`raw_voltage = true` compares the bounds against the voltage at the ADC input rather than against the converted value, for a channel whose off state is better recognised before the conversion: a railed amplifier, or a conversion characterised over only part of the input range. The bounds are then written in volts whatever the channel converts to, and the rule — not the acquisition loop — decides which quantity it reads.

Every bound is dimensioned and trial-converted at startup against the quantity it will be compared to, so a bound in the wrong unit is a startup error rather than a comparison that quietly means something else.

## Conservative about stopping, eager about resuming

The asymmetry is the design. Stopping wrongly loses real data; resuming wrongly costs a handful of junk samples.

- `for` is optional and applies to **stopping only**. Without it, the first reading outside the band stops recording. A reading that leaves by one bound and returns by way of the other never resets the dwell — outside is outside.
- Resuming is **always immediate**. Waiting would swallow the turn-on transient, which is often the most interesting part of the trace.
- `resume_above` and `resume_below` are optional deadbands on `below` and `above` respectively; without them the stop bounds are reused and there is no deadband.
- A gate **starts out recording**, so a misconfigured one errs towards keeping data.

Every comparison is strict, so each key means what it says: a reading of exactly 3 V is not *above* 3 V and does not stop a channel bounded there. A reading sitting exactly on a bound therefore neither stops nor resumes, and the gate holds the state it was already in — the only answer that does not pick a winner between the two directions.

## Reading the gap

Nothing is written while the gate is closed, `input_volts` included — a half-populated series is harder to read than a gap. Each transition is logged once, never per reading, carrying the value that caused it and the bound it crossed:

```
level=info logger=labmon.gate msg="recording stopped" limit="above 2.05 V" sensor_id=laser-1 value="2.083 V"
level=info logger=labmon.gate msg="recording resumed" limit="above 1.75 V and below 2 V" sensor_id=laser-1 value="1.994 V"
```

On a two-sided gate, "below 100 mV" and "above 3 V" are very different faults to be reading about at 03:00, so the bound is carried rather than left to be inferred. That line is what makes an instrument being off distinguishable from an acquisition crashing — in the data alone they look identical. With the `logs` profile it sits next to the series in Grafana.

## Rejected at load time

A gate that silently does nothing is worse than no gate, since it looks configured. So, rejected at startup:

- a table with neither `below` nor `above`
- a deadband without the bound it widens (`resume_above` with no `below`) — alone it deadbands nothing
- bounds that do not read `below <= resume_above < resume_below <= above`, which covers a deadband inside its own stop bound (the gate would resume the moment it stopped), stop bounds that cross, and a resume band of zero width
- a bound in a dimension the gated quantity cannot be compared to — checked against volts when `raw_voltage` is set, against what the conversion produces otherwise
- a bare number where a dimensioned quantity belongs
- a `for` that is not a duration. `for = "1m"` is **one metre** to pint, so the error says so outright rather than leaving a dimensionality complaint to be puzzled over
- any unknown key — a typo'd `resume` would otherwise mean no deadband at all

The gate is excluded from `calibration_id`. When to record is not how a reading was converted.

## Where it lives

`labmon.gate` is independent of the serial path, but only the calibrated path has per-channel config today, so that is the only caller. One gate per channel, since each carries its own deadband state — sharing one would let an instrument being off silence a channel that is still running.

## Test plan

- [x] 223 tests, 100% coverage, `basedpyright` 0 errors 0 warnings, `ruff check`/`format` and `typos` clean
- [x] **14 mutations, 14 caught**: `raw_voltage` ignored; each of the three boundary comparisons reverted to a non-strict form; the upper edge of the resume band ignored; the `above` bound ignored entirely; deadband defaults dropped; the dwell clock restarted on every reading outside the band; the direction word dropped from the log line; band ordering unchecked; the resume band allowed to be zero width; `raw_voltage` bounds checked against the converted unit; an orphan deadband accepted; a table with no stop bound accepted
- [x] A channel stopped by `above` with the value still past both resume bounds (`resume_above < resume_below < value`) stays stopped, from either side and with or without a lower bound
- [x] Both shipped configs still load (`calibration.example.toml`, `demo/calibration.demo.toml`), including the commented two-sided example once uncommented
- [x] **Live against the demo stack**, with the photodiode temporarily gated on its raw input inside its real swing (`raw_voltage = true`, `below = "1.75 V"`, `above = "2.05 V"`, `for = "10s"`, `resume_below = "2.0 V"`; A3 oscillates ~1.65–2.15 V on a 300 s period), all four behaviours fired in one period:

```
07:54:47 msg="recording stopped" limit="above 2.05 V" sensor_id=laser-1 value="2.083 V"
07:56:17 msg="recording resumed" limit="above 1.75 V and below 2.0 V" sensor_id=laser-1 value="1.997 V"
07:57:20 msg="recording stopped" limit="below 1.75 V" sensor_id=laser-1 value="1.707 V"
```

Both bounds of the two-sided band stopped it, each after its 10 s dwell, and each naming which one it crossed. The resume came at 1.997 V rather than at 2.049 V — the deadband held recording off for the ~40 s the input spent between 2.05 V and 2.0 V, which is exactly what it exists to do. Meanwhile the 30 s summaries show `laser-1` at 31 readings, then 11 in the window containing the stop, then absent from two whole windows, then 20 in the window containing the resume, while `pirani-1` on the same board wrote 30/30 s throughout — the gate is per channel. Temporary gate reverted.
