### PR TITLE
docs: write down the trust model the stack actually has

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,11 +107,66 @@ network, not an oversight — TLS (e.g. via a reverse proxy, or InfluxDB's
 own TLS support) is a reasonable future upgrade if the network model ever
 changes, but isn't built here.
 
+## One token, and it is an admin token
+
+Every client holds the *same* `INFLUXDB3_AUTH_TOKEN`, and that token
+grants full control of the database: write, delete, reconfigure, mint
+further tokens.
+
+So the blast radius of one mislaid client is the whole historical record.
+A machine taped to an optical table, shared between students, or carried
+between buildings has the same authority over your data as the server
+does.
+
+This is a platform constraint rather than a choice. **InfluxDB 3 Core
+issues admin tokens only** — the per-client, write-only, least-privilege
+tokens a deployment like this would otherwise use are an Enterprise
+feature. There is no narrower credential to hand a sensor.
+
+What follows from that:
+
+- **Site clients accordingly.** Treat any machine holding the token as
+  trusted infrastructure, because it is.
+- **Keep port 8181 off network segments that do not need it.** This is
+  the strongest argument for the reverse proxy in
+  [#52](https://github.com/quentinmarolleau/labmon/issues/52): once
+  clients reach InfluxDB through it, the database's own port need not be
+  reachable at all.
+- **TLS does not solve this.** It protects the token in transit. Every
+  client still holds an admin credential at rest.
+- **Rotate on any suspicion**, using the drill below.
+
+### Rotating the token
+
+One command on the server, then every client. Expect writes to fail in
+between, which is why this is worth rehearsing before you need it:
+
+```bash
+# On the server — mint the replacement first, so there is no window
+# with no valid token at all.
+docker compose exec influxdb influxdb3 create token --admin
+```
+
+Put the new value in the server's `.env`, restart the stack, then update
+each client's env file and restart its sensor. Revoke the old token last,
+once every client is confirmed writing again:
+
+```bash
+# Both need a valid token themselves; the container already has the
+# server's in its environment.
+docker compose exec influxdb sh -c \
+  'influxdb3 show tokens --token "$INFLUXDB3_AUTH_TOKEN"'
+docker compose exec influxdb sh -c \
+  'influxdb3 delete token --token-name <name> --token "$INFLUXDB3_AUTH_TOKEN"'
+```
+
+Clients buffer while they cannot write (see
+[`docs/latency.md`](latency.md)), so a rotation completed within the
+queue's depth loses nothing.
+
 ## Distributing the auth token
 
-Every client needs the same `INFLUXDB3_AUTH_TOKEN` the server was set up
-with (see the root [`.env.example`](../.env.example)). Copy it out of
-band — e.g. `scp` the value directly into each client's own env file
-(see [`docs/client-setup.md`](client-setup.md)) — never commit it, and
-never send it over an unencrypted channel you don't already trust (email,
-chat, etc.).
+Copy it out of band — e.g. `scp` the value directly into each client's
+own env file (see [`docs/client-setup.md`](client-setup.md)) — never
+commit it, and never send it over an unencrypted channel you don't
+already trust (email, chat, etc.).

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -303,11 +303,28 @@ expression = "10**(1.667*v - 11.33)"
 value_unit = "mbar"
 ```
 
-Expressions are evaluated by [asteval](https://github.com/lmfit/asteval)
-in a restricted interpreter — arithmetic only, with no ability to import
-modules or reach the filesystem. An expression that references an
-unknown name, or returns something that isn't a number, is rejected at
-startup.
+Expressions are evaluated by [asteval](https://github.com/lmfit/asteval),
+which does not import modules or reach the filesystem. An expression that
+references an unknown name, or returns something that isn't a number, is
+rejected at startup.
+
+#### A calibration file is code, not configuration
+
+That restriction makes typos safe. It is **not** a security boundary, and
+asteval's own documentation says so plainly: a crafted expression can
+still exhaust memory or crash the interpreter, and escapes have been
+found before.
+
+For the intended use this changes nothing — whoever writes
+`calibration.toml` already controls the process that reads it, so there
+is no boundary to cross. It matters because these files do not *look*
+like code. They are small, they are TOML, and they encode something a
+colleague might reasonably want to reuse, so they are exactly the kind of
+artefact that gets emailed between groups.
+
+**Give a calibration file the same trust you would give a Python file
+from the same source.** Review a third-party one before loading it, and
+do not accept one from outside the lab.
 
 ## Options
 


### PR DESCRIPTION
Closes #106. Closes #112.

Two gaps in the same area: things the deployment already assumes, which nothing said out loud.

## Every client holds an admin token (#106)

The plain-HTTP trade was already documented as deliberate. What sets the *size* of that trade was not documented at all — the token crossing the network grants full control of the database, and every client holds the same one.

So the blast radius of one mislaid client is the entire historical record. A machine taped to an optical table has the same authority over the data as the server does.

The part worth writing down is that this is a **platform constraint, not a choice**: InfluxDB 3 Core issues admin tokens only, and the per-client write-only credentials this deployment would otherwise use are an Enterprise feature. Someone reading the deployment guide looking for how to scope a sensor's access should learn here that there is no such thing, rather than concluding they missed it.

Also states explicitly that TLS will not fix it, so #52 is not oversold when it lands: encrypting the transport protects the token on the wire and changes nothing about every client holding an admin credential at rest.

### Rotation drill

New, because nobody works these out calmly during an incident. Both commands were run against a live stack to get the flags right — my first draft documented `influxdb3 token list`, which does not exist. The real ones are `influxdb3 show tokens` and `influxdb3 delete token --token-name`, each needing a valid token of its own.

## A calibration file is code (#112)

The `expression` section described asteval as running "in a restricted interpreter — arithmetic only, with no ability to import modules or reach the filesystem", which reads as a safety guarantee. asteval's own documentation is explicit that it is not one: a crafted expression can exhaust memory or crash the interpreter, and escapes have been found before.

The restriction is real and stays in the text, but what it buys is that a *typo* fails cleanly — not that an untrusted file is safe to load.

For the intended use this changes nothing, since whoever writes `calibration.toml` already controls the process reading it. It is worth saying because these files do not *look* like code — small, TOML, encoding something a colleague might want to reuse — which makes them exactly the kind of artefact that gets emailed between groups.

## Scope

Documentation only. Tightening asteval's symbol table (`minimal=True` or an explicit allowlist) is a separate question that wants measuring against the conversions already in the test suite before anything is removed; noted on #112.

## Test plan

- [x] `typos` clean
- [x] Every documented command executed against a live stack and its output checked
- [x] No code changes, so the remaining gates are unaffected