### PR TITLE
Quote and escape carriage returns in logfmt values

### DIFF
--- a/src/labmon/logs.py
+++ b/src/labmon/logs.py
@@ -34,7 +34,12 @@ _STANDARD_FIELDS = frozenset(
 
 # Characters that force a value to be quoted. A bare `=` would look like
 # the start of another field, and whitespace would split one field in two.
-_NEEDS_QUOTING = frozenset(' \t\n"=')
+# `\r` is here for a different reason than the rest: a terminal treats it as
+# "return to the start of the line", so an unescaped one lets the tail of a
+# value overwrite what was already printed — and values are not all ours.
+# Channel names arrive off the serial wire, and a malformed-line warning
+# carries the raw line, so a noisy or hostile device picks those bytes.
+_NEEDS_QUOTING = frozenset(' \t\n\r"=')
 
 
 def quote(value: object) -> str:
@@ -43,7 +48,12 @@ def quote(value: object) -> str:
     if text == "":
         return '""'
     if any(character in text for character in _NEEDS_QUOTING):
-        escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        escaped = (
+            text.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+        )
         return f'"{escaped}"'
     return text
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -45,11 +45,37 @@ def _record(message: str = "hello", **extra: object) -> logging.LogRecord:
         ("", '""'),
         ('say "hi"', '"say \\"hi\\""'),
         ("line\nbreak", '"line\\nbreak"'),
+        # A bare CR returns a terminal's cursor to the start of the line, so
+        # the tail of a value would overwrite what was already printed.
+        ("over\rwrite", '"over\\rwrite"'),
+        ("crlf\r\nline", '"crlf\\r\\nline"'),
+        ("\r", '"\\r"'),
         ("back\\slash", "back\\slash"),
     ],
 )
 def test_quote_only_when_it_must(value: object, expected: str) -> None:
     assert quote(value) == expected
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\r\n"])
+def test_no_control_character_survives_quoting(control: str) -> None:
+    """Whatever a device puts on the wire, the rendered token stays one line.
+
+    Channel names come off the serial port and a malformed-line warning
+    carries the raw line, so these bytes are not always ours to choose.
+    """
+    rendered = quote(f"before{control}after")
+
+    assert control not in rendered
+    assert rendered.startswith('"') and rendered.endswith('"')
+
+
+def test_a_carriage_return_cannot_forge_a_field() -> None:
+    """The attack the quoting exists to stop, in its CR spelling."""
+    rendered = quote("ok\rlevel=error msg=fake")
+
+    assert "\r" not in rendered
+    assert rendered == '"ok\\rlevel=error msg=fake"'
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #113.

## Problem

`_NEEDS_QUOTING` was `frozenset(' \t\n"=')` — no `\r`. A value containing a bare carriage return was emitted unquoted and unescaped.

Loki does not mind. A terminal does: CR returns the cursor to the start of the line, so the remainder of the value overwrites what was already printed, and a log line can be made to *display* as something other than what it says.

That matters because these values are not all ours. Channel names arrive off the serial wire, and `parse_reading` puts the raw line into the `line` field of every "skipping malformed line" warning — so a noisy or hostile device picks the bytes.

## Fix

`\r` joins `_NEEDS_QUOTING`, and the escape chain in `quote()` gains `.replace("\r", "\\r")` next to the existing `\n` handling. The chain is reflowed across lines; `\\` is still replaced first, so the escapes cannot double up.

```python
>>> quote("over\rwrite")
'"over\\rwrite"'
>>> quote("crlf\r\nline")
'"crlf\\r\\nline"'
```

The comment on `_NEEDS_QUOTING` now says *why* `\r` is there, since it is a display concern rather than the parsing concern the other characters are.

## Tests

Three rows added to the existing `test_quote_only_when_it_must` table (`over\rwrite`, `crlf\r\nline`, a lone `\r`), plus two tests that state the property rather than the example:

- `test_no_control_character_survives_quoting` — parametrised over `\n`, `\r`, `\r\n`: the rendered token contains no raw control character and stays a single quoted string.
- `test_a_carriage_return_cannot_forge_a_field` — the attack in its CR spelling: `"ok\rlevel=error msg=fake"` renders escaped rather than as something a terminal would redraw over the real fields.

5 tests fail on `main`, pass here.

## Verification

```
pytest                                  # 289 passed
ruff check src tests                    # All checks passed
ruff format --check src/labmon/logs.py tests/test_logs.py   # clean
```

(`tests/test_calibration.py` needs `scipy` — the `spline` extra — or 5 tests error on import. Unrelated to this change; noting it in case it is not obvious from `pyproject.toml`.)