### PR TITLE
fix: type-check the code users copy

### DIFF
--- a/demo/adc_feeder.py
+++ b/demo/adc_feeder.py
@@ -24,7 +24,7 @@ import socket
 import sys
 import time
 from datetime import UTC, datetime
-from typing import override
+from typing import cast, override
 
 # Loopback by default, so running this directly on a workstation cannot
 # expose the feeder to the network. The demo container overrides it with
@@ -111,8 +111,15 @@ def serve(host: str = HOST, port: int = PORT) -> None:
 
     started = time.monotonic()
     while True:
-        client, address = listener.accept()
-        logger.info('msg="client connected" peer=%s', address[0])
+        # Indexed rather than unpacked. `accept()` returns the peer address
+        # as `Any` in typeshed, because its shape depends on the address
+        # family, and unpacking binds that `Any` to a name — which is what
+        # a type checker objects to. Indexing keeps it unnamed until the
+        # cast says what an AF_INET address actually is.
+        accepted = listener.accept()
+        client = accepted[0]
+        peer, _port = cast(tuple[str, int], accepted[1])
+        logger.info('msg="client connected" peer=%s', peer)
         try:
             with client:
                 while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.basedpyright]
-include = ["src", "tests", "scripts"]
+include = ["src", "tests", "scripts", "demo", "templates"]
 stubPath = "typings"
 
 [tool.coverage.run]


### PR DESCRIPTION
Closes #82.

`basedpyright` now covers `demo/` and `templates/` too, matching what `ruff check .` already saw.

## Why these two directories

`templates/custom-sensor/` is what a user copies as the starting point for their own sensor — the one place in this repo where a type error propagates into somebody else's project instead of staying in ours. `demo/adc_feeder.py` ships inside the image and is among the first code a new user reads.

`templates/` was already clean and cost nothing. The feeder produced two `reportAny` warnings, both from `socket.accept()`, whose address half is `Any` in typeshed because its shape depends on the address family. Unpacking binds that `Any` to a name, which is what the check objects to, so a cast afterwards does not help — indexing keeps it unnamed until the cast says what an AF_INET address is.

## The enforcement is real, not nominal

`_UtcMilliseconds.formatTime` carries `@override`, and nothing verified it. Renaming its `datefmt` parameter now fails the build:

```
Parameter 3 name mismatch: base parameter is named "datefmt",
override parameter is named "_datefmt"   (reportIncompatibleMethodOverride)
```

Before this, that reached `main` green and failed only when the demo was actually run.

## Test plan

- [x] `basedpyright` across all five directories — 0 errors, 0 warnings
- [x] Confirmed the override rule fires by temporarily renaming the parameter, then restoring
- [x] **The feeder still runs**, not just type-checks: started directly, accepted a connection, logged `peer=127.0.0.1` from the cast address, streamed channel readings, and returned to waiting when the client disconnected
- [x] `ruff check`, `ruff format --check`, `typos`, `pytest` at 100%
