### PR TITLE
fix: probe InfluxDB with a TCP connect, not HTTP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,16 +73,22 @@ services:
         target: /var/lib/influxdb3/data
     # influxdb3 takes a few seconds to start accepting connections after the
     # container starts, so `docker compose up -d --wait` needs this to know
-    # when the server is actually ready (any HTTP response counts, even 401).
+    # when the server is actually ready.
     #
-    # It stays unauthenticated on purpose: the token is issued by this server,
-    # so during first-time setup there is no token to send yet, and a check
-    # that required one would never go healthy. The cost is that /health
-    # answers 401 and influxdb3 logs "the request was not authenticated" once
-    # per interval, forever. That line is expected and is not a real failure —
-    # see docs/deployment.md.
+    # This opens the port and closes it without sending a request, which is
+    # what makes it silent. Every influxdb3 endpoint answers 401 without a
+    # token — and the token is issued by this server, so during first-time
+    # setup there is none to send. An HTTP probe therefore had to accept 401
+    # as proof of life, and influxdb3 logged an ERROR for each one: ~164,000
+    # lines a day, invisible while logs were ephemeral and ~5 million per
+    # retention window once the `logs` profile stores them. A TCP connect
+    # asks nothing, so there is nothing to reject and nothing to log.
+    #
+    # It proves the listener is bound rather than that HTTP answers, which
+    # is all the 401 probe established either. `nc` is not in the image;
+    # bash is, and /dev/tcp is a bash builtin rather than a binary.
     healthcheck:
-      test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://127.0.0.1:8181/health"]
+      test: ["CMD", "bash", "-c", "timeout 2 bash -c '</dev/tcp/127.0.0.1/8181'"]
       interval: 1s
       timeout: 2s
       retries: 30
@@ -121,6 +127,10 @@ services:
         source: .grafana/data
         target: /var/lib/grafana
     healthcheck:
+      # Left at one second on purpose. Grafana's /api/health answers 200
+      # without a token and logs nothing per probe, so it never contributed
+      # to the noise that changed the InfluxDB check above — slowing it down
+      # would only delay noticing that Grafana had died.
       test: ["CMD", "curl", "-s", "-o", "/dev/null", "http://127.0.0.1:3000/api/health"]
       interval: 1s
       timeout: 2s

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,16 +46,26 @@ and needs no network when it boots — which is usually what you want on a
 server, at the cost of that one panel not rendering. See
 [`docs/demo-stack.md`](demo-stack.md#the-dashboard-needs-one-panel-plugin).
 
-## Two things in the logs that look wrong and are not
+## Why InfluxDB's healthcheck opens a socket
 
-**InfluxDB logs `the request was not authenticated` once a second.** That is
-its own healthcheck. The token is issued by InfluxDB, so during first-time
-setup there is no token to send, and a healthcheck that required one could
-never go healthy — it therefore calls `/health` unauthenticated and treats
-any response, including 401, as proof the server is up. Every endpoint
-returns 401 without a token, so there is no quieter alternative. Worth
-knowing mainly because it masks *real* auth failures: to see those, filter
-the line out rather than trusting a plain grep for "unauthenticated".
+It connects to port 8181 and closes again, rather than calling `/health`.
+
+Every influxdb3 endpoint answers 401 without a token, and the token is
+issued by InfluxDB itself, so during first-time setup there is none to
+send — a check that required one could never go healthy on a fresh install.
+An HTTP probe therefore had to accept 401 as proof of life, and influxdb3
+logged `the request was not authenticated` at ERROR for every one of them,
+once per interval, forever. A TCP connect sends no request, so there is
+nothing to reject and nothing to log.
+
+It proves the listener is bound rather than that HTTP answers, which is all
+the 401 probe established either.
+
+Worth knowing when reading logs: `the request was not authenticated` now
+indicates a *real* auth failure. It used to be healthcheck noise that had to
+be filtered out first, which masked genuine ones.
+
+## One thing in the logs that looks wrong and is not
 
 **A container called `labmon-init-state-dirs` exits immediately.** That is
 correct — it prepares `.influxdb3/data` and `.grafana/data` and stops. Docker


### PR DESCRIPTION
Closes #42.

InfluxDB's healthcheck now opens port 8181 and closes it again instead of calling `/health`. Grafana's check and both sets of timings are unchanged.

## Why

Every influxdb3 endpoint answers 401 without a token, and the token is issued by influxdb3 itself, so a probe that had to carry one could never go healthy on a fresh install. The old probe therefore accepted 401 as proof of life, and the server logged `the request was not authenticated` at ERROR once per interval — forever.

A TCP connect asks nothing, so there is nothing to reject and nothing to log. It proves the listener is bound rather than that HTTP answers, which is all the 401 probe established either.

As a side effect, `the request was not authenticated` now means a *real* auth failure, where before it was noise that masked genuine ones.

## Measured

Sixty seconds of an idle server, `docker compose logs influxdb`:

| | `not authenticated` | total lines |
|---|---|---|
| before | 57 | 114 |
| after | **0** | 2 |

The healthcheck was producing exactly half of everything InfluxDB logged.

The probe is genuinely running, not silently disabled — `.State.Health.Log` shows `exits=[1 0]`: the first probe fails while influxdb3 is still binding, the second passes.

## Alternatives rejected

**Raising `--wal-flush-interval`** is unrelated; see #86 for the remaining log volume.

**Raising the healthcheck interval to 30s** cut the rate without removing the cause, and made a hung service take fifteen minutes rather than thirty seconds to be marked unhealthy. **Adding `start_interval`** on top then forced `start_period` to stretch over a whole cold start, since `start_interval` only applies inside it. Neither is needed once the probe stops generating the lines at all. Both were attempted on the branch that became #68, now closed.

`nc` is not in the image; bash is, and `/dev/tcp` is a bash builtin rather than a binary, so this installs nothing.

## Test plan

- [x] `docker compose config -q`
- [x] Cold start, twelve services, demo + logs profiles — 14.1s to healthy
- [x] Zero `not authenticated` lines in the first thirty seconds
- [x] `scripts/smoke_dashboard.py` — all fourteen queries returned rows
- [x] Probe exits 0 against a live port, 1 with no listener, 124 against a black-holed address
