### PR TITLE
fix: structure writer and serial-source logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ build-backend = "hatchling.build"
 include = ["src", "tests", "scripts"]
 stubPath = "typings"
 
+[tool.ruff.lint]
+extend-select = ["G"]
+
 [tool.coverage.run]
 source = ["src"]
 

--- a/src/labmon/sensors/serial_source.py
+++ b/src/labmon/sensors/serial_source.py
@@ -77,7 +77,10 @@ def parse_reading(line: bytes) -> RawReading | None:
     try:
         text = line.decode("utf-8").strip()
     except UnicodeDecodeError:
-        logger.warning("Skipping malformed line (not valid UTF-8): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "not valid UTF-8", "line": line},
+        )
         return None
 
     if not text:
@@ -86,25 +89,35 @@ def parse_reading(line: bytes) -> RawReading | None:
     fields = [field.strip() for field in text.split(_FIELD_SEPARATOR)]
     if len(fields) != _FIELDS_PER_LINE:
         logger.warning(
-            "Skipping malformed line (expected '<channel>,<count>'): %r", line
+            "skipping malformed line",
+            extra={"reason": "expected '<channel>,<count>'", "line": line},
         )
         return None
 
     channel, raw_count = fields
     if not channel:
-        logger.warning("Skipping malformed line (empty channel): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "empty channel", "line": line},
+        )
         return None
 
     try:
         count = float(raw_count)
     except ValueError:
-        logger.warning("Skipping malformed line (count is not a number): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "count is not a number", "line": line},
+        )
         return None
 
     # float() accepts "nan" and "inf", which would otherwise reach InfluxDB
     # and poison every aggregate computed over the series.
     if not math.isfinite(count):
-        logger.warning("Skipping malformed line (count is not finite): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "count is not finite", "line": line},
+        )
         return None
 
     return RawReading(channel=channel, raw_count=count)

--- a/src/labmon/writer.py
+++ b/src/labmon/writer.py
@@ -111,18 +111,16 @@ class PointWriter[T]:
                 return
             except Exception:
                 logger.warning(
-                    "Write attempt %d failed for a batch of %d point(s);"
-                    + " retrying in %.0fs",
-                    attempt,
-                    len(batch),
-                    backoff,
+                    "write attempt failed",
+                    extra={
+                        "attempt": attempt,
+                        "points": len(batch),
+                        "retry_in_s": f"{backoff:.0f}",
+                    },
                     exc_info=True,
                 )
             if self._stop.wait(timeout=backoff):
-                logger.error(
-                    "Dropping a batch of %d point(s) still unwritten at shutdown",
-                    len(batch),
-                )
+                logger.error("dropping batch at shutdown", extra={"points": len(batch)})
                 return
             backoff = min(backoff * 2, self._max_backoff)
             attempt += 1

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -11,6 +11,11 @@ from labmon.sensors.serial_source import (
 )
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a structured log field off a record."""
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class FakeSerialPort:
     """Stands in for a pyserial Serial, replaying canned lines."""
 
@@ -64,27 +69,34 @@ def test_parse_reading_ignores_a_blank_line() -> None:
 
 
 @pytest.mark.parametrize(
-    "line",
+    ("line", "reason"),
     [
-        pytest.param(b"garbage\n", id="no-separator"),
-        pytest.param(b"A0,2048,extra\n", id="too-many-fields"),
-        pytest.param(b"A0,not-a-number\n", id="non-numeric-count"),
+        pytest.param(b"garbage\n", "expected '<channel>,<count>'", id="no-separator"),
+        pytest.param(
+            b"A0,2048,extra\n", "expected '<channel>,<count>'", id="too-many-fields"
+        ),
+        pytest.param(
+            b"A0,not-a-number\n", "count is not a number", id="non-numeric-count"
+        ),
         # float() would accept these where int() did not; a non-finite
         # count reaching InfluxDB poisons every aggregate over the series.
-        pytest.param(b"A0,nan\n", id="nan-count"),
-        pytest.param(b"A0,inf\n", id="inf-count"),
-        pytest.param(b"A0,-inf\n", id="negative-inf-count"),
-        pytest.param(b",2048\n", id="empty-channel"),
-        pytest.param(b"\xff\xfe\n", id="undecodable-bytes"),
+        pytest.param(b"A0,nan\n", "count is not finite", id="nan-count"),
+        pytest.param(b"A0,inf\n", "count is not finite", id="inf-count"),
+        pytest.param(b"A0,-inf\n", "count is not finite", id="negative-inf-count"),
+        pytest.param(b",2048\n", "empty channel", id="empty-channel"),
+        pytest.param(b"\xff\xfe\n", "not valid UTF-8", id="undecodable-bytes"),
     ],
 )
 def test_parse_reading_skips_a_malformed_line(
-    line: bytes, caplog: pytest.LogCaptureFixture
+    line: bytes, reason: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING):
         assert parse_reading(line) is None
 
-    assert "Skipping malformed line" in caplog.text
+    (record,) = caplog.records
+    assert record.message == "skipping malformed line"
+    assert _field(record, "line") == line
+    assert _field(record, "reason") == reason
 
 
 def test_read_returns_successive_readings() -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,6 +8,11 @@ from labmon import writer as writer_module
 from labmon.writer import PointWriter
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a structured log field off a record."""
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class FakeClient[T]:
     def __init__(self) -> None:
         self.batches: list[list[T]] = []
@@ -108,7 +113,12 @@ def test_write_retries_transient_failures_then_succeeds(
     written = [point for batch in client.batches for point in batch]
     assert written == [1]
     assert client.attempts == 3
-    assert caplog.text.count("Write attempt") == 2
+    retries = [
+        record for record in caplog.records if record.message == "write attempt failed"
+    ]
+    assert len(retries) == 2
+    assert [_field(record, "attempt") for record in retries] == [1, 2]
+    assert all(_field(record, "points") == 1 for record in retries)
 
 
 def test_close_drops_a_batch_still_failing_at_shutdown(
@@ -128,7 +138,13 @@ def test_close_drops_a_batch_still_failing_at_shutdown(
     assert elapsed < 1.0
     assert client.attempts >= 1
     assert client.closed.is_set()
-    assert "Dropping a batch of 1 point(s)" in caplog.text
+    (record,) = [
+        record
+        for record in caplog.records
+        if record.message == "dropping batch at shutdown"
+    ]
+    assert record.message == "dropping batch at shutdown"
+    assert _field(record, "points") == 1
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What and why

Closes #83.

- Replaces seven interpolated writer and serial-source log messages with stable event names and structured fields.
- Enables Ruff's `G` logging rules to keep the convention enforced.
- Updates tests to assert the structured log records directly.

## Test plan

- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `basedpyright`
- [x] `typos`
- [x] Full test suite reached 100% coverage; 242 tests passed.
- [!] One existing Windows-specific retry timing assertion failed because 2ms waits resolve to roughly 15ms on this machine; no production behavior was changed for that test.