### PR TITLE
fix: make the templates log the way the pipeline reads

### DIFF
--- a/templates/custom-sensor/sensor_continuous.py
+++ b/templates/custom-sensor/sensor_continuous.py
@@ -14,9 +14,9 @@ API is rate-limited, billed per call, or takes minutes to answer, use
 `sensor_triggered.py` instead.
 """
 
-import logging
 import random
 
+from labmon import logs
 from labmon.sensors.polling import poll
 
 # --------------------------------------------------------------------------
@@ -49,9 +49,12 @@ def read_value() -> float | None:
 if __name__ == "__main__":
     # INFO so the periodic "still writing" summary is visible; the
     # per-reading line is DEBUG.
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
-    )
+    # labmon's own logfmt setup, not a hand-rolled format. Every query
+    # in docs/logging.md and every panel on the Logs dashboard parses
+    # `| logfmt` and filters on named fields; a sensor that emits prose
+    # is collected into Loki and then matches none of them, which reads
+    # as an instrument with nothing to say.
+    logs.configure()
 
     poll(
         read_value,

--- a/templates/custom-sensor/sensor_triggered.py
+++ b/templates/custom-sensor/sensor_triggered.py
@@ -21,6 +21,7 @@ import logging
 import random
 import sys
 
+from labmon import logs
 from labmon.sensors.polling import write_reading
 
 # --------------------------------------------------------------------------
@@ -39,22 +40,37 @@ def read_value() -> float | None:
 
 # --------------------------------------------------------------------------
 
+# The instrument this script speaks for. Named once, so the log line
+# below and the reading itself cannot drift apart.
+SENSOR_ID = "CHANGE-ME"
+
+
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
-    )
+    # labmon's own logfmt setup, not a hand-rolled format. Every query
+    # in docs/logging.md and every panel on the Logs dashboard parses
+    # `| logfmt` and filters on named fields; a sensor that emits prose
+    # is collected into Loki and then matches none of them, which reads
+    # as an instrument with nothing to say.
+    logs.configure()
 
     value = read_value()
     if value is None:
         # Nothing to record this time. Exit 0: a timer treats a non-zero
         # status as a failure and will report the unit as failed, which is
         # wrong for "the instrument had nothing to say".
-        logging.getLogger(__name__).info("No reading available; nothing written")
+        #
+        # A constant message with the data in `extra=`, the shape the rest
+        # of labmon uses: the message groups every occurrence together and
+        # the fields are what a query filters on.
+        logging.getLogger(__name__).info(
+            "no reading available; nothing written",
+            extra={"sensor_id": SENSOR_ID},
+        )
         sys.exit(0)
 
     write_reading(
         value,
-        sensor_id="CHANGE-ME",
+        sensor_id=SENSOR_ID,
         measurement="temperature",
         unit="degC",
     )


### PR DESCRIPTION
Closes #111.

Both custom-sensor templates configured logging by hand:

```python
logging.basicConfig(
    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
)
```

That is not logfmt. Every query in `docs/logging.md` and every panel on the Logs dashboard filters on `| logfmt` and named fields, so all of them returned nothing for sensors built from these files.

The lines were still collected into Loki. They simply could not be found by any documented way of looking — which is worse than not being collected, because the instrument then appears to have nothing to say.

This is the worst place in the repo for that gap: a vendor-API instrument written from one of these templates is the sensor type most likely to exist in a real lab.

## What changed

- `logs.configure()` in both templates, replacing the hand-rolled format
- the triggered template's own "nothing to record" line becomes a constant message with the data in `extra=`, since a template teaches its style as much as its structure
- its `sensor_id` becomes a module constant instead of a literal repeated in two calls, so a log line cannot name a different instrument than the reading beside it
- `import logging` dropped from the continuous template, which no longer uses it

These were also the last two files in the repo teaching the pre-logfmt style. `grep` for `basicConfig` across `docs/`, `templates/` and the README now returns nothing.

## Verification

Ran the configured logger and read the output:

```
ts=2026-08-21T13:07:04.739+00:00 level=info logger=templates.sensor_triggered msg="no reading available; nothing written" sensor_id=CHANGE-ME
```

Parses under `| logfmt`, and `sensor_id` is a field the documented queries filter on.

## Test plan

- [x] `pytest` — 272 passed
- [x] ruff / ruff format / typos / basedpyright clean (templates are type-checked since #82)
- [x] Log output verified to be valid logfmt with the expected fields
- [x] No `basicConfig` remaining anywhere in docs or templates