### PR TITLE
test: say which regexes are meant as regexes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ target-version = "py312"
 extend-select = [
     "G",   # flake8-logging-format
     "LOG", # flake8-logging
+    "RUF", # ruff's own rules
 ]
 
 # `G` is the reason this section exists. Every logging call in the package
@@ -63,6 +64,11 @@ extend-select = [
 # `LOG` is its neighbour: `logging.warn()`, a logger built with the wrong
 # name, `.error()` where `.exception()` was meant. Clean today, and it
 # guards the same call sites from a different direction.
+#
+# `RUF043` is why `RUF` is here. A `pytest.raises(match=...)` pattern is a
+# regex whether or not it was meant as one, so `match="a (b)"` silently
+# asserts something other than it appears to. Marking the deliberate ones
+# raw makes the accidental ones visible.
 
 [tool.basedpyright]
 include = ["src", "tests", "scripts"]

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -270,7 +270,7 @@ def test_trial_apply_wraps_an_unexpected_failure() -> None:
             return "broken"
 
     where = Location(Path("calibration.toml"), "A0")
-    with pytest.raises(CalibrationError, match="cannot be applied.*sensor on fire"):
+    with pytest.raises(CalibrationError, match=r"cannot be applied.*sensor on fire"):
         _trial_apply(where, BrokenConversion())
 
 
@@ -605,7 +605,7 @@ def test_load_calibration_rejects_a_missing_key(tmp_path: Path) -> None:
         """,
     )
 
-    with pytest.raises(CalibrationError, match="A0.*missing.*measurement"):
+    with pytest.raises(CalibrationError, match=r"A0.*missing.*measurement"):
         _ = load_calibration(path)
 
 
@@ -620,7 +620,7 @@ def test_load_calibration_rejects_a_non_string_value(tmp_path: Path) -> None:
         """,
     )
 
-    with pytest.raises(CalibrationError, match="A0.*conversion_factor.*string"):
+    with pytest.raises(CalibrationError, match=r"A0.*conversion_factor.*string"):
         _ = load_calibration(path)
 
 
@@ -650,7 +650,7 @@ def test_load_calibration_rejects_an_unknown_unit(tmp_path: Path) -> None:
         """,
     )
 
-    with pytest.raises(CalibrationError, match="A0.*conversion_factor"):
+    with pytest.raises(CalibrationError, match=r"A0.*conversion_factor"):
         _ = load_calibration(path)
 
 
@@ -841,7 +841,7 @@ def test_load_calibration_rejects_points_that_are_not_an_array(tmp_path: Path) -
         """,
     )
 
-    with pytest.raises(CalibrationError, match="voltages.*array of numbers"):
+    with pytest.raises(CalibrationError, match=r"voltages.*array of numbers"):
         _ = load_calibration(path)
 
 


### PR DESCRIPTION
Stacked on #95 — review that one first; this PR's diff against `main` includes it.

`match=` is a regex whether or not the author meant one. All five of these did mean it — `match="A0.*missing.*measurement"` asserts that two fragments appear in that order, not that a literal `.*` appears — so escaping them would have broken exactly what they test.

What was missing is the marker that says so. `RUF043` objects to a pattern that is neither escaped nor raw, because there is no way to read one and tell a deliberate `.*` from a `(` somebody typed into a message and never meant as a group. The `r` prefix changes no behaviour, since none of the five contains a backslash escape, and makes the intent local to the line.

## Why the rule earns its place

The case that is not here yet. A pattern like `match="expected '<channel>,<count>'"` reads as a literal and is not one; a future `match="value (V)"` would quietly assert something other than it appears to, and pass for the wrong reason. Invisible in review, silent at runtime.

`RUF` is enabled wholesale rather than `RUF043` alone: the family is clean across the repo once these five are marked, so there is nothing to weigh against.

Refs #83. Wider rule-set adoption is tracked in #88 and #89.

## Test plan

- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `typos`
- [x] `pytest --cov=src --cov-fail-under=100` — 243 passed, 100%
