### PR TITLE
refactor: name the data instead of formatting it into the message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,35 @@ spline = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.ruff]
+# Matches requires-python above. Without it ruff infers a target from
+# whichever interpreter happens to run it, so a rule that rewrites for a
+# newer Python (pyupgrade) could propose something CI's oldest supported
+# version cannot parse.
+target-version = "py312"
+
+[tool.ruff.lint]
+# Added to ruff's defaults rather than replacing them, so a rule the
+# upstream project decides is worth having by default arrives here too.
+# The cost is that a release can introduce one and turn CI red on code
+# nobody touched; the answer to that is to pin ruff in the dev
+# dependencies when it happens, not to freeze the rule set in advance.
+extend-select = [
+    "G",   # flake8-logging-format
+    "LOG", # flake8-logging
+]
+
+# `G` is the reason this section exists. Every logging call in the package
+# names its data in `extra=` so a collector reads fields rather than
+# parsing a sentence, and nothing enforced that: `G003` had already crept
+# back into writer.py. Note that `G004` flags f-strings in logging calls
+# and leaves `logger.warning("...%r", value)` alone — the lazy form is the
+# endorsed one, so a sweep towards f-strings would fight this rule.
+#
+# `LOG` is its neighbour: `logging.warn()`, a logger built with the wrong
+# name, `.error()` where `.exception()` was meant. Clean today, and it
+# guards the same call sites from a different direction.
+
 [tool.basedpyright]
 include = ["src", "tests", "scripts"]
 stubPath = "typings"

--- a/src/labmon/sensors/serial_source.py
+++ b/src/labmon/sensors/serial_source.py
@@ -77,7 +77,10 @@ def parse_reading(line: bytes) -> RawReading | None:
     try:
         text = line.decode("utf-8").strip()
     except UnicodeDecodeError:
-        logger.warning("Skipping malformed line (not valid UTF-8): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "not valid UTF-8", "line": line},
+        )
         return None
 
     if not text:
@@ -86,25 +89,35 @@ def parse_reading(line: bytes) -> RawReading | None:
     fields = [field.strip() for field in text.split(_FIELD_SEPARATOR)]
     if len(fields) != _FIELDS_PER_LINE:
         logger.warning(
-            "Skipping malformed line (expected '<channel>,<count>'): %r", line
+            "skipping malformed line",
+            extra={"reason": "expected '<channel>,<count>'", "line": line},
         )
         return None
 
     channel, raw_count = fields
     if not channel:
-        logger.warning("Skipping malformed line (empty channel): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "empty channel", "line": line},
+        )
         return None
 
     try:
         count = float(raw_count)
     except ValueError:
-        logger.warning("Skipping malformed line (count is not a number): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "count is not a number", "line": line},
+        )
         return None
 
     # float() accepts "nan" and "inf", which would otherwise reach InfluxDB
     # and poison every aggregate computed over the series.
     if not math.isfinite(count):
-        logger.warning("Skipping malformed line (count is not finite): %r", line)
+        logger.warning(
+            "skipping malformed line",
+            extra={"reason": "count is not finite", "line": line},
+        )
         return None
 
     return RawReading(channel=channel, raw_count=count)

--- a/src/labmon/writer.py
+++ b/src/labmon/writer.py
@@ -111,17 +111,18 @@ class PointWriter[T]:
                 return
             except Exception:
                 logger.warning(
-                    "Write attempt %d failed for a batch of %d point(s);"
-                    + " retrying in %.0fs",
-                    attempt,
-                    len(batch),
-                    backoff,
+                    "write attempt failed",
+                    extra={
+                        "attempt": attempt,
+                        "points": len(batch),
+                        "retry_in_s": f"{backoff:.0f}",
+                    },
                     exc_info=True,
                 )
             if self._stop.wait(timeout=backoff):
                 logger.error(
-                    "Dropping a batch of %d point(s) still unwritten at shutdown",
-                    len(batch),
+                    "dropping an unwritten batch at shutdown",
+                    extra={"points": len(batch)},
                 )
                 return
             backoff = min(backoff * 2, self._max_backoff)

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -10,6 +10,19 @@ from labmon.sensors.serial_source import (
     parse_reading,
 )
 
+# Quoted verbatim from the call site, so a reworded reason fails here
+# rather than silently weakening the assertion to "some warning happened".
+_EXPECTED_SHAPE = "expected '<channel>,<count>'"
+
+
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
 
 class FakeSerialPort:
     """Stands in for a pyserial Serial, replaying canned lines."""
@@ -64,27 +77,33 @@ def test_parse_reading_ignores_a_blank_line() -> None:
 
 
 @pytest.mark.parametrize(
-    "line",
+    ("line", "reason"),
     [
-        pytest.param(b"garbage\n", id="no-separator"),
-        pytest.param(b"A0,2048,extra\n", id="too-many-fields"),
-        pytest.param(b"A0,not-a-number\n", id="non-numeric-count"),
+        pytest.param(b"garbage\n", _EXPECTED_SHAPE, id="no-separator"),
+        pytest.param(b"A0,2048,extra\n", _EXPECTED_SHAPE, id="too-many-fields"),
+        pytest.param(b"A0,not-a-number\n", "count is not a number", id="non-numeric"),
         # float() would accept these where int() did not; a non-finite
         # count reaching InfluxDB poisons every aggregate over the series.
-        pytest.param(b"A0,nan\n", id="nan-count"),
-        pytest.param(b"A0,inf\n", id="inf-count"),
-        pytest.param(b"A0,-inf\n", id="negative-inf-count"),
-        pytest.param(b",2048\n", id="empty-channel"),
-        pytest.param(b"\xff\xfe\n", id="undecodable-bytes"),
+        pytest.param(b"A0,nan\n", "count is not finite", id="nan-count"),
+        pytest.param(b"A0,inf\n", "count is not finite", id="inf-count"),
+        pytest.param(b"A0,-inf\n", "count is not finite", id="negative-inf-count"),
+        pytest.param(b",2048\n", "empty channel", id="empty-channel"),
+        pytest.param(b"\xff\xfe\n", "not valid UTF-8", id="undecodable-bytes"),
     ],
 )
 def test_parse_reading_skips_a_malformed_line(
-    line: bytes, caplog: pytest.LogCaptureFixture
+    line: bytes, reason: str, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING):
         assert parse_reading(line) is None
 
-    assert "Skipping malformed line" in caplog.text
+    # The message is a constant so every cause groups under one `msg`, and
+    # `reason` is what tells them apart — which is the point of putting the
+    # data in fields rather than in the sentence.
+    [record] = caplog.records
+    assert record.getMessage() == "skipping malformed line"
+    assert _field(record, "reason") == reason
+    assert _field(record, "line") == line
 
 
 def test_read_returns_successive_readings() -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,6 +8,15 @@ from labmon import writer as writer_module
 from labmon.writer import PointWriter
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    so this says plainly that the lookup is dynamic.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
 class FakeClient[T]:
     def __init__(self) -> None:
         self.batches: list[list[T]] = []
@@ -108,7 +117,9 @@ def test_write_retries_transient_failures_then_succeeds(
     written = [point for batch in client.batches for point in batch]
     assert written == [1]
     assert client.attempts == 3
-    assert caplog.text.count("Write attempt") == 2
+    retries = [r for r in caplog.records if r.getMessage() == "write attempt failed"]
+    assert [_field(r, "attempt") for r in retries] == [1, 2]
+    assert all(_field(r, "points") == 1 for r in retries)
 
 
 def test_close_drops_a_batch_still_failing_at_shutdown(
@@ -128,7 +139,14 @@ def test_close_drops_a_batch_still_failing_at_shutdown(
     assert elapsed < 1.0
     assert client.attempts >= 1
     assert client.closed.is_set()
-    assert "Dropping a batch of 1 point(s)" in caplog.text
+    # Asserting on the field rather than the sentence: the batch size is
+    # the part that matters, and a reworded message should not fail here.
+    [dropped] = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "dropping an unwritten batch at shutdown"
+    ]
+    assert _field(dropped, "points") == 1
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #83.

Seven logging calls still formatted their data into the message string — the shape logfmt exists to replace. #75 converted the rest; these were the ones it missed.

## What changed

- **`serial_source.py`** — five call sites collapse to one constant `msg` plus a `reason` field. A malformed line used to spread one event across five distinct `msg` values, with the offending bytes inside the message where the quoting rules escaped them a second time. Nothing could count malformed lines, and nothing could break them down by cause. Now `| logfmt | msg="skipping malformed line"` counts all five and `reason` splits them.
- **`writer.py`** — `attempt`, `points` and `retry_in_s` become fields.
- **`[tool.ruff.lint]`** gains `G` (flake8-logging-format) and `LOG` (flake8-logging), so this cannot drift back. `G003` had already crept into `writer.py`.

## The tests got stronger, not just adjusted

Each malformed-line case now asserts *which* `reason` it produced, so a parse branch returning the wrong diagnosis fails where it previously passed on a shared substring. The writer's retry test asserts the attempt numbers and the batch size rather than counting occurrences of a sentence.

## On the ruff section

The families are added to ruff's defaults rather than replacing them, so a rule upstream decides is worth having by default arrives here too. A release can introduce one and turn CI red on untouched code; the answer to that is pinning ruff when it happens rather than freezing the rule set in advance.

`RUF` is deliberately not here — it reports five `pytest.raises(match=...)` patterns whose metacharacters are neither escaped nor raw. That is a real finding and gets its own PR, stacked on this one.

Wider rule-set adoption is tracked separately in #88 and #89.

## Relationship to #90

#90 implemented the same issue independently and arrived first. It could not be merged because `main` requires verified signatures and its commit is unsigned. Its wording for the retry warning was better than what this branch originally had — the message fires on every failed attempt including the last one before the batch is dropped, so the `; retrying` this branch used was false in exactly the case that matters most. That correction is incorporated here.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `typos`
- [x] `pytest --cov=src --cov-fail-under=100` — 243 passed, 100%
