### PR TITLE
fix: bring the server stack back after a reboot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
   influxdb:
     image: influxdb:3-core
     container_name: influxdb
+    # Comes back after a reboot or a daemon restart, but stays down once
+    # deliberately stopped. This half of the deployment is the always-on
+    # one: without it a power cut leaves the stack down until somebody
+    # notices, while every client fills its queue and then blocks.
+    restart: unless-stopped
     depends_on:
       init-state-dirs:
         condition: service_completed_successfully
@@ -97,6 +102,11 @@ services:
   grafana:
     image: grafana/grafana:13.1.3
     container_name: grafana
+    # Comes back after a reboot or a daemon restart, but stays down once
+    # deliberately stopped. This half of the deployment is the always-on
+    # one: without it a power cut leaves the stack down until somebody
+    # notices, while every client fills its queue and then blocks.
+    restart: unless-stopped
     depends_on:
       init-state-dirs:
         condition: service_completed_successfully
@@ -143,6 +153,11 @@ services:
   loki:
     image: grafana/loki:3.7.6
     container_name: loki
+    # Comes back after a reboot or a daemon restart, but stays down once
+    # deliberately stopped. This half of the deployment is the always-on
+    # one: without it a power cut leaves the stack down until somebody
+    # notices, while every client fills its queue and then blocks.
+    restart: unless-stopped
     profiles: [logs]
     depends_on:
       init-state-dirs:
@@ -175,6 +190,11 @@ services:
   alloy:
     image: grafana/alloy:v1.18.1
     container_name: alloy
+    # Comes back after a reboot or a daemon restart, but stays down once
+    # deliberately stopped. This half of the deployment is the always-on
+    # one: without it a power cut leaves the stack down until somebody
+    # notices, while every client fills its queue and then blocks.
+    restart: unless-stopped
     profiles: [logs]
     depends_on:
       # service_started, not service_healthy: Loki has no healthcheck to


### PR DESCRIPTION
Closes #107.

No service in `docker-compose.yml` carried a restart policy, while `docker-compose.client.yml` has set `unless-stopped` since it was written. The two halves of the deployment disagreed, and the half that disagreed is the one meant to run unattended.

After a power cut or an unattended reboot, the stack stayed down until somebody noticed. Clients meanwhile filled their queue and then blocked — so the readings taken *during* the outage were lost along with the ones that would have been taken after it.

## What changed

`restart: unless-stopped` on `influxdb`, `grafana`, `loki` and `alloy`.

Two deliberate exclusions:

- **`init-state-dirs`** prepares the bind-mount directories and exits. A restart policy would loop it forever.
- **The mock sensors** keep today's semantics — a demo that resurrects itself after `docker compose stop` is surprising rather than helpful.

`unless-stopped` rather than `always`, so a stack stopped on purpose stays stopped across a daemon restart.

## Verification

Worth spelling out, because the obvious test gives a false negative.

`docker kill grafana` did **not** trigger a restart — Docker records it as a *manual* stop, and declining to override a manual stop is precisely what separates `unless-stopped` from `always`. Killing PID 1 from inside the container is seen as a crash instead:

```
policy=unless-stopped running=true restarts=1
```

## Test plan

- [x] `docker compose config -q` valid
- [x] All four services report `restart: unless-stopped` in the resolved config
- [x] `init-state-dirs` confirmed to have no policy
- [x] Crash-restart demonstrated on a live container