### PR TITLE
docs: index every configurable setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ together visually.*
 - [The dashboard](#the-dashboard) — what Grafana brings along
 - [Connecting a real instrument](#connecting-a-real-instrument)
 - [Running it across the lab](#running-it-across-the-lab)
+- [Configuration](docs/configuration.md) — every setting, and where it lives
 - [How it works](#how-it-works)
 - [Project structure](#project-structure)
 - [Development](#development)
@@ -259,7 +260,7 @@ this repository.
 - `firmware/` — reference Arduino sketches for boards labmon reads
 - `demo/` — stands in for a board so the demo runs the real acquisition path
 - `tests/` — pytest suite
-- `docs/` — usage docs per component
+- `docs/` — usage docs per component, indexed by `docs/configuration.md`
 - `typings/` — local type stubs for untyped third-party dependencies
 - `grafana/` — provisioned datasources and dashboards
 - `loki/` · `alloy/` — log storage and collection, behind the `logs` profile

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,210 @@
+# Configuration reference
+
+Every setting labmon exposes, in one place. Behaviour is tuned in three
+places — the environment, a command line, and the calibration file — and
+which one a given knob lives in is not always guessable. This page is the
+index; the per-component docs explain what each setting is *for*.
+
+There is a fourth category, at the bottom: the constants that are
+deliberately **not** configurable, and what breaks if you change them
+anyway.
+
+## Environment variables
+
+Read from `.env` by Compose, or from the process environment for a bare
+install. `.env` is **not** read by your shell — a value set there reaches
+a container but not a `uv run mock-sensor` you type yourself, unless
+something like direnv exports it.
+
+### Connection settings
+
+Every sensor needs these, wherever it runs.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `INFLUXDB3_AUTH_TOKEN` | *(required)* | InfluxDB API token. No default, and startup fails without it |
+| `INFLUXDB_HOST` | `http://localhost:8181` | Where to write. Containers on the server use `http://influxdb:8181`; a client machine uses the server's address |
+| `INFLUXDB_DATABASE` | `lab` | Database readings are written to |
+
+`INFLUXDB_HOST` is set per service in the Compose files rather than in
+`.env`, because one value cannot serve both a container (which needs the
+Docker network name) and a host-side process (which needs `localhost`).
+
+**Set-but-empty is not the same as unset.** Compose substitutes its own
+default for an empty value, but Python does not: `INFLUXDB_DATABASE=`
+with nothing after it makes a host-side sensor write to a database named
+`""` rather than to `lab`. `.env.example` ships several keys in exactly
+that shape, so either fill them in or comment them out.
+
+### Server stack
+
+Only meaningful on the machine running `docker-compose.yml`.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `INFLUXDB_NODE_ID` | *(required)* | Node identifier for the InfluxDB instance |
+| `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana admin login |
+| `COMPOSE_PROFILES` | *(unset)* | Which optional services start — see below |
+| `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Unset means Grafana needs no network at boot |
+| `LOKI_RETENTION_PERIOD` | `720h` | How long a log line is kept, with the `logs` profile active. Never below `24h` — Loki accepts less and cannot honour it |
+
+`COMPOSE_PROFILES` takes a comma-separated list:
+
+| Value | Adds |
+|---|---|
+| *(unset)* | Nothing — just InfluxDB and Grafana, which is the real-server shape |
+| `demo` | The mock sensors and the simulated board, for a stack with no hardware |
+| `logs` | Loki and Alloy, collecting every container's output |
+
+The two are independent, so `demo,logs` is valid. A profile is needed to
+*stop* its services as well as start them: `docker compose down` without
+it leaves them running. See
+[`docs/deployment.md`](deployment.md#demo-vs-server-compose_profiles).
+
+`ADC_FEEDER_HOST` also exists, but only the demo's simulated board reads
+it — see [`docs/demo-stack.md`](demo-stack.md).
+
+## Command-line flags
+
+### `mock-sensor`
+
+Simulates readings, so most of these shape a random walk rather than
+describing hardware. Full description in
+[`docs/mock-sensor.md`](mock-sensor.md).
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--sensor-id` | `mock-sensor-1` | Tag identifying the sensor |
+| `--measurement` | `temperature` | InfluxDB measurement (table) to write to |
+| `--field` | `value` | Field name for the reading |
+| `--unit` | *(none)* | Unit tag; omitted entirely when unset |
+| `--interval` | `5.0` | Seconds between readings |
+| `--setpoint` | `21.0` | Baseline the walk reverts toward |
+| `--noise` | `0.1` | Standard deviation of the step noise |
+| `--log-scale` | off | Walk in log₁₀ space, for a quantity spanning decades |
+| `--log-level` | `INFO` | `DEBUG` adds a line per reading |
+| `--summary-interval` | `30.0` | Seconds between "still writing" lines; `0` turns them off |
+
+### `serial-sensor`
+
+Reads a real board. Full description in
+[`docs/serial-sensor.md`](serial-sensor.md).
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--port` | *(required)* | Device path, or any pyserial URL (`rfc2217://`, `socket://`) |
+| `--calibration` | *(required)* | Path to the TOML calibration file |
+| `--baudrate` | `115200` | Ignored by a board on native USB, but pyserial requires a value |
+| `--resolution-bits` | `12` | ADC resolution |
+| `--vref` | `3.3` | ADC reference voltage |
+| `--log-level` | `INFO` | `DEBUG` adds a line per reading |
+| `--summary-interval` | `30.0` | Seconds between "still writing" lines; `0` turns them off |
+
+`--vref` and `--resolution-bits` are *not* stored with a reading. They
+don't need to be: both scale the recorded voltage linearly, so getting
+either wrong stays correctable with a query.
+
+## The calibration file
+
+One `[channels.<name>]` section per channel the board streams.
+[`calibration.example.toml`](../calibration.example.toml) works through
+every mode; [`docs/serial-sensor.md`](serial-sensor.md#the-calibration-file)
+explains the choices between them.
+
+| Key | Default | Applies to |
+|---|---|---|
+| `sensor_id` | *(required)* | Every channel |
+| `measurement` | *(required)* | Every channel |
+| `mode` | `linear` | Every channel |
+| `store_input` | `true` | Every channel; also settable file-wide at top level |
+| `conversion_factor` | *(required)* | `linear`, `affine` |
+| `offset` | *(required)* | `affine` |
+| `voltages`, `values`, `value_unit` | *(required)* | `spline`, `piecewise_linear` |
+| `expression`, `value_unit` | *(required)* | `expression` |
+
+Two optional sub-tables per channel:
+
+| Table | Purpose |
+|---|---|
+| `[channels.<name>.provenance]` | Free-form notes on how the calibration was obtained. Logged at startup, never written to InfluxDB. Any keys accepted |
+| `[channels.<name>.stop_recording_when]` | Stops recording while the instrument is off — see below |
+
+### `stop_recording_when`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `below` | *(none)* | Stop recording under this level |
+| `above` | *(none)* | Stop recording over this level |
+| `for` | `0s` | How long a breach must persist before recording stops |
+| `resume_above` | `below` | Resume only once back over this — the deadband on `below` |
+| `resume_below` | `above` | Resume only once back under this — the deadband on `above` |
+| `raw_voltage` | `false` | Gate on the measured voltage rather than the converted value |
+
+At least one of `below` or `above` is required, and the bounds must nest
+as `below <= resume_above < resume_below <= above`. A file breaking that
+is rejected at startup, as is a `resume_*` without the bound it
+deadbands. Note that `for = "1m"` is one *metre*: minutes are `min`.
+
+Full semantics, including why stopping is delayed and resuming is not, in
+[`docs/serial-sensor.md`](serial-sensor.md).
+
+## Library parameters
+
+For a sensor written against `labmon.sensors.polling` — see
+[`docs/custom-sensor.md`](custom-sensor.md). These have no CLI flag
+because the caller *is* the program.
+
+`poll()`:
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `interval` | `5.0` | Seconds between reads |
+| `initial_backoff` | `1.0` | First wait after a read raises |
+| `max_backoff` | `60.0` | Ceiling the backoff doubles up to |
+| `summary_interval` | `30.0` | Seconds between summary lines; `None` disables |
+
+An instrument with a known recovery time — a controller that takes a
+minute to reboot — should be given it rather than left to the defaults.
+
+`PointWriter()`, which decouples writing from reading so a slow InfluxDB
+never stalls a read loop:
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `maxsize` | `10_000` | Queued points before `write()` starts blocking |
+| `poll_interval` | `0.5` | Idle wake-up; bounds how long `close()` takes |
+| `initial_backoff` | `1.0` | First wait after a failed batch |
+| `max_backoff` | `30.0` | Ceiling the backoff doubles up to |
+
+The queue depth is what decides how long an outage a sensor rides out:
+ten thousand points is about a hundred seconds at 100 Hz, or most of a
+day at one reading every five seconds. [`docs/latency.md`](latency.md)
+has the measurements.
+
+A sensor built on `SensorLoop` takes a writer rather than forwarding each
+of these:
+
+```python
+from labmon.influx import get_client
+from labmon.sensors.loop import SensorLoop
+from labmon.writer import PointWriter
+
+loop = SensorLoop(writer=PointWriter(get_client(), maxsize=100_000))
+```
+
+## What is deliberately not configurable
+
+These are schema and protocol invariants. They are marked `INVARIANT` in
+the source, so grepping for that finds them all.
+
+| Constant | Consequence of changing it |
+|---|---|
+| `FIELD_NAME`, `INPUT_FIELD_NAME`, `CALIBRATION_ID_TAG` | Splits the history in two: rows already stored keep the old name, and no query spans both |
+| `CALIBRATION_ID_LENGTH`, `FINGERPRINT_SIGNIFICANT_DIGITS` | Re-tags every calibration, so a new id never matches one in the database |
+| `VOLTAGE_SYMBOL` | Invalidates every `expression` conversion in every calibration file at once |
+| `_FIELD_SEPARATOR`, `_FIELDS_PER_LINE` | Breaks the wire contract: readings stop parsing until the board is reflashed to match |
+
+Everything else with a `DEFAULT_` prefix is the default of a parameter
+next to it, and can be changed by passing a value — which survives an
+upgrade, and is visible in the deployment. Editing installed source does
+neither.

--- a/docs/custom-sensor.md
+++ b/docs/custom-sensor.md
@@ -59,6 +59,22 @@ already handled, and swallowing an error turns a broken instrument into a
 flat line — the failure mode nobody notices until a week of data is
 missing.
 
+The backoff defaults to one second, doubling to a minute. An instrument
+with a known recovery time should be told it rather than left to guess:
+
+```python
+poll(
+    read_value,
+    sensor_id="cryo-1",
+    measurement="temperature",
+    initial_backoff=30.0,
+    max_backoff=300.0,
+)
+```
+
+`poll` and `PointWriter` take a handful of other parameters, all listed
+in [`docs/configuration.md`](configuration.md#library-parameters).
+
 ### Recording more than one number
 
 `build_point()` is public for a device read that yields several values at

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -47,7 +47,12 @@ process closes its InfluxDB connection cleanly on SIGINT/SIGTERM.
 | `--field`          | `value`        | InfluxDB field name for the reading                                |
 | `--noise`          | `0.1`          | Std dev of Gaussian noise added each step                         |
 | `--log-scale`      | off            | Perform the walk in log10 space (see below)                       |
-| `--unit`           | `""`           | Unit of the reading (e.g. `°C`, `K`, `mbar`) — written as an InfluxDB `unit` tag when set, and shown in the console output |
+| `--unit`           | `""`           | Unit of the reading (e.g. `°C`, `K`, `mbar`) — written as an InfluxDB `unit` tag when set |
+| `--log-level`      | `INFO`         | `DEBUG` adds a line per reading                                   |
+| `--summary-interval` | `30.0`       | Seconds between "still writing" lines; `0` turns them off         |
+
+Every setting in the project, not just this script's, is indexed in
+[`docs/configuration.md`](configuration.md).
 
 ### `--log-scale`
 

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -323,6 +323,11 @@ Connection settings (`INFLUXDB_HOST`, `INFLUXDB_DATABASE`,
 `INFLUXDB3_AUTH_TOKEN`) come from the environment, exactly as for
 [`mock-sensor`](mock-sensor.md#configuration).
 
+`--log-level DEBUG` adds a line per reading; `--summary-interval` sets
+how often the "still writing" line appears, and `0` turns it off.
+[`docs/configuration.md`](configuration.md) indexes every setting in the
+project, this one included.
+
 ## Arduino Due specifics
 
 The reference firmware is

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -53,6 +53,9 @@ ADC_RESOLUTION_BITS = 12
 ADC_VREF_VOLTS = 3.3
 
 # The name an `expression` conversion uses for the measured voltage.
+# INVARIANT (see docs/configuration.md): every `expression` in every
+# calibration file already written is spelled in terms of this, so
+# changing it invalidates all of them at once.
 VOLTAGE_SYMBOL = "v"
 
 # Applied at load time to check a conversion works and to read off the
@@ -67,6 +70,11 @@ DEFAULT_MODE = "linear"
 # without the input, correcting a wrong calibration cannot reach readings
 # already written.
 DEFAULT_STORE_INPUT = True
+
+# INVARIANT (see docs/configuration.md): both feed the calibration_id
+# already tagged onto stored readings. Changing either re-tags every
+# calibration, so a new id never matches one in the database and the
+# provenance trail the tag exists for is broken.
 
 # Length of the calibration_id tag, in hex characters. Long enough that
 # a lab's handful of calibrations will not collide, short enough to read

--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -30,8 +30,9 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # How often to report that readings are still arriving. One line per
 # reading is unreadable at any real rate, but silence gives an operator no
-# way to tell "working" from "wedged".
-SUMMARY_INTERVAL_SECONDS = 30.0
+# way to tell "working" from "wedged". A default rather than a fixed
+# constant: both sensor entry points expose it as --summary-interval.
+DEFAULT_SUMMARY_INTERVAL_SECONDS = 30.0
 
 
 class Closeable(Protocol):
@@ -52,15 +53,23 @@ class SensorLoop:
 
     `summary_interval` of None disables the summary, for a sensor that
     already reports every reading.
+
+    `writer` is how a deployment tunes the queue: build a `PointWriter`
+    with the depth and backoff that suit the link, and hand it over.
+    Taking the writer rather than forwarding each of its arguments keeps
+    this signature from growing every time the writer gains one — and a
+    caller who supplies a writer already holds the client, so none is
+    opened here.
     """
 
     def __init__(
         self,
         *,
         closes: Closeable | None = None,
-        summary_interval: float | None = SUMMARY_INTERVAL_SECONDS,
+        summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
+        writer: PointWriter[Point] | None = None,
     ) -> None:
-        self.writer: PointWriter[Point] = PointWriter[Point](get_client())
+        self.writer: PointWriter[Point] = writer or PointWriter[Point](get_client())
         self._summary_interval: float | None = summary_interval
         self._written: Counter[str] = Counter()
         self._next_summary: float = time.monotonic() + (summary_interval or 0.0)

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -29,7 +29,7 @@ from influxdb_client_3 import Point
 
 from labmon import logs
 from labmon.influx import INFLUXDB_DATABASE
-from labmon.sensors.loop import SensorLoop
+from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -73,6 +73,7 @@ def run(
     noise: float = 0.1,
     log_scale: bool = False,
     unit: str = "",
+    summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
 ) -> None:
     """Write simulated readings for `sensor_id` to InfluxDB until interrupted.
 
@@ -82,7 +83,7 @@ def run(
     # The summary is on now that per-reading lines are DEBUG. Without it a
     # sensor at the default level would say nothing at all after startup,
     # and silence is indistinguishable from a wedged process.
-    loop = SensorLoop()
+    loop = SensorLoop(summary_interval=summary_interval)
     walk = RandomWalk(setpoint=setpoint, noise=noise, log_scale=log_scale)
 
     logger.info(
@@ -153,7 +154,7 @@ def main() -> None:
         "--unit",
         default="",
         help="Unit of the reading (e.g. '°C', 'K', 'mbar'). Written as an "
-        + "InfluxDB tag (when set) and shown in the console output.",
+        + "InfluxDB tag when set, and omitted entirely when not.",
     )
     _ = parser.add_argument(
         "--log-level",
@@ -161,6 +162,12 @@ def main() -> None:
         choices=logs.LEVEL_NAMES,
         type=str.upper,
         help="DEBUG shows every reading; INFO shows startup and the summary",
+    )
+    _ = parser.add_argument(
+        "--summary-interval",
+        type=float,
+        default=DEFAULT_SUMMARY_INTERVAL_SECONDS,
+        help="Seconds between 'still writing' summary lines; 0 turns them off",
     )
     args = parser.parse_args()
 
@@ -174,6 +181,9 @@ def main() -> None:
     noise = cast(float, args.noise)
     log_scale = cast(bool, args.log_scale)
     unit = cast(str, args.unit)
+    # argparse cannot hand back None from a float flag, so zero is the off
+    # switch — and "summarise every zero seconds" has no other meaning.
+    summary_interval = cast(float, args.summary_interval) or None
 
     run(
         sensor_id=sensor_id,
@@ -184,6 +194,7 @@ def main() -> None:
         noise=noise,
         log_scale=log_scale,
         unit=unit,
+        summary_interval=summary_interval,
     )
 
 

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -44,15 +44,17 @@ from datetime import UTC, datetime
 from influxdb_client_3 import Point
 
 from labmon.influx import INFLUXDB_DATABASE, get_client
-from labmon.sensors.loop import SensorLoop
+from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
 
 # A read that raises backs off instead of retrying at the nominal interval,
 # so an instrument that is switched off is not hammered all night. Capped so
-# recovery is still noticed promptly once it comes back.
-INITIAL_BACKOFF_SECONDS = 1.0
-MAX_BACKOFF_SECONDS = 60.0
+# recovery is still noticed promptly once it comes back. Defaults rather
+# than fixed constants: an instrument whose reboot takes a known minute
+# should be told that, not guessed at.
+DEFAULT_INITIAL_BACKOFF_SECONDS = 1.0
+DEFAULT_MAX_BACKOFF_SECONDS = 60.0
 
 
 def build_point(
@@ -131,6 +133,9 @@ def poll(
     interval: float = 5.0,
     field: str = "value",
     tags: Mapping[str, str] | None = None,
+    initial_backoff: float = DEFAULT_INITIAL_BACKOFF_SECONDS,
+    max_backoff: float = DEFAULT_MAX_BACKOFF_SECONDS,
+    summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
 ) -> None:
     """Read every `interval` seconds and write what comes back, forever.
 
@@ -142,13 +147,15 @@ def poll(
     SDK that throws on a transient network blip, a device that reports busy,
     an expired session — none of these should end the process, because the
     failure that matters is the one nobody notices until a week of data is
-    missing. Successive failures back off up to MAX_BACKOFF_SECONDS and
-    return to the nominal interval on the first success.
+    missing. Successive failures double the wait from `initial_backoff` up
+    to `max_backoff`, and return to the nominal interval on the first
+    success. An instrument with a known recovery time should be given it
+    rather than left to the defaults.
 
     Runs until SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`), at which
     point queued readings are flushed and the client closed.
     """
-    loop = SensorLoop()
+    loop = SensorLoop(summary_interval=summary_interval)
 
     logger.info(
         "writing readings",
@@ -160,7 +167,7 @@ def poll(
         },
     )
 
-    backoff = INITIAL_BACKOFF_SECONDS
+    backoff = initial_backoff
 
     while True:
         try:
@@ -172,10 +179,10 @@ def poll(
                 exc_info=True,
             )
             time.sleep(backoff)
-            backoff = min(backoff * 2, MAX_BACKOFF_SECONDS)
+            backoff = min(backoff * 2, max_backoff)
             continue
 
-        backoff = INITIAL_BACKOFF_SECONDS
+        backoff = initial_backoff
         if value is not None:
             point = build_point(
                 value,

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -38,7 +38,7 @@ from labmon.calibration import (
 )
 from labmon.gate import RecordingGate
 from labmon.influx import INFLUXDB_DATABASE
-from labmon.sensors.loop import SensorLoop
+from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 from labmon.sensors.serial_source import (
     DEFAULT_BAUDRATE,
     RawSource,
@@ -47,6 +47,11 @@ from labmon.sensors.serial_source import (
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# INVARIANT (see docs/configuration.md): the three names below are the
+# schema every stored reading was written under. Changing one splits the
+# history in two — rows already in InfluxDB keep the old name, and no
+# query spans both — so they are deliberately not configurable.
 
 # The InfluxDB field every reading is written to. Unlike the mock
 # sensor's --field, there's nothing to vary here: a channel's identity
@@ -91,6 +96,7 @@ def run(
     calibrations: dict[str, Calibration],
     resolution_bits: int = ADC_RESOLUTION_BITS,
     v_ref: float = ADC_VREF_VOLTS,
+    summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
 ) -> None:
     """Write calibrated readings from `source` to InfluxDB until interrupted.
 
@@ -100,7 +106,7 @@ def run(
     """
     # The port is closed before the writer, so nothing new arrives while
     # the queue drains.
-    loop = SensorLoop(closes=source)
+    loop = SensorLoop(closes=source, summary_interval=summary_interval)
 
     logger.info(
         "writing calibrated readings",
@@ -217,6 +223,12 @@ def main() -> None:
         type=str.upper,
         help="DEBUG shows every reading; INFO shows startup and the summary",
     )
+    _ = parser.add_argument(
+        "--summary-interval",
+        type=float,
+        default=DEFAULT_SUMMARY_INTERVAL_SECONDS,
+        help="Seconds between 'still writing' summary lines; 0 turns them off",
+    )
     args = parser.parse_args()
 
     port = cast(str, args.port)
@@ -224,6 +236,9 @@ def main() -> None:
     baudrate = cast(int, args.baudrate)
     resolution_bits = cast(int, args.resolution_bits)
     v_ref = cast(float, args.vref)
+    # argparse cannot hand back None from a float flag, so zero is the off
+    # switch — and "summarise every zero seconds" has no other meaning.
+    summary_interval = cast(float, args.summary_interval) or None
 
     logs.configure(logs.level_from_name(cast(str, args.log_level)))
 
@@ -237,6 +252,7 @@ def main() -> None:
         calibrations=calibrations,
         resolution_bits=resolution_bits,
         v_ref=v_ref,
+        summary_interval=summary_interval,
     )
 
 

--- a/src/labmon/sensors/serial_source.py
+++ b/src/labmon/sensors/serial_source.py
@@ -27,6 +27,10 @@ import serial
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# INVARIANT (see docs/configuration.md): the wire contract with the
+# firmware. The board is flashed to send this shape, so changing either
+# here alone stops every reading parsing until the sketch is reflashed
+# to match.
 _FIELD_SEPARATOR = ","
 _FIELDS_PER_LINE = 2
 

--- a/src/labmon/writer.py
+++ b/src/labmon/writer.py
@@ -7,8 +7,22 @@ from typing import Protocol
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-_INITIAL_BACKOFF_SECONDS = 1.0
-_MAX_BACKOFF_SECONDS = 30.0
+# Defaults for the constructor arguments below, named so they can be
+# quoted in docs/configuration.md and referred to from a call site that
+# wants to change one of them without restating the others.
+
+# How many points may queue up before write() starts blocking. At ten
+# thousand a 100 Hz sensor rides out a ~100s outage before it does.
+DEFAULT_QUEUE_MAXSIZE = 10_000
+
+# How long the background thread waits on an empty queue before
+# re-checking for a stop request. Bounds how long close() can take.
+DEFAULT_POLL_INTERVAL_SECONDS = 0.5
+
+# The first retry wait after a failed batch, and the ceiling the
+# doubling stops at.
+DEFAULT_INITIAL_BACKOFF_SECONDS = 1.0
+DEFAULT_MAX_BACKOFF_SECONDS = 30.0
 
 
 class _Writable[T](Protocol):
@@ -28,20 +42,33 @@ class PointWriter[T]:
     request when the queue is empty (the background thread re-checks for
     a stop roughly every poll_interval seconds while idle).
 
-    A batch that fails to write is retried with exponential backoff
-    (capped, and interruptible by close()) rather than being dropped or
-    left to kill the background thread — a real network to a remote
-    server can have transient outages that a same-host connection never
-    would. A batch still failing when close() is called is logged and
-    dropped rather than retried indefinitely, so shutdown stays prompt.
+    A batch that fails to write is retried with exponential backoff from
+    initial_backoff up to max_backoff (interruptible by close()) rather
+    than being dropped or left to kill the background thread — a real
+    network to a remote server can have transient outages that a
+    same-host connection never would. A batch still failing when close()
+    is called is logged and dropped rather than retried indefinitely, so
+    shutdown stays prompt.
+
+    All four are arguments rather than module constants because the right
+    values depend on the deployment: a 100 Hz board on a flaky link wants
+    a deeper queue than a thermometer sampled every minute. Passing one
+    survives an upgrade; editing installed source does not.
     """
 
     def __init__(
-        self, client: _Writable[T], maxsize: int = 10_000, poll_interval: float = 0.5
+        self,
+        client: _Writable[T],
+        maxsize: int = DEFAULT_QUEUE_MAXSIZE,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        initial_backoff: float = DEFAULT_INITIAL_BACKOFF_SECONDS,
+        max_backoff: float = DEFAULT_MAX_BACKOFF_SECONDS,
     ) -> None:
         self._client: _Writable[T] = client
         self._queue: queue.Queue[T] = queue.Queue(maxsize=maxsize)
         self._poll_interval: float = poll_interval
+        self._initial_backoff: float = initial_backoff
+        self._max_backoff: float = max_backoff
         self._stop: threading.Event = threading.Event()
         self._thread: threading.Thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -76,7 +103,7 @@ class PointWriter[T]:
         logged and dropped instead of retried forever, so close() stays
         responsive even during a sustained outage.
         """
-        backoff = _INITIAL_BACKOFF_SECONDS
+        backoff = self._initial_backoff
         attempt = 1
         while True:
             try:
@@ -97,5 +124,5 @@ class PointWriter[T]:
                     len(batch),
                 )
                 return
-            backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
+            backoff = min(backoff * 2, self._max_backoff)
             attempt += 1

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -9,6 +9,7 @@ from influxdb_client_3 import Point
 
 from labmon.sensors import loop as sensor_loop
 from labmon.sensors.loop import SensorLoop
+from labmon.writer import PointWriter
 
 SignalHandler = Callable[[int, FrameType | None], None]
 
@@ -120,7 +121,7 @@ def test_shutdown_closes_the_port_before_the_writer(
 def test_the_summary_names_each_sensor_and_its_count(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    ticks = iter([0.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
     monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
     loop = SensorLoop()
     loop.record(_point(1.0), "cryo-77k")
@@ -167,3 +168,51 @@ def test_a_loop_without_a_summary_never_emits_one(
         loop.summarise_if_due()
 
     assert "wrote readings" not in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Tuning the writer without editing installed source
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("registered_handlers")
+def test_a_supplied_writer_is_used_instead_of_a_default_one() -> None:
+    """How a deployment tunes the queue: build the writer, hand it over.
+
+    Forwarding every PointWriter argument through SensorLoop would grow
+    a parameter each time the writer gains one; taking the writer itself
+    stays one parameter forever.
+    """
+    client = FakeInfluxClient()
+    writer = PointWriter[Point](client, maxsize=5, poll_interval=0.01)
+    loop = SensorLoop(writer=writer)
+
+    loop.record(_point(1.0), "s")
+    loop.writer.close()
+
+    assert loop.writer is writer
+    assert len(client.points) == 1
+
+
+def test_supplying_a_writer_does_not_open_a_second_client(
+    monkeypatch: pytest.MonkeyPatch, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """A caller who built the writer already holds the only connection."""
+
+    def unexpected() -> FakeInfluxClient:  # pragma: no cover - must not run
+        raise AssertionError("get_client() was called despite a supplied writer")
+
+    monkeypatch.setattr(sensor_loop, "get_client", unexpected)
+    client = FakeInfluxClient()
+    loop = SensorLoop(writer=PointWriter[Point](client, poll_interval=0.01))
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert loop.writer is not None
+    assert client.closed is True
+
+
+def test_the_summary_default_is_the_documented_one() -> None:
+    """docs/configuration.md quotes it, so a change must break a test."""
+    assert sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS == 30.0

--- a/tests/test_mock_sensor.py
+++ b/tests/test_mock_sensor.py
@@ -164,6 +164,7 @@ def test_main_parses_defaults_and_calls_run(monkeypatch: pytest.MonkeyPatch) -> 
             "noise": 0.1,
             "log_scale": False,
             "unit": "",
+            "summary_interval": 30.0,
         }
     ]
 
@@ -201,6 +202,7 @@ def test_main_parses_custom_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
             "noise": 0.1,
             "log_scale": False,
             "unit": "",
+            "summary_interval": 30.0,
         }
     ]
 
@@ -245,6 +247,7 @@ def test_main_parses_pressure_gauge_arguments(monkeypatch: pytest.MonkeyPatch) -
             "noise": 0.05,
             "log_scale": True,
             "unit": "mbar",
+            "summary_interval": 30.0,
         }
     ]
 
@@ -272,3 +275,72 @@ def test_a_lower_case_log_level_is_accepted(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert logging.getLogger().level == logging.DEBUG
     assert len(calls) == 1
+
+
+def test_main_accepts_a_custom_summary_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A quiet sensor may want the heartbeat rarer than every 30s."""
+    calls: list[dict[str, object]] = []
+
+    def fake_run(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(mock_sensor, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["mock-sensor", "--summary-interval", "300"])
+
+    main()
+
+    [call] = calls
+    assert call["summary_interval"] == 300.0
+
+
+def test_a_summary_interval_of_zero_turns_the_heartbeat_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero is the off switch, since a float flag cannot take None."""
+    calls: list[dict[str, object]] = []
+
+    def fake_run(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(mock_sensor, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["mock-sensor", "--summary-interval", "0"])
+
+    main()
+
+    [call] = calls
+    assert call["summary_interval"] is None
+
+
+def test_run_passes_its_summary_interval_to_the_loop(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The flag is only worth parsing if it reaches the loop that uses it."""
+    monkeypatch.setattr(sensor_loop, "get_client", FakeInfluxClient)
+
+    def ignore_signal(_signum: int, _handler: SignalHandler) -> None:
+        return None
+
+    monkeypatch.setattr(signal, "signal", ignore_signal)
+    # Well past the default interval, so a dropped argument would summarise.
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+
+    def fake_sleep(seconds: float) -> None:
+        raise _StopLoop(seconds)
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    with (
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        run(
+            sensor_id="test-sensor",
+            interval=1.0,
+            setpoint=10.0,
+            summary_interval=None,
+        )
+
+    assert "wrote readings" not in caplog.text

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -307,7 +307,39 @@ def test_poll_backoff_is_capped(no_sleep: list[float]) -> None:
     with pytest.raises(_StopLoop):
         poll(read, sensor_id="c", measurement="m", interval=1.0)
 
-    assert max(no_sleep) == polling.MAX_BACKOFF_SECONDS
+    assert max(no_sleep) == polling.DEFAULT_MAX_BACKOFF_SECONDS
+
+
+@pytest.mark.usefixtures("registered_handlers", "fake_client")
+def test_poll_backoff_bounds_are_parameters(no_sleep: list[float]) -> None:
+    """A device known to need a minute to reboot should not be guessed at."""
+    failures = iter(range(30))
+
+    def read() -> float | None:
+        try:
+            _ = next(failures)
+        except StopIteration:
+            raise _StopLoop from None
+        raise RuntimeError("unreachable")
+
+    with pytest.raises(_StopLoop):
+        poll(
+            read,
+            sensor_id="c",
+            measurement="m",
+            interval=1.0,
+            initial_backoff=5.0,
+            max_backoff=20.0,
+        )
+
+    assert no_sleep[0] == 5.0
+    assert max(no_sleep) == 20.0
+
+
+def test_the_backoff_defaults_are_the_documented_ones() -> None:
+    """docs/configuration.md quotes these, so a change must break a test."""
+    assert polling.DEFAULT_INITIAL_BACKOFF_SECONDS == 1.0
+    assert polling.DEFAULT_MAX_BACKOFF_SECONDS == 60.0
 
 
 @pytest.mark.usefixtures("registered_handlers", "fake_client")
@@ -342,7 +374,7 @@ def test_poll_summarises_once_the_interval_elapses(
 ) -> None:
     """The per-reading line is DEBUG, so this carries "it is still working"."""
     # The clock passes the summary interval only on the second reading.
-    ticks = iter([0.0, 1.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
+    ticks = iter([0.0, 1.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
     monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
 
     with (
@@ -355,3 +387,26 @@ def test_poll_summarises_once_the_interval_elapses(
     assert [(_field(r, "sensor_id"), _field(r, "readings")) for r in summaries] == [
         ("c", 2)
     ]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers", "no_sleep")
+def test_poll_passes_its_summary_interval_to_the_loop(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sensor that reports another way should be able to turn it off."""
+    # Well past the default interval, so a dropped argument would summarise.
+    ticks = iter([0.0, 1.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+
+    with (
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        poll(
+            _stop_after([1.0, 2.0]),
+            sensor_id="c",
+            measurement="m",
+            summary_interval=None,
+        )
+
+    assert "wrote readings" not in caplog.text

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -321,6 +321,7 @@ def test_main_parses_defaults_and_calls_run(monkeypatch: pytest.MonkeyPatch) -> 
     [call] = run_calls
     assert call["resolution_bits"] == 12
     assert call["v_ref"] == 3.3
+    assert call["summary_interval"] == 30.0
     assert call["calibrations"] == {"A0": _temperature_calibration()}
 
 
@@ -341,6 +342,8 @@ def test_main_parses_custom_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
             "10",
             "--vref",
             "5.0",
+            "--summary-interval",
+            "120",
         ],
     )
 
@@ -350,6 +353,32 @@ def test_main_parses_custom_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
     [call] = run_calls
     assert call["resolution_bits"] == 10
     assert call["v_ref"] == 5.0
+    assert call["summary_interval"] == 120.0
+
+
+def test_a_summary_interval_of_zero_turns_the_heartbeat_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero is the off switch, since a float flag cannot take None."""
+    run_calls, _ = _patch_main_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "serial-sensor",
+            "--port",
+            "/dev/labmon-due",
+            "--calibration",
+            "cal.toml",
+            "--summary-interval",
+            "0",
+        ],
+    )
+
+    main()
+
+    [call] = run_calls
+    assert call["summary_interval"] is None
 
 
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
@@ -383,7 +412,7 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     # so exactly one summary covering both should be emitted. Patched on
     # the time module itself, which serial_sensor imports rather than
     # re-exports.
-    ticks = iter([0.0, 1.0, sensor_loop.SUMMARY_INTERVAL_SECONDS + 1.0])
+    ticks = iter([0.0, 1.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
     monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
     source = FakeRawSource(
         [
@@ -425,6 +454,30 @@ def test_an_unknown_log_level_is_rejected(monkeypatch: pytest.MonkeyPatch) -> No
         main()
 
     assert exit_info.value.code == 2
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_run_passes_its_summary_interval_to_the_loop(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag is only worth parsing if it reaches the loop that uses it."""
+    # Well past the default interval, so a dropped argument would summarise.
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+
+    with (
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        run(
+            source=source,
+            calibrations={"A0": _temperature_calibration()},
+            summary_interval=None,
+        )
+
+    assert "wrote readings" not in caplog.text
 
 
 # --------------------------------------------------------------------------
@@ -512,7 +565,7 @@ def test_a_gated_out_reading_is_not_counted_in_the_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The summary reports what was written; a gap must not read as activity."""
-    monkeypatch.setattr(sensor_loop, "SUMMARY_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(sensor_loop, "DEFAULT_SUMMARY_INTERVAL_SECONDS", 0.0)
     source = FakeRawSource([RawReading(channel="A0", raw_count=1)])
 
     with caplog.at_level(logging.INFO), pytest.raises(_StopLoop):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -93,12 +93,12 @@ def test_survives_idle_polling_before_a_point_arrives() -> None:
 
 
 def test_write_retries_transient_failures_then_succeeds(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.setattr(writer_module, "_INITIAL_BACKOFF_SECONDS", 0.01)
-    monkeypatch.setattr(writer_module, "_MAX_BACKOFF_SECONDS", 0.01)
     client = FlakyClient[int](fail_times=2)
-    writer = PointWriter[int](client, poll_interval=0.01)
+    writer = PointWriter[int](
+        client, poll_interval=0.01, initial_backoff=0.01, max_backoff=0.01
+    )
 
     with caplog.at_level(logging.WARNING):
         writer.write(1)
@@ -129,3 +129,54 @@ def test_close_drops_a_batch_still_failing_at_shutdown(
     assert client.attempts >= 1
     assert client.closed.is_set()
     assert "Dropping a batch of 1 point(s)" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Every knob is a parameter, not an edit to installed source
+# --------------------------------------------------------------------------
+
+
+def test_the_backoff_defaults_are_the_documented_ones() -> None:
+    """docs/configuration.md quotes these, so a change must break a test."""
+    assert writer_module.DEFAULT_QUEUE_MAXSIZE == 10_000
+    assert writer_module.DEFAULT_POLL_INTERVAL_SECONDS == 0.5
+    assert writer_module.DEFAULT_INITIAL_BACKOFF_SECONDS == 1.0
+    assert writer_module.DEFAULT_MAX_BACKOFF_SECONDS == 30.0
+
+
+def test_the_first_retry_waits_the_backoff_it_was_given(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A one-second default would not fit three attempts in this window."""
+    client = FlakyClient[int](fail_times=2)
+    writer = PointWriter[int](
+        client, poll_interval=0.01, initial_backoff=0.01, max_backoff=0.01
+    )
+
+    with caplog.at_level(logging.CRITICAL, logger="labmon.writer"):
+        writer.write(1)
+        time.sleep(0.1)
+        writer.close()
+
+    assert client.attempts == 3
+
+
+def test_the_cap_stops_the_backoff_doubling_away(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Uncapped doubling from 1ms reaches ~64ms by the eighth attempt.
+
+    Capping at 2ms keeps every wait short, so a fixed window fits far
+    more attempts than doubling would — which is what the cap is for.
+    """
+    client = AlwaysFailingClient[int]()
+    writer = PointWriter[int](
+        client, poll_interval=0.001, initial_backoff=0.001, max_backoff=0.002
+    )
+
+    with caplog.at_level(logging.CRITICAL, logger="labmon.writer"):
+        writer.write(1)
+        time.sleep(0.2)
+        writer.close()
+
+    assert client.attempts > 20


### PR DESCRIPTION
Closes #48. Top of the stack, on #76 (recording gate).

Behaviour was tuned in three unrelated places — the environment, a command line, and the calibration file — with no page listing them, and several genuinely tunable values reachable only by editing installed source.

## A configuration reference

`docs/configuration.md` indexes every setting: connection and server environment variables, the flags of both entry points, every calibration file key including `stop_recording_when` in the shape #76 settled on, the library parameters a custom sensor passes, and what is deliberately not configurable. Linked from the README's contents and from the four component docs.

It documents one trap found while verifying it: **set-but-empty is not unset**. Compose substitutes `${INFLUXDB_DATABASE:-lab}`, but `os.environ.get(..., "lab")` returns `""` for an empty assignment, so a host-side sensor writes to a database named `""`. `.env.example` ships several keys in exactly that shape. That is #79 — documented here, not fixed here, since the fix belongs in `influx.py`.

## The tunables, promoted to parameters

| Where | Now a parameter |
| --- | --- |
| `PointWriter` | `initial_backoff`, `max_backoff` (were private module constants); `maxsize`/`poll_interval` already were |
| `SensorLoop` | `writer=` |
| `poll()` | `initial_backoff`, `max_backoff`, `summary_interval` |
| `mock-sensor`, `serial-sensor` | `--summary-interval`, where `0` turns the heartbeat off |

`SensorLoop` takes a writer rather than forwarding each of `PointWriter`'s four arguments, so tuning the queue does not grow the signature every time the writer gains a knob — and a caller who supplies a writer already holds the client, so none is opened. `0` is the off switch for `--summary-interval` because argparse cannot hand back `None` from a float flag, and "summarise every zero seconds" has no other meaning.

Every default is now a `DEFAULT_` constant beside the parameter it defaults, so the prefix itself says a thing is tunable. `calibration.py`'s `ADC_RESOLUTION_BITS`/`ADC_VREF_VOLTS` were deliberately left alone: they are already exposed as `--resolution-bits`/`--vref`, so renaming would only risk a conflict with #69 a few lines away.

## The invariants, marked as such

The field names, the calibration-id parameters, `VOLTAGE_SYMBOL` and the wire separators are marked `INVARIANT` in the source, so `grep INVARIANT` finds the set the reference tabulates. Each says what breaks: a split history, a re-tagged calibration, every `expression` invalidated at once, or a wire contract the board would need reflashing to match.

## Verification

243 tests, 100% coverage, ruff/basedpyright/typos clean.

**13/13 mutations caught.** The first run had three survivors — nothing proved the parsed `--summary-interval` actually reached the loop in any of the three sensors, only that argparse had produced the right number. That gap is what the three added tests close.

Checked live against the demo stack:

```
--summary-interval 5  ->  three summaries at 5s spacing, window_s=5
--summary-interval 0  ->  zero summaries, startup line still emitted
```
