### PR TITLE
fix: read InfluxDB settings when they are used, not at import

### DIFF
--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -23,8 +23,25 @@ def _setting(name: str, default: str) -> str:
     return os.environ.get(name) or default
 
 
-INFLUXDB_HOST = _setting("INFLUXDB_HOST", "http://localhost:8181")
-INFLUXDB_DATABASE = _setting("INFLUXDB_DATABASE", "lab")
+def influx_host() -> str:
+    """Where readings are written, from INFLUXDB_HOST.
+
+    A function rather than a module constant so the value is read when it
+    is asked for. Read at import, it pins whatever happened to be set the
+    first time anything imported this module — which is long before a
+    test, a library embedding labmon, or anyone following
+    `docs/custom-sensor.md` has configured anything. The symptom of that
+    is not an error but a client quietly pointed somewhere else.
+    """
+    return _setting("INFLUXDB_HOST", "http://localhost:8181")
+
+
+def influx_database() -> str:
+    """Database readings are written to, from INFLUXDB_DATABASE.
+
+    Read per call, for the reason given on `influx_host`.
+    """
+    return _setting("INFLUXDB_DATABASE", "lab")
 
 
 def get_client() -> InfluxDBClient3:
@@ -44,6 +61,7 @@ def get_client() -> InfluxDBClient3:
     Raises KeyError if INFLUXDB3_AUTH_TOKEN is not set, and
     FileNotFoundError if INFLUXDB_TLS_CA names a file that is not there.
     """
+    host = influx_host()
     options: dict[str, str] = {}
     ca = os.environ.get("INFLUXDB_TLS_CA")
     if ca:
@@ -63,17 +81,17 @@ def get_client() -> InfluxDBClient3:
         # raise, because pointing a sensor at a local plain stack while
         # the shared env file still names a CA is a legitimate thing to
         # do — it just should not look like it is protected.
-        if not INFLUXDB_HOST.lower().startswith("https://"):
+        if not host.lower().startswith("https://"):
             logger.warning(
                 "ignoring INFLUXDB_TLS_CA because the host is not https",
-                extra={"host": INFLUXDB_HOST, "ca": ca},
+                extra={"host": host, "ca": ca},
             )
 
         options["ssl_ca_cert"] = ca
 
     return InfluxDBClient3(
-        host=INFLUXDB_HOST,
+        host=host,
         token=os.environ["INFLUXDB3_AUTH_TOKEN"],
-        database=INFLUXDB_DATABASE,
+        database=influx_database(),
         **options,
     )

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -28,7 +28,7 @@ from typing import cast
 from influxdb_client_3 import Point
 
 from labmon import logs
-from labmon.influx import INFLUXDB_DATABASE
+from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def run(
         extra={
             "sensor_id": sensor_id,
             "measurement": measurement,
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
             "interval_s": interval,
         },
     )

--- a/src/labmon/sensors/polling.py
+++ b/src/labmon/sensors/polling.py
@@ -44,7 +44,7 @@ from datetime import UTC, datetime
 
 from influxdb_client_3 import Point
 
-from labmon.influx import INFLUXDB_DATABASE, get_client
+from labmon.influx import get_client, influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -182,7 +182,7 @@ def poll(
         extra={
             "sensor_id": sensor_id,
             "measurement": measurement,
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
             "interval_s": interval,
         },
     )

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -37,7 +37,7 @@ from labmon.calibration import (
     ureg,
 )
 from labmon.gate import RecordingGate
-from labmon.influx import INFLUXDB_DATABASE
+from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 from labmon.sensors.serial_source import (
     DEFAULT_BAUDRATE,
@@ -118,7 +118,7 @@ def run(
         "writing calibrated readings",
         extra={
             "channels": ",".join(sorted(calibrations)) or "-",
-            "database": INFLUXDB_DATABASE,
+            "database": influx_database(),
         },
     )
     _log_calibrations(calibrations)

--- a/tests/test_influx.py
+++ b/tests/test_influx.py
@@ -8,6 +8,8 @@ from labmon import influx
 from labmon.influx import (
     _setting,  # pyright: ignore[reportPrivateUsage]
     get_client,
+    influx_database,
+    influx_host,
 )
 
 _NAME = "LABMON_TEST_SETTING"
@@ -141,8 +143,7 @@ def test_a_ca_against_a_plain_http_host_warns(
     ca = tmp_path / "labmon-ca.crt"
     _ = ca.write_text("-- not parsed here --", encoding="utf-8")
     monkeypatch.setenv("INFLUXDB_TLS_CA", str(ca))
-    # The host is a module constant, resolved at import — see #119.
-    monkeypatch.setattr(influx, "INFLUXDB_HOST", "http://localhost:8181")
+    monkeypatch.setenv("INFLUXDB_HOST", "http://localhost:8181")
     monkeypatch.setattr(influx, "InfluxDBClient3", _unused_client)
 
     with caplog.at_level(logging.WARNING, logger=influx.__name__):
@@ -160,10 +161,73 @@ def test_a_ca_against_an_https_host_is_silent(
     ca = tmp_path / "labmon-ca.crt"
     _ = ca.write_text("-- not parsed here --", encoding="utf-8")
     monkeypatch.setenv("INFLUXDB_TLS_CA", str(ca))
-    monkeypatch.setattr(influx, "INFLUXDB_HOST", "HTTPS://server:8443")
+    monkeypatch.setenv("INFLUXDB_HOST", "HTTPS://server:8443")
     monkeypatch.setattr(influx, "InfluxDBClient3", _unused_client)
 
     with caplog.at_level(logging.WARNING, logger=influx.__name__):
         _ = get_client()
 
     assert caplog.records == []
+
+
+# --------------------------------------------------------------------------
+# Settings are read per call, not per import
+# --------------------------------------------------------------------------
+
+
+def test_the_host_is_read_on_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The point of #119.
+
+    `labmon.influx` is imported long before most callers configure
+    anything, so a value read at import is whatever happened to be set at
+    that moment rather than what the caller asked for.
+    """
+    monkeypatch.setenv("INFLUXDB_HOST", "http://first:8181")
+    assert influx_host() == "http://first:8181"
+
+    monkeypatch.setenv("INFLUXDB_HOST", "http://second:8181")
+    assert influx_host() == "http://second:8181"
+
+
+def test_the_database_is_read_on_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INFLUXDB_DATABASE", "first")
+    assert influx_database() == "first"
+
+    monkeypatch.setenv("INFLUXDB_DATABASE", "second")
+    assert influx_database() == "second"
+
+
+def test_both_fall_back_when_unset_or_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty counts as unset, the way Compose reads the same variables."""
+    monkeypatch.delenv("INFLUXDB_HOST", raising=False)
+    monkeypatch.setenv("INFLUXDB_DATABASE", "")
+
+    assert influx_host() == "http://localhost:8181"
+    assert influx_database() == "lab"
+
+
+def test_the_client_follows_the_environment_between_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two clients built either side of a change disagree, as they should."""
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "test-token")
+    captured: list[dict[str, object]] = []
+
+    def capture(**kwargs: object) -> object:
+        captured.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(influx, "InfluxDBClient3", capture)
+
+    monkeypatch.setenv("INFLUXDB_HOST", "http://first:8181")
+    monkeypatch.setenv("INFLUXDB_DATABASE", "first")
+    _ = get_client()
+
+    monkeypatch.setenv("INFLUXDB_HOST", "http://second:8181")
+    monkeypatch.setenv("INFLUXDB_DATABASE", "second")
+    _ = get_client()
+
+    assert [(call["host"], call["database"]) for call in captured] == [
+        ("http://first:8181", "first"),
+        ("http://second:8181", "second"),
+    ]


### PR DESCRIPTION
Closes #119.

`INFLUXDB_HOST` and `INFLUXDB_DATABASE` were module constants resolved when `labmon.influx` was first imported, so anything setting the environment afterwards silently got whatever happened to be set at that moment.

Today's entry points all import after the environment is ready, which is why nothing is broken. But a test, a future embedding of labmon as a library, and anyone following `docs/custom-sensor.md` who imports before configuring all sit on the wrong side of it — and the symptom is not an error. It is a client quietly pointed at the wrong database.

## Named accessors rather than deleting the constants

The issue floated letting the names go and calling `_setting()` at each site. Three modules (`polling`, `mock_sensor`, `serial_sensor`) read the database name for a log field, so `influx_host()` / `influx_database()` keeps one definition of each default that everything reads through. Only the timing was wrong, not the shape.

I checked what referenced the old names before removing them, as the issue asked: three `src` modules, no scripts, and nothing in the docs — `docs/configuration.md` documents them as environment variables, not as importable symbols.

## A side benefit

This tidies something #73 left behind. The test covering the warning for `INFLUXDB_TLS_CA` set against a plain-HTTP host had to `monkeypatch.setattr(influx, "INFLUXDB_HOST", ...)`, because the host it checks was fixed at import — the footgun this issue is about, showing up in the test suite. It sets the environment variable now, like every other test in the file.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 291 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean
- [x] A second `get_client()` after changing the environment builds a client with the new host and database
- [x] Both accessors follow the environment between calls
- [x] Empty still counts as unset, matching how Compose reads the same variables
- [x] No remaining reference to the old names in `src`, `tests`, `scripts` or `docs`
