### PR TITLE
Resolve InfluxDB settings when they are used, not at import time

### DIFF
--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -19,8 +19,25 @@ def _setting(name: str, default: str) -> str:
     return os.environ.get(name) or default
 
 
-INFLUXDB_HOST = _setting("INFLUXDB_HOST", "http://localhost:8181")
-INFLUXDB_DATABASE = _setting("INFLUXDB_DATABASE", "lab")
+def influx_host() -> str:
+    """Where readings are written, from INFLUXDB_HOST.
+
+    A function rather than a module constant so the value is resolved when it
+    is asked for. Resolved at import time it would silently pin whatever was
+    set at that moment: a test, a library embedding labmon, or anyone
+    following docs/custom-sensor.md who imports before configuring gets a
+    stale value, and the symptom is "it connects to the wrong database and I
+    cannot see why" rather than an error.
+    """
+    return _setting("INFLUXDB_HOST", "http://localhost:8181")
+
+
+def influx_database() -> str:
+    """Database readings are written to, from INFLUXDB_DATABASE.
+
+    Resolved per call, for the reason given on `influx_host`.
+    """
+    return _setting("INFLUXDB_DATABASE", "lab")
 
 
 def get_client() -> InfluxDBClient3:
@@ -29,7 +46,7 @@ def get_client() -> InfluxDBClient3:
     Raises KeyError if INFLUXDB3_AUTH_TOKEN is not set.
     """
     return InfluxDBClient3(
-        host=INFLUXDB_HOST,
+        host=influx_host(),
         token=os.environ["INFLUXDB3_AUTH_TOKEN"],
-        database=INFLUXDB_DATABASE,
+        database=influx_database(),
     )

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -28,7 +28,7 @@ from typing import cast
 from influxdb_client_3 import Point
 
 from labmon import logs
-from labmon.influx import INFLUXDB_DATABASE
+from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def run(
         extra={
             "sensor_id": sensor_id,
             "measurement": measurement,
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
             "interval_s": interval,
         },
     )

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -44,7 +44,7 @@ from datetime import UTC, datetime
 
 from influxdb_client_3 import Point
 
-from labmon.influx import INFLUXDB_DATABASE, get_client
+from labmon.influx import get_client, influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -182,7 +182,7 @@ def poll(
         extra={
             "sensor_id": sensor_id,
             "measurement": measurement,
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
             "interval_s": interval,
         },
     )

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -37,7 +37,7 @@ from labmon.calibration import (
     ureg,
 )
 from labmon.gate import RecordingGate
-from labmon.influx import INFLUXDB_DATABASE
+from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 from labmon.sensors.serial_source import (
     DEFAULT_BAUDRATE,
@@ -118,7 +118,7 @@ def run(
         "writing calibrated readings",
         extra={
             "channels": ",".join(sorted(calibrations)) or "-",
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
         },
     )
     _log_calibrations(calibrations)

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -1,9 +1,12 @@
 import pytest
 from influxdb_client_3 import InfluxDBClient3
 
+from labmon import influx
 from labmon.influx import (
     _setting,  # pyright: ignore[reportPrivateUsage]
     get_client,
+    influx_database,
+    influx_host,
 )
 
 _NAME = "LABMON_TEST_SETTING"
@@ -49,3 +52,101 @@ def test_get_client_builds_client_with_auth_token(
 
     assert isinstance(client, InfluxDBClient3)
     client.close()
+
+
+@pytest.fixture
+def client_kwargs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
+    """Record what get_client passes to InfluxDBClient3.
+
+    The client stores its host inside a write client rather than on an
+    attribute, so spying on the constructor is both simpler and less brittle
+    than reading the object back.
+    """
+    calls: list[dict[str, str]] = []
+
+    class _Spy:
+        def __init__(self, **kwargs: str) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(influx, "InfluxDBClient3", _Spy)
+    return calls
+
+
+def test_get_client_reads_the_environment_when_called(
+    monkeypatch: pytest.MonkeyPatch, client_kwargs: list[dict[str, str]]
+) -> None:
+    """The point of #119: settings resolve per call, not per import.
+
+    labmon.influx is imported long before most callers configure anything, so
+    a value read at import time is whatever happened to be set at that moment.
+    """
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("INFLUXDB_HOST", "http://first:8181")
+    monkeypatch.setenv("INFLUXDB_DATABASE", "first")
+
+    _ = get_client()
+
+    monkeypatch.setenv("INFLUXDB_HOST", "http://second:8181")
+    monkeypatch.setenv("INFLUXDB_DATABASE", "second")
+
+    _ = get_client()
+
+    assert client_kwargs[0]["host"] == "http://first:8181"
+    assert client_kwargs[0]["database"] == "first"
+    assert client_kwargs[1]["host"] == "http://second:8181"
+    assert client_kwargs[1]["database"] == "second"
+
+
+def test_get_client_uses_the_documented_defaults(
+    monkeypatch: pytest.MonkeyPatch, client_kwargs: list[dict[str, str]]
+) -> None:
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    monkeypatch.delenv("INFLUXDB_HOST", raising=False)
+    monkeypatch.delenv("INFLUXDB_DATABASE", raising=False)
+
+    _ = get_client()
+
+    assert client_kwargs[0]["host"] == "http://localhost:8181"
+    assert client_kwargs[0]["database"] == "lab"
+
+
+def test_get_client_falls_back_on_an_empty_value(
+    monkeypatch: pytest.MonkeyPatch, client_kwargs: list[dict[str, str]]
+) -> None:
+    """`.env.example` ships INFLUXDB_DATABASE empty; Compose defaults it too."""
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("INFLUXDB_DATABASE", "")
+
+    _ = get_client()
+
+    assert client_kwargs[0]["database"] == "lab"
+
+
+def test_influx_host_reads_the_environment_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INFLUXDB_HOST", "http://first:8181")
+    assert influx_host() == "http://first:8181"
+
+    monkeypatch.setenv("INFLUXDB_HOST", "http://second:8181")
+    assert influx_host() == "http://second:8181"
+
+
+def test_influx_database_reads_the_environment_each_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("INFLUXDB_DATABASE", "first")
+    assert influx_database() == "first"
+
+    monkeypatch.setenv("INFLUXDB_DATABASE", "second")
+    assert influx_database() == "second"
+
+
+def test_settings_fall_back_when_unset_or_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("INFLUXDB_HOST", raising=False)
+    monkeypatch.setenv("INFLUXDB_DATABASE", "")
+
+    assert influx_host() == "http://localhost:8181"
+    assert influx_database() == "lab"


### PR DESCRIPTION
Closes #119.

## Problem

`INFLUXDB_HOST` and `INFLUXDB_DATABASE` were module constants evaluated when `labmon.influx` was first imported. Anything setting the environment *afterwards* silently got stale values — a test, a future embedding of labmon as a library, or anyone following `docs/custom-sensor.md` who imports before configuring.

As the issue says, it is a footgun rather than a bug today: the symptom is "it connects to the wrong database and I cannot see why", not an error.

## What I found before changing it

The issue asked to check whether anything imports those names before removing them. **Three modules do**, all for a `database` log field:

- `src/labmon/sensors/polling.py:47`
- `src/labmon/sensors/mock_sensor.py:31`
- `src/labmon/sensors/serial_sensor.py:40`

Dropping the constants outright breaks all three at import. The docs reference the *environment variables* everywhere but never the Python names, so nothing there needed changing.

## Fix

Rather than removing the names, they become functions:

```python
def influx_host() -> str: ...
def influx_database() -> str: ...
```

`get_client()` reads through the same pair, and the three call sites now call `influx_database()`. One definition of each default, resolved per call everywhere — no module `__getattr__` indirection, and the call sites read the same as before.

`_setting()` is untouched: it already handles the unset-versus-empty distinction correctly, and this change is about *when* it runs.

## Tests

Six in `tests/test_influx.py`. The client stores its host inside a write client rather than on an attribute, so a `client_kwargs` fixture spies on the `InfluxDBClient3` constructor — simpler and far less brittle than reading private internals back off the object:

- `test_get_client_reads_the_environment_when_called` — the core one: change `INFLUXDB_HOST`/`INFLUXDB_DATABASE` *between* two `get_client()` calls, and each client is built with the values current at its call. Fails on `main`.
- `test_get_client_uses_the_documented_defaults` — `http://localhost:8181` and `lab`, matching `docs/configuration.md`.
- `test_get_client_falls_back_on_an_empty_value` — `INFLUXDB_DATABASE=` still yields `lab`, the behaviour `_setting` exists for.
- Plus direct per-call tests for `influx_host()` and `influx_database()`, and one for the unset/empty fallbacks.

## Verification

```
pytest                     # 288 passed
ruff check src tests       # All checks passed
ruff format --check ...    # 5 files already formatted
```

(`tests/test_calibration.py` needs the `spline` extra — `scipy` — or 5 tests error on import; unrelated to this change.)