### PR TITLE
Add a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ together visually.*
 - [Project structure](#project-structure)
 - [Development](#development)
 - [Status](#status)
-- [Contributing](#contributing) · [License](#license)
+- [Contributing](#contributing) · [Security](#security) · [License](#license)
 
 ## What labmon gives you
 
@@ -311,6 +311,11 @@ is the set targeted for the first beta.
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branch/PR workflow,
 commit conventions, and testing policy (`AGENTS.md` is the condensed,
 agent-oriented version of the same document).
+
+## Security
+
+[`SECURITY.md`](SECURITY.md) has the private disclosure route, the supported
+version, and the three assumptions the design is built on.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a suspected vulnerability.
+
+Report it privately by email to **q.marolleau-dev@pm.me** — the address
+`CONTRIBUTING.md` already uses for Code of Conduct reports. Include what you
+found, how to reproduce it, and what you think an attacker gains; a proof of
+concept helps but is not required.
+
+Expect an acknowledgement within a week. You will be told whether the report is
+accepted, and kept informed while a fix is prepared. If you would like credit in
+the release notes, say so — and say how you want to be named.
+
+## Supported versions
+
+labmon is pre-1.0 and there are no released tags yet, so there is only one
+supported version: **the latest commit on `main`**. Fixes land there. There are
+no backports, and no security support for a checkout you are holding at an older
+commit.
+
+That changes when the [v0.2.0-beta milestone][milestone] ships; this section
+will be updated to name the supported tags then.
+
+[milestone]: https://github.com/quentinmarolleau/labmon/milestone/1
+
+## Threat model
+
+Three assumptions are built into the design. A report that a documented
+assumption holds is not a vulnerability; a report that one can be *broken* very
+much is.
+
+**The lab LAN is trusted.** The stack speaks plain HTTP and gRPC with no TLS, so
+`INFLUXDB3_AUTH_TOKEN` travels unencrypted between clients and the server. That
+is a deliberate tradeoff for a small trusted network rather than an oversight —
+see [Security: plain HTTP, by design][http] in the deployment guide. TLS through
+a reverse proxy is a planned upgrade, not a shipped feature.
+
+**Every client holds an admin token.** All clients share the same
+`INFLUXDB3_AUTH_TOKEN`, and it grants full control of the database: write,
+delete, reconfigure, mint further tokens. This is a platform constraint —
+InfluxDB 3 Core issues admin tokens only, and the per-client write-only tokens a
+deployment like this would otherwise use are an Enterprise feature. So the blast
+radius of one mislaid client is the whole historical record: treat any machine
+holding the token as trusted infrastructure, and keep port 8181 off network
+segments that do not need it. See [One token, and it is an admin token][token],
+and rotate using the drill there on any suspicion.
+
+**A calibration file is code, not configuration.** Expressions in
+`calibration.toml` are evaluated by [asteval][asteval], which does not import
+modules or reach the filesystem. That restriction makes typos safe; it is not a
+security boundary, and asteval's own documentation says so — a crafted
+expression can still exhaust memory or crash the interpreter. Whoever writes a
+calibration file already controls the process that reads it, so for the intended
+use there is no boundary to cross. Do not accept one from someone you would not
+give a shell to. See [A calibration file is code, not configuration][calib].
+
+[http]: docs/deployment.md#security-plain-http-by-design-for-now
+[token]: docs/deployment.md#one-token-and-it-is-an-admin-token
+[calib]: docs/serial-sensor.md#a-calibration-file-is-code-not-configuration
+[asteval]: https://github.com/lmfit/asteval
+
+### What is in scope
+
+A way to break one of those assumptions. For example: reaching data or the
+database without the token from a client that never held it; escaping the
+asteval sandbox from an expression a *user* did not write; anything that lets a
+sensor's serial output — which is untrusted input, and the one place bytes
+arrive from outside — affect the host beyond the reading it encodes.
+
+### What is out of scope
+
+The assumptions themselves, reported as findings: that the LAN is unencrypted,
+that clients share an admin token, that a calibration file can run code. Those
+are documented above and in the deployment guide. If you think one of them is
+the wrong tradeoff, that is a design discussion — open an issue.


### PR DESCRIPTION
Closes #120.

The repository had `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and issue forms but no `SECURITY.md`, so the only route for a vulnerability report was a public issue.

Three sections, as the issue laid out.

**A private address.** `CONTRIBUTING.md` already directs Code of Conduct reports to `q.marolleau-dev@pm.me`; the same address serves here rather than introducing a second one, and the policy says what to include and what to expect back (acknowledgement within a week, credit on request). GitHub private vulnerability reporting is the other option and costs one setting — happy to switch the wording if you would rather enable that instead.

**Supported versions.** Pre-1.0 with no tags, the honest answer is *the latest commit on `main`*, stated rather than left to inference: no backports, no support for a checkout held at an older commit. The section names the [v0.2.0-beta milestone](https://github.com/quentinmarolleau/labmon/milestone/1) as the point it gets rewritten.

**The threat model** — the part with real value, and the reason this issue is worth more than a template. The three assumptions currently live spread across `docs/deployment.md` and `docs/serial-sensor.md`:

- the lab LAN is trusted, so there is no TLS and the token travels in the clear;
- every client holds the same **admin** token, because InfluxDB 3 Core issues nothing narrower — blast radius of one mislaid client is the whole record;
- a calibration file is code: asteval makes typos safe but is not a security boundary, and its own docs say so.

Each gets a paragraph here and a deep link to the full treatment, so the two issues that want to add more of this prose have one page to point at rather than three paragraphs that drift apart. The deep-link anchors are checked against the actual headings.

Scope and out-of-scope follow from the model: reporting a *documented* assumption is not a finding, breaking one is. Serial input is called out as in scope — it is the one place bytes arrive from outside the trust boundary.

## Also

`README.md` gains a Security section and a table-of-contents entry, since nothing else pointed a reader at the file.

## Verification

```
typos SECURITY.md README.md   # clean
pytest                        # 282 passed (unaffected — docs only)
```

The wording is deliberately yours where it exists: the paragraphs paraphrase `docs/deployment.md` and `docs/serial-sensor.md` rather than restating the tradeoffs in new terms. Where I have inferred something you have not written down — the response-time promise, the credit offer, the in-scope list — say the word and I will cut or change it.