### PR TITLE
fix: skip a reading a conversion made non-finite

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -72,7 +72,7 @@ still read the line.
 
 ```
 ts=2026-08-04T09:31:07.412+00:00 level=info logger=labmon.sensors.loop \
-  msg="wrote readings" readings=7 sensor_id=room-1 window_s=30
+  msg="wrote readings" readings=7 sensor_id=room-1 skipped=0 window_s=30
 ```
 
 Query on the fields in Grafana:
@@ -92,6 +92,22 @@ storing a second copy of what InfluxDB already holds far more compactly.
 summary every 30s, every warning and every error. Those are what you
 correlate against a flat trace — "why did this stop" is answered by a
 warning, not by the last normal reading.
+
+`skipped` counts readings that arrived and could not be written, which
+today means a conversion produced `nan` or `inf` — a formula undefined
+over part of its range, or a factor large enough to overflow. The first
+one on a channel also logs a warning naming the sensor; after that the
+count is the only report, so a channel producing nothing else stays
+visible without a line per reading:
+
+```logql
+{container=~".+"} | logfmt | skipped > 0
+```
+
+A sensor appears in the summary even when it wrote nothing at all, which
+is the case worth seeing: the trace is flat, and this line is the only
+thing that distinguishes readings arriving unwritable from a sensor that
+died.
 
 To see every reading while bringing a board up:
 

--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -14,6 +14,7 @@ was the same.
 """
 
 import logging
+import math
 import signal
 import sys
 import time
@@ -72,6 +73,8 @@ class SensorLoop:
         self.writer: PointWriter[Point] = writer or PointWriter[Point](get_client())
         self._summary_interval: float | None = summary_interval
         self._written: Counter[str] = Counter()
+        self._skipped: Counter[str] = Counter()
+        self._warned: set[str] = set()
         self._next_summary: float = time.monotonic() + (summary_interval or 0.0)
 
         def shutdown(_signum: int, _frame: FrameType | None) -> None:
@@ -82,6 +85,38 @@ class SensorLoop:
 
         _ = signal.signal(signal.SIGINT, shutdown)
         _ = signal.signal(signal.SIGTERM, shutdown)
+
+    def admits(self, value: float, *, sensor_id: str) -> bool:
+        """Whether a reading can be written, warning once if it cannot.
+
+        A conversion can produce `nan` or `inf` without raising — `log(v -
+        2.0)` below two volts, an affine factor large enough to overflow, a
+        spline through awkward points. `float()` accepts both, so the value
+        reaches InfluxDB looking like any other, and one of them poisons
+        every average, minimum and maximum over that series from then on.
+        `serial_source.parse_reading` already guards the input side for the
+        same reason; this is the output side.
+
+        Refusing is not enough on its own, because a gap in a trace looks
+        the same as a dead sensor. So the first refusal for a sensor says
+        so at WARNING, and every refusal is counted into the periodic
+        summary. One line establishes that it is happening; the count
+        establishes how much, which is what separates a transient from a
+        calibration that is wrong across half its range.
+
+        Warning once per sensor rather than once per reading is the shape
+        `serial_sensor` already uses for a channel with no calibration.
+        """
+        if math.isfinite(value):
+            return True
+        self._skipped[sensor_id] += 1
+        if sensor_id not in self._warned:
+            self._warned.add(sensor_id)
+            logger.warning(
+                "conversion produced a non-finite value; skipping those readings",
+                extra={"sensor_id": sensor_id, "value": repr(value)},
+            )
+        return False
 
     def record(self, point: Point, sensor_id: str) -> None:
         """Queue a point and count it towards the next summary."""
@@ -102,14 +137,19 @@ class SensorLoop:
         # One line per sensor rather than one line listing all of them:
         # each carries its own sensor_id field, so a collector can label
         # it and a query for one instrument returns only its own lines.
-        for sensor_id, count in sorted(self._written.items()):
+        # Sensors that only skipped are reported too, which is the case
+        # most worth seeing: the trace is flat, and this line is the only
+        # thing that can say the readings arrived and were unwritable.
+        for sensor_id in sorted(set(self._written) | set(self._skipped)):
             logger.info(
                 "wrote readings",
                 extra={
                     "sensor_id": sensor_id,
-                    "readings": count,
+                    "readings": self._written[sensor_id],
+                    "skipped": self._skipped[sensor_id],
                     "window_s": f"{self._summary_interval:.0f}",
                 },
             )
         self._written.clear()
+        self._skipped.clear()
         self._next_summary = now + self._summary_interval

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -98,15 +98,21 @@ def run(
     while True:
         reading_time = datetime.now(UTC)
         reading = walk.next()
-        point = Point(measurement).tag("sensor_id", sensor_id)
-        if unit:
-            point = point.tag("unit", unit)
-        point = point.field(field, reading).time(reading_time, write_precision="ms")
-        loop.record(point, sensor_id)
-        logger.debug(
-            "reading",
-            extra={"sensor_id": sensor_id, "value": f"{reading:.4g}", "unit": unit},
-        )
+        # The walk cannot currently produce one, but this file is also the
+        # template a user copies and edits, and the guard belongs wherever
+        # a value becomes a field. Guarding the write rather than skipping
+        # the rest of the iteration, so the pacing stays in one place and a
+        # bad reading cannot turn the loop into a spin.
+        if loop.admits(reading, sensor_id=sensor_id):
+            point = Point(measurement).tag("sensor_id", sensor_id)
+            if unit:
+                point = point.tag("unit", unit)
+            point = point.field(field, reading).time(reading_time, write_precision="ms")
+            loop.record(point, sensor_id)
+            logger.debug(
+                "reading",
+                extra={"sensor_id": sensor_id, "value": f"{reading:.4g}", "unit": unit},
+            )
         loop.summarise_if_due()
         time.sleep(interval)
 

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -37,6 +37,7 @@ Requires INFLUXDB3_AUTH_TOKEN to be set (e.g. via .env / direnv).
 """
 
 import logging
+import math
 import time
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
@@ -71,7 +72,14 @@ def build_point(
     Exposed so a sensor with something unusual to record — several fields
     from one device read, say — can build on the same tag conventions
     rather than inventing its own.
+
+    Raises ValueError for a non-finite value. `float()` accepts `nan` and
+    `inf`, and one of either poisons every average, minimum and maximum
+    over the series from then on, so the primitive refuses to build one
+    rather than leaving each caller to remember.
     """
+    if not math.isfinite(value):
+        raise ValueError(f"refusing to build a point for a non-finite value: {value!r}")
     point = Point(measurement).tag("sensor_id", sensor_id)
     # An empty unit tag is not the same as no unit tag: it would split the
     # series in two, and the halves would look identical in a legend.
@@ -103,7 +111,19 @@ def write_reading(
     its WAL (see docs/latency.md). That is the price of the reading
     actually being stored, and it is paid once per run rather than once per
     reading.
+
+    A non-finite reading is reported and skipped rather than raised. This
+    typically runs under a systemd timer with Restart=on-failure, where an
+    exception would turn one bad reading from a vendor API into a restart
+    loop; there is no next tick to recover on, so the run ends cleanly
+    having written nothing.
     """
+    if not math.isfinite(value):
+        logger.warning(
+            "reading is non-finite; writing nothing",
+            extra={"sensor_id": sensor_id, "value": repr(value)},
+        )
+        return
     client = get_client()
     try:
         client.write(
@@ -183,7 +203,7 @@ def poll(
             continue
 
         backoff = initial_backoff
-        if value is not None:
+        if value is not None and loop.admits(value, sensor_id=sensor_id):
             point = build_point(
                 value,
                 sensor_id=sensor_id,

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -149,6 +149,12 @@ def run(
         voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)
         value = calibration.conversion.apply(voltage)
 
+        # Before the gate, which compares against bounds: every comparison
+        # with a NaN is False, so a gate would admit it and a gate-less
+        # channel would never look at it at all.
+        if not loop.admits(value.magnitude, sensor_id=calibration.sensor_id):
+            continue
+
         gate = gates.get(reading.channel)
         if gate is not None and not gate.admits(value, voltage):
             # Nothing is written at all, not even input_volts: a

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -171,6 +171,121 @@ def test_a_loop_without_a_summary_never_emits_one(
 
 
 # --------------------------------------------------------------------------
+# Readings a conversion made non-finite
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_a_non_finite_reading_is_refused_and_warned_about(
+    value: float, caplog: pytest.LogCaptureFixture
+) -> None:
+    loop = SensorLoop()
+
+    with caplog.at_level(logging.WARNING, logger=sensor_loop.logger.name):
+        admitted = loop.admits(value, sensor_id="cryo-diode")
+
+    assert admitted is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert _field(warnings[0], "sensor_id") == "cryo-diode"
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_a_finite_reading_is_admitted_without_a_word(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    loop = SensorLoop()
+
+    with caplog.at_level(logging.DEBUG, logger=sensor_loop.logger.name):
+        admitted = loop.admits(1.0, sensor_id="cryo-diode")
+
+    assert admitted is True
+    assert caplog.records == []
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_the_warning_is_once_per_sensor_not_once_per_reading(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A calibration wrong below some voltage fires on every reading.
+
+    One line saying so is the signal; the rest is the summary's job.
+    """
+    loop = SensorLoop()
+
+    with caplog.at_level(logging.WARNING, logger=sensor_loop.logger.name):
+        for _ in range(3):
+            _ = loop.admits(float("nan"), sensor_id="cryo-diode")
+        _ = loop.admits(float("nan"), sensor_id="room-1")
+
+    warned = [_field(r, "sensor_id") for r in caplog.records]
+    assert warned == ["cryo-diode", "room-1"]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_the_summary_counts_what_was_skipped(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    loop.record(_point(1.0), "cryo-diode")
+    _ = loop.admits(float("nan"), sensor_id="cryo-diode")
+    _ = loop.admits(float("nan"), sensor_id="cryo-diode")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [(_field(r, "readings"), _field(r, "skipped")) for r in summaries] == [
+        (1, 2)
+    ]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_a_sensor_that_only_skipped_is_still_reported(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Otherwise a channel producing nothing but NaN vanishes from the log.
+
+    Which is the case most worth seeing: the trace is flat and the
+    summary is the only thing that can say why.
+    """
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    _ = loop.admits(float("nan"), sensor_id="cryo-diode")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [
+        (_field(r, "sensor_id"), _field(r, "readings"), _field(r, "skipped"))
+        for r in summaries
+    ] == [("cryo-diode", 0, 1)]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_skips_do_not_carry_into_the_next_window(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    interval = sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS
+    ticks = iter([0.0, interval + 1.0, 2 * interval + 2.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    _ = loop.admits(float("nan"), sensor_id="cryo-diode")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+        caplog.clear()
+        loop.summarise_if_due()
+
+    assert "wrote readings" not in caplog.text
+
+
+# --------------------------------------------------------------------------
 # Tuning the writer without editing installed source
 # --------------------------------------------------------------------------
 

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -183,6 +183,66 @@ def _stop_after(values: list[float | None]) -> Callable[[], float | None]:
     return read
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_build_point_refuses_a_non_finite_value(value: float) -> None:
+    """The primitive will not construct a point that poisons a series."""
+    with pytest.raises(ValueError, match="non-finite"):
+        _ = build_point(value, sensor_id="c", measurement="m")
+
+
+def test_write_reading_skips_a_non_finite_value_without_raising(
+    fake_client: FakeInfluxClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A one-shot run under a systemd timer must not fail on a bad read.
+
+    Restart=on-failure would turn one NaN from a vendor API into a
+    restart loop, so this reports and exits cleanly having written
+    nothing.
+    """
+    with caplog.at_level(logging.WARNING, logger=polling.logger.name):
+        write_reading(float("nan"), sensor_id="c", measurement="m")
+
+    assert fake_client.points == []
+    # No connection is opened at all: there is nothing to send, and a
+    # timer-driven script should not touch the network to decide that.
+    assert fake_client.closed is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert _field(warnings[0], "sensor_id") == "c"
+
+
+@pytest.mark.usefixtures("no_sleep")
+def test_poll_keeps_going_after_a_non_finite_reading(
+    fake_client: FakeInfluxClient,
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The transient case: good, two bad, good again.
+
+    The valid readings either side must still be written — a conversion
+    that fails at one voltage says nothing about the rest of the range.
+    """
+    with (
+        caplog.at_level(logging.WARNING, logger=sensor_loop.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        poll(
+            _stop_after([1.0, float("nan"), float("nan"), 2.0]),
+            sensor_id="c",
+            measurement="m",
+        )
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    values = [
+        point.to_line_protocol().split("value=")[1].split()[0]
+        for point in fake_client.points
+    ]
+    assert values == ["1", "2"]
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
 @pytest.mark.usefixtures("no_sleep")
 def test_poll_flushes_everything_it_read_on_shutdown(
     fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 from types import FrameType
 
+import pint
 import pytest
 from influxdb_client_3 import Point
 
@@ -58,6 +59,23 @@ class FakeRawSource:
 
     def close(self) -> None:
         self.closed = True
+
+
+class _UndefinedBelowMidscale:
+    """A conversion with no value over part of its range.
+
+    Stands in for the reported case, `log(v - 2.0)`, without needing an
+    asteval interpreter — and makes the point that the guard is not
+    specific to expression conversions. A spline through awkward points or
+    an affine factor large enough to overflow arrives the same way.
+    """
+
+    def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
+        volts = voltage.to(ureg.volt).magnitude
+        return (float("nan") if volts < 1.65 else 42.5 * volts) * ureg.kelvin
+
+    def fingerprint(self) -> str:
+        return "test|undefined-below-midscale"
 
 
 def _temperature_calibration(store_input: bool = True) -> Calibration:
@@ -230,6 +248,44 @@ def test_run_skips_reads_that_produced_nothing(
         registered_handlers[signal.SIGINT](signal.SIGINT, None)
 
     assert fake_client.batches == []
+
+
+def test_run_skips_a_non_finite_conversion_and_keeps_the_rest(
+    fake_client: FakeInfluxClient,
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The transient case: valid, two undefined, valid again.
+
+    A conversion undefined at one end of its range says nothing about the
+    rest, so the readings either side are still written. Only the two that
+    have no value are dropped, and one line says so.
+    """
+    calibration = Calibration(
+        sensor_id="cryo-diode",
+        measurement="temperature",
+        conversion=_UndefinedBelowMidscale(),
+    )
+    source = FakeRawSource(
+        [
+            RawReading(channel="A0", raw_count=4095),
+            RawReading(channel="A0", raw_count=0),
+            RawReading(channel="A0", raw_count=100),
+            RawReading(channel="A0", raw_count=4095),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING), pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": calibration})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    written = [point for batch in fake_client.batches for point in batch]
+    assert len(written) == 2
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert _field(warnings[0], "sensor_id") == "cryo-diode"
 
 
 def test_run_warns_once_per_uncalibrated_channel(


### PR DESCRIPTION
Closes #70.

A reading that a conversion made `nan` or `inf` is no longer written. The first one on a sensor logs a warning; every one is counted into the periodic summary.

## Why

A conversion can produce a non-finite value without raising. `log(v - 2.0)` is `nan` at one volt and `-inf` at two, an affine factor can overflow, and a spline through awkward points can do either. `float()` accepts all of them, so the value reached InfluxDB looking like any other reading — and one of them poisons every average, minimum and maximum over that series from then on, retroactively, for the whole retention window.

`serial_source.parse_reading` already guarded the **input** side, with a comment giving exactly this reasoning. Nothing guarded the **output** side. That asymmetry was the bug.

The check lives where a value becomes a field rather than in any one conversion type, because interpolation and affine conversions reach it the same way an expression does.

## Reporting, not just refusing

A gap in a trace looks exactly like a dead sensor, so refusing alone would not be enough:

- the **first** refusal per sensor logs a WARNING naming it — the same warn-once shape `serial_sensor` already uses for a channel with no calibration
- **every** refusal increments `skipped` in the 30s summary

One line establishes that it is happening; the count establishes how much, which separates a transient glitch from a calibration wrong across half its range. A sensor now appears in the summary even when it wrote nothing at all — the case most worth seeing, since the trace is flat and the summary is the only thing that can say the readings arrived and were unwritable.

## The three entry points differ deliberately

| | Behaviour | Why |
|---|---|---|
| `poll()` | skip the tick | there is a next one |
| `write_reading()` | warn, return, open no connection | runs under a systemd timer where `Restart=on-failure` would turn one bad reading into a restart loop |
| `build_point()` | raise `ValueError` | a caller building a point by hand asked for something that cannot exist |

In `serial_sensor` the check runs **before** the recording gate: every comparison against a NaN is false, so a gate would have admitted it and a gate-less channel would never have looked.

`docs/logging.md` gains the `skipped` field and the query for it.

## Test plan

- [x] Transient case asserted directly — good, two bad, good again; both valid readings still written, one warning logged
- [x] Warn-once-per-sensor, and a sensor that only skipped still reported
- [x] `pytest --cov=src --cov-fail-under=100` — 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright`, `typos`
