### PR TITLE
fix: always report whether a sensor is still alive

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -127,6 +127,14 @@ is the case worth seeing: the trace is flat, and this line is the only
 thing that distinguishes readings arriving unwritable from a sensor that
 died.
 
+That holds for a sensor which produced *nothing* too, not only one whose
+readings were rejected. Each loop declares the sensors it is responsible
+for — from the calibration file, for `serial-sensor` — so a channel that
+has never said a word still reports `readings=0 skipped=0` every window.
+An instrument that is powered off, a board that has stopped talking and a
+process that has died are three different situations, and only the last
+one produces no line.
+
 To see every reading while bringing a board up:
 
 ```bash

--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -19,6 +19,7 @@ import signal
 import sys
 import time
 from collections import Counter
+from collections.abc import Iterable
 from types import FrameType
 from typing import Protocol
 
@@ -69,9 +70,16 @@ class SensorLoop:
         closes: Closeable | None = None,
         summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
         writer: PointWriter[Point] | None = None,
+        sensors: Iterable[str] = (),
     ) -> None:
         self.writer: PointWriter[Point] = writer or PointWriter[Point](get_client())
         self._summary_interval: float | None = summary_interval
+        # The sensors this loop is responsible for, whether or not they
+        # ever produce anything. Without them the summary can only report
+        # sensors that were seen, so a board that says nothing says nothing
+        # here either — and silence is the state the summary exists to
+        # distinguish from a dead process.
+        self._sensors: frozenset[str] = frozenset(sensors)
         self._written: Counter[str] = Counter()
         self._skipped: Counter[str] = Counter()
         self._warned: set[str] = set()
@@ -140,7 +148,9 @@ class SensorLoop:
         # Sensors that only skipped are reported too, which is the case
         # most worth seeing: the trace is flat, and this line is the only
         # thing that can say the readings arrived and were unwritable.
-        for sensor_id in sorted(set(self._written) | set(self._skipped)):
+        for sensor_id in sorted(
+            self._sensors | set(self._written) | set(self._skipped)
+        ):
             logger.info(
                 "wrote readings",
                 extra={

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -83,7 +83,7 @@ def run(
     # The summary is on now that per-reading lines are DEBUG. Without it a
     # sensor at the default level would say nothing at all after startup,
     # and silence is indistinguishable from a wedged process.
-    loop = SensorLoop(summary_interval=summary_interval)
+    loop = SensorLoop(summary_interval=summary_interval, sensors=(sensor_id,))
     walk = RandomWalk(setpoint=setpoint, noise=noise, log_scale=log_scale)
 
     logger.info(

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -175,7 +175,7 @@ def poll(
     Runs until SIGINT (Ctrl+C) or SIGTERM (e.g. `docker stop`), at which
     point queued readings are flushed and the client closed.
     """
-    loop = SensorLoop(summary_interval=summary_interval)
+    loop = SensorLoop(summary_interval=summary_interval, sensors=(sensor_id,))
 
     logger.info(
         "writing readings",

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -106,7 +106,13 @@ def run(
     """
     # The port is closed before the writer, so nothing new arrives while
     # the queue drains.
-    loop = SensorLoop(closes=source, summary_interval=summary_interval)
+    loop = SensorLoop(
+        closes=source,
+        summary_interval=summary_interval,
+        # Declared from the calibration file, so a channel that never
+        # reports still appears in the summary as zero.
+        sensors={calibration.sensor_id for calibration in calibrations.values()},
+    )
 
     logger.info(
         "writing calibrated readings",
@@ -132,61 +138,72 @@ def run(
     }
 
     while True:
-        reading = source.read()
-        if reading is None:
-            continue
+        # `finally`, so the summary runs whatever this iteration did. Every
+        # path below can `continue` — a read timeout, an uncalibrated
+        # channel, a non-finite conversion, a closed gate — and skipping
+        # the summary on those suppresses it exactly when it matters: a
+        # silent board, a fully gated channel set and an all-uncalibrated
+        # stream would each produce no output at all, leaving "working but
+        # quiet" indistinguishable from "wedged". Keeping it at the end of
+        # the iteration rather than the start means a summary still reports
+        # the readings it covers, instead of lagging one behind.
+        try:
+            reading = source.read()
+            if reading is None:
+                continue
 
-        calibration = calibrations.get(reading.channel)
-        if calibration is None:
-            if reading.channel not in warned_channels:
-                warned_channels.add(reading.channel)
-                logger.warning(
-                    "no calibration for channel; ignoring its readings",
-                    extra={"channel": reading.channel},
-                )
-            continue
+            calibration = calibrations.get(reading.channel)
+            if calibration is None:
+                if reading.channel not in warned_channels:
+                    warned_channels.add(reading.channel)
+                    logger.warning(
+                        "no calibration for channel; ignoring its readings",
+                        extra={"channel": reading.channel},
+                    )
+                continue
 
-        voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)
-        value = calibration.conversion.apply(voltage)
+            voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)
+            value = calibration.conversion.apply(voltage)
 
-        # Before the gate, which compares against bounds: every comparison
-        # with a NaN is False, so a gate would admit it and a gate-less
-        # channel would never look at it at all.
-        if not loop.admits(value.magnitude, sensor_id=calibration.sensor_id):
-            continue
+            # Before the gate, which compares against bounds: every comparison
+            # with a NaN is False, so a gate would admit it and a gate-less
+            # channel would never look at it at all.
+            if not loop.admits(value.magnitude, sensor_id=calibration.sensor_id):
+                continue
 
-        gate = gates.get(reading.channel)
-        if gate is not None and not gate.admits(value, voltage):
-            # Nothing is written at all, not even input_volts: a
-            # half-populated series is harder to read than a gap, and the
-            # transition the gate logged is the evidence for the gap.
-            continue
+            gate = gates.get(reading.channel)
+            if gate is not None and not gate.admits(value, voltage):
+                # Nothing is written at all, not even input_volts: a
+                # half-populated series is harder to read than a gap, and the
+                # transition the gate logged is the evidence for the gap.
+                continue
 
-        # The board has no clock, so the host stamps the reading on
-        # arrival; serial transit is negligible next to sample rates here.
-        point = (
-            Point(calibration.measurement)
-            .tag("sensor_id", calibration.sensor_id)
-            .tag("unit", calibration.unit)
-            .tag(CALIBRATION_ID_TAG, calibration.calibration_id)
-            .field(FIELD_NAME, value.magnitude)
-            .time(datetime.now(UTC), write_precision="ms")
-        )
-        if calibration.store_input:
-            # Keeping the conversion's input makes a wrong calibration
-            # correctable after the fact; without it, readings already
-            # written can't be recomputed.
-            point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
-        loop.record(point, calibration.sensor_id)
-        logger.debug(
-            "reading",
-            extra={
-                "sensor_id": calibration.sensor_id,
-                "value": f"{value.magnitude:.4g}",
-                "unit": calibration.unit,
-            },
-        )
-        loop.summarise_if_due()
+            # The board has no clock, so the host stamps the reading on
+            # arrival; serial transit is negligible next to sample rates here.
+            point = (
+                Point(calibration.measurement)
+                .tag("sensor_id", calibration.sensor_id)
+                .tag("unit", calibration.unit)
+                .tag(CALIBRATION_ID_TAG, calibration.calibration_id)
+                .field(FIELD_NAME, value.magnitude)
+                .time(datetime.now(UTC), write_precision="ms")
+            )
+            if calibration.store_input:
+                # Keeping the conversion's input makes a wrong calibration
+                # correctable after the fact; without it, readings already
+                # written can't be recomputed.
+                point = point.field(INPUT_FIELD_NAME, voltage.to(ureg.volt).magnitude)
+            loop.record(point, calibration.sensor_id)
+            logger.debug(
+                "reading",
+                extra={
+                    "sensor_id": calibration.sensor_id,
+                    "value": f"{value.magnitude:.4g}",
+                    "unit": calibration.unit,
+                },
+            )
+        finally:
+            loop.summarise_if_due()
 
 
 def main() -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -157,6 +157,31 @@ def test_the_summary_waits_for_its_interval(
 
 
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
+def test_a_declared_sensor_is_reported_even_having_done_nothing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The silent-instrument case, which the counters alone cannot see.
+
+    `_written` and `_skipped` only know about sensors that produced
+    something. A board that says nothing at all leaves both empty, so a
+    summary built from them is not merely zero — it is absent, and an
+    absent line reads as a dead process rather than a quiet one.
+    """
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop(sensors=("cryo-diode", "room-1"))
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert [
+        (_field(r, "sensor_id"), _field(r, "readings"), _field(r, "skipped"))
+        for r in summaries
+    ] == [("cryo-diode", 0, 0), ("room-1", 0, 0)]
+
+
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
 def test_a_loop_without_a_summary_never_emits_one(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -33,6 +33,22 @@ class _StopLoop(Exception):
     pass
 
 
+def _clock(*ticks: float) -> Callable[[], float]:
+    """A `time.monotonic` stand-in that holds its final value.
+
+    These tests care that the clock crosses the summary interval, not how
+    many times the loop happens to read it. A plain iterator pins the call
+    count, so an unrelated change to the loop body fails here with a
+    `StopIteration` that says nothing about what broke.
+    """
+    values = list(ticks)
+
+    def read() -> float:
+        return values.pop(0) if len(values) > 1 else values[0]
+
+    return read
+
+
 class FakeInfluxClient:
     def __init__(self) -> None:
         self.batches: list[list[Point]] = []
@@ -248,6 +264,42 @@ def test_run_skips_reads_that_produced_nothing(
         registered_handlers[signal.SIGINT](signal.SIGINT, None)
 
     assert fake_client.batches == []
+
+
+@pytest.mark.usefixtures("fake_client")
+def test_run_still_summarises_when_the_board_says_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A silent board is the case the summary exists to report on.
+
+    `None` is what a read timeout looks like. If the summary only runs on
+    an iteration that wrote something, a board that has stopped talking
+    produces no output at all — and "working but quiet" becomes
+    indistinguishable from "wedged", which is the one distinction this
+    line is for.
+    """
+    monkeypatch.setattr(
+        time,
+        "monotonic",
+        _clock(0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0),
+    )
+    source = FakeRawSource([None, None])
+
+    with (
+        caplog.at_level(logging.INFO, logger=sensor_loop.logger.name),
+        pytest.raises(_StopLoop),
+    ):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    # Nothing was written, and the summary says exactly that rather than
+    # being absent.
+    summaries = [r for r in caplog.records if r.getMessage() == "wrote readings"]
+    assert summaries != [], "a silent source produced no summary at all"
 
 
 def test_run_skips_a_non_finite_conversion_and_keeps_the_rest(
@@ -468,8 +520,11 @@ def test_a_summary_is_logged_once_the_interval_elapses(
     # so exactly one summary covering both should be emitted. Patched on
     # the time module itself, which serial_sensor imports rather than
     # re-exports.
-    ticks = iter([0.0, 1.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
-    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(
+        time,
+        "monotonic",
+        _clock(0.0, 1.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0),
+    )
     source = FakeRawSource(
         [
             RawReading(channel="A0", raw_count=4095),


### PR DESCRIPTION
Closes #108.

The periodic summary exists to separate "working but quiet" from "wedged", and it went missing in exactly that situation — for **two** independent reasons.

## 1. The call was skipped by every `continue`

In `serial_sensor.run()` the call sat at the end of the loop body, after four `continue` statements: a read timeout, an uncalibrated channel, a non-finite conversion, a closed gate. So it only ran on an iteration that successfully wrote a reading. `polling.poll` and `mock_sensor.run` already called it unconditionally.

Fixed by wrapping the body in `try`/`finally` rather than moving the call to the top of the loop. Top placement also works, but it makes each summary report the *previous* iteration's readings — the existing test asserting that a summary after two readings reports two would have had to be weakened to accept one, which is a real loss of meaning rather than a test detail.

## 2. Fixing the placement was not sufficient

This only showed up because the new test drove a genuinely silent source and still failed.

`summarise_if_due` iterated `set(self._written) | set(self._skipped)`. Both counters only know about sensors that *produced* something, so a board saying nothing at all leaves both empty and the loop body never executes — no line, however often the method is called.

`SensorLoop` now takes the sensors it is responsible for and reports each one every window regardless. `serial-sensor` declares them from the calibration file; the other two pass their single `sensor_id`.

The distinction this restores is between three states that look identical in a flat trace: an instrument powered off, a board that has stopped talking, and a process that has died. Only the last should produce no line.

## Incidental

- `docs/logging.md` already claimed a sensor appears in the summary having written nothing. That was true only for the *skipped* case; it is now true as written.
- Both summary-interval tests used an exhaustible tick iterator, which pinned the *number* of `time.monotonic` calls as well as their values — any change to the loop body failed them with a `StopIteration` naming nothing. Replaced with a clock that holds its final value.

## Test plan

- [x] New test drives a source yielding only `None` and asserts a summary is still emitted — fails on `main`, passes here
- [x] New `SensorLoop` test asserts two declared-but-silent sensors both report `readings=0 skipped=0`
- [x] `pytest --cov=src --cov-fail-under=100` — 274 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean