### PR TITLE
fix: fall back when a setting is empty, not only when unset

### DIFF
--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -4,8 +4,23 @@ import os
 
 from influxdb_client_3 import InfluxDBClient3
 
-INFLUXDB_HOST = os.environ.get("INFLUXDB_HOST", "http://localhost:8181")
-INFLUXDB_DATABASE = os.environ.get("INFLUXDB_DATABASE", "lab")
+
+def _setting(name: str, default: str) -> str:
+    """Value of `name`, falling back when it is unset *or* empty.
+
+    `os.environ.get(name, default)` falls back only when the variable is
+    absent, which is not how the rest of the stack behaves. `.env.example`
+    ships INFLUXDB_DATABASE empty and Compose reads it as
+    `${INFLUXDB_DATABASE:-lab}`, whose default applies to an empty value
+    too. Anything host-side sourcing that same file has to agree, or it
+    connects to a database named "" and fails with a server-side error
+    that names neither the variable nor the value.
+    """
+    return os.environ.get(name) or default
+
+
+INFLUXDB_HOST = _setting("INFLUXDB_HOST", "http://localhost:8181")
+INFLUXDB_DATABASE = _setting("INFLUXDB_DATABASE", "lab")
 
 
 def get_client() -> InfluxDBClient3:

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -1,7 +1,36 @@
 import pytest
 from influxdb_client_3 import InfluxDBClient3
 
-from labmon.influx import get_client
+from labmon.influx import (
+    _setting,  # pyright: ignore[reportPrivateUsage]
+    get_client,
+)
+
+_NAME = "LABMON_TEST_SETTING"
+
+
+def test_setting_prefers_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_NAME, "chosen")
+
+    assert _setting(_NAME, "fallback") == "chosen"
+
+
+def test_setting_falls_back_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_NAME, raising=False)
+
+    assert _setting(_NAME, "fallback") == "fallback"
+
+
+def test_setting_falls_back_when_set_but_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The reported bug. `.env.example` ships INFLUXDB_DATABASE empty and
+    # Compose substitutes its default on empty as well as unset, so a
+    # host-side script sourcing that file has to do the same or it selects
+    # a database named "".
+    monkeypatch.setenv(_NAME, "")
+
+    assert _setting(_NAME, "fallback") == "fallback"
 
 
 def test_get_client_raises_without_auth_token(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #79.

`INFLUXDB_HOST` and `INFLUXDB_DATABASE` now fall back when the variable is **empty** as well as absent.

## Why

`os.environ.get(name, default)` returns the default only when a variable is missing. Set-but-empty returns `""` — and `.env.example` ships `INFLUXDB_DATABASE=` empty on purpose, because Compose reads it as `${INFLUXDB_DATABASE:-lab}` and that default covers empty too. The file is correct from Compose's side.

Anything host-side reading the same file disagreed. `CONTRIBUTING.md` tells contributors to source `.env` before running `scripts/smoke_dashboard.py`, so copying `.env.example` unchanged and following the instructions selected a database named `""` and failed with:

```
Cannot retrieve database: External error: database not found
```

which names neither the variable nor the value, and points at the server rather than at the configuration.

`INFLUXDB_HOST` had the same defect and is fixed with it. Nothing shipped it empty, but the two are read the same way three lines apart, and leaving one behind invites the bug back.

The helper exists rather than an inline `or` so the reasoning is written down once instead of twice, and so the behaviour is testable without reimporting the module to re-evaluate its constants.

## Test plan

- [x] Unit tests for set / unset / set-but-empty
- [x] Verified with both variables set empty, as `.env.example` ships them: database resolves to `lab`, host to `http://localhost:8181`
- [x] `pytest --cov=src --cov-fail-under=100` — 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright`, `typos`
