### PR TITLE
fix: escape what a terminal acts on, not just what logfmt parses

### DIFF
--- a/src/labmon/logs.py
+++ b/src/labmon/logs.py
@@ -32,19 +32,63 @@ _STANDARD_FIELDS = frozenset(
     logging.LogRecord("", 0, "", 0, "", None, None).__dict__
 ) | {"message", "asctime", "taskName"}
 
-# Characters that force a value to be quoted. A bare `=` would look like
-# the start of another field, and whitespace would split one field in two.
-_NEEDS_QUOTING = frozenset(' \t\n"=')
+# Characters that force a value to be quoted because of what logfmt makes
+# of them: a bare `=` looks like the start of another field, and a space
+# splits one field in two.
+_STRUCTURAL = frozenset(' "=')
+
+# Escapes for the characters that have a conventional short spelling,
+# which is what Go's logfmt writer and Python's own repr both use.
+_SHORT_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+
+def _escaped(character: str) -> str:
+    """One character, rendered so it cannot act on whatever reads it."""
+    short = _SHORT_ESCAPES.get(character)
+    if short is not None:
+        return short
+    if character.isprintable():
+        return character
+    # Anything else that draws rather than prints. `\r` is the obvious
+    # case and has a short form above, but it is not the strongest one:
+    # ESC introduces the ANSI sequences that repaint and reposition, BS
+    # overwrites like `\r` does, and the bidi overrides reorder a line
+    # without touching a single byte of its content.
+    codepoint = ord(character)
+    if codepoint < 0x100:
+        return f"\\x{codepoint:02x}"
+    if codepoint < 0x10000:
+        return f"\\u{codepoint:04x}"
+    return f"\\U{codepoint:08x}"
+
+
+def _must_quote(text: str) -> bool:
+    """Whether logfmt or a terminal would misread this value bare."""
+    return any(
+        character in _STRUCTURAL or not character.isprintable() for character in text
+    )
 
 
 def quote(value: object) -> str:
-    """Render a value as a logfmt token, quoting only when it must."""
+    """Render a value as a logfmt token, quoting only when it must.
+
+    Quoting is not only about logfmt's own syntax. These values are not
+    all ours — channel names arrive off the serial wire, and a malformed
+    line is logged verbatim — so a value that a terminal would *act on*
+    rather than print is quoted and escaped too, and one log line can no
+    longer be made to display as something other than what it says.
+    """
     text = str(value)
     if text == "":
         return '""'
-    if any(character in text for character in _NEEDS_QUOTING):
-        escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
-        return f'"{escaped}"'
+    if _must_quote(text):
+        return '"' + "".join(_escaped(character) for character in text) + '"'
     return text
 
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -46,10 +46,75 @@ def _record(message: str = "hello", **extra: object) -> logging.LogRecord:
         ('say "hi"', '"say \\"hi\\""'),
         ("line\nbreak", '"line\\nbreak"'),
         ("back\\slash", "back\\slash"),
+        # A tab used to force quoting and then survive inside the quotes.
+        ("a\tb", '"a\\tb"'),
+        # CR returns a terminal's cursor to the start of the line, so the
+        # tail of a value overwrites what was already printed.
+        ("over\rwrite", '"over\\rwrite"'),
+        ("crlf\r\nline", '"crlf\\r\\nline"'),
+        # No short spelling, so these fall through to a hex escape. ESC is
+        # the one that matters: it introduces the ANSI sequences.
+        ("\x1b[31mred", '"\\x1b[31mred"'),
+        ("ring\x07ing", '"ring\\x07ing"'),
+        ("ab\x08\x08cd", '"ab\\x08\\x08cd"'),
+        ("a\x00b", '"a\\x00b"'),
+        # Reorders a line without altering a byte of its content.
+        ("start\u202eend", '"start\\u202eend"'),
+        # Printable is printable, whatever its codepoint.
+        ("20\u00b0C", "20\u00b0C"),
+        ("\u00b5m", "\u00b5m"),
+        ("\u03a9", "\u03a9"),
     ],
 )
 def test_quote_only_when_it_must(value: object, expected: str) -> None:
     assert quote(value) == expected
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        "\n",
+        "\r",
+        "\r\n",
+        "\t",
+        "\x00",
+        "\x07",
+        "\x08",
+        "\x0b",
+        "\x0c",
+        "\x1b",
+        "\x7f",
+        "\u202e",
+        "\u0085",
+    ],
+)
+def test_no_control_character_survives_quoting(control: str) -> None:
+    """Whatever a device puts on the wire, the token stays one flat line.
+
+    Channel names come off the serial port and a malformed-line warning
+    carries the raw line, so these bytes are not always ours to choose.
+    """
+    rendered = quote(f"before{control}after")
+
+    assert control not in rendered
+    assert rendered.startswith('"') and rendered.endswith('"')
+    assert all(character.isprintable() for character in rendered)
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\x1b", "\x08"])
+def test_a_control_character_cannot_forge_a_field(control: str) -> None:
+    """The attack the quoting exists to stop, in each of its spellings."""
+    rendered = quote(f"ok{control}level=error msg=fake")
+
+    assert control not in rendered
+    assert rendered.count("=") == 2
+    assert rendered.startswith('"') and rendered.endswith('"')
+
+
+def test_an_astral_non_printable_is_escaped_too() -> None:
+    """Above the BMP the escape widens rather than truncating."""
+    # A tag character: invisible, and above U+FFFF.
+    assert quote("a\U000e0041b") == '"a\\U000e0041b"'
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #113.

`_NEEDS_QUOTING` was `frozenset(' \t\n"=')` — no `\r`. A value carrying a bare carriage return was emitted unquoted and unescaped. Loki does not mind; a terminal does: CR returns the cursor to the start of the line, so the remainder of the value overwrites what was already printed, and a log line can be made to **display as something other than what it says**.

## Why this fixes the class, not the spelling

Adding `\r` to the list would fix the reported case and leave its own reasoning half-applied. `ESC` is the stronger primitive by some distance — it introduces the ANSI sequences that recolour, reposition and clear the screen. `BS` overwrites much as CR does. The bidi overrides reorder a rendered line without altering a byte of its content.

So the rule is now the property rather than a list: **quote when logfmt needs it quoted, or when any character is not printable**, and escape those characters inside the quotes.

```
'over\rwrite'      ->  "over\rwrite"          'a\x07b'          ->  "a\x07b"
'\x1b[31mred'      ->  "\x1b[31mred"          'ab\x08\x08cd'    ->  "ab\x08\x08cd"
'a\tb'             ->  "a\tb"                 'start‮end'  ->  "start‮end"
'has space'        ->  "has space"            '20°C'            ->  20°C
'back\slash'       ->  back\slash             'µm'              ->  µm
```

Short forms for the five with a conventional spelling (`\\ " \n \r \t`), then `\xNN` / `\uNNNN` / `\UNNNNNNNN` by width. Printable is left alone whatever its codepoint, so unit strings survive. A backslash still does not force quoting on its own, preserving existing behaviour and its test.

## Two things the reported bug did not cover

- **A tab** used to force quoting and then sit **raw inside the quotes** — it was in `_NEEDS_QUOTING` but never in the escape chain.
- **Bidi overrides** (U+202E and friends) reorder a line with no control character present at all.

## Why these values deserve it

They are not all ours. Channel names arrive off the serial wire, and `parse_reading` puts the raw line into the `line` field of every "skipping malformed line" warning — so a noisy or hostile device chooses those bytes.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 316 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean
- [x] Table extended: `\r`, `\r\n`, `\t`, `ESC`, `BEL`, `BS`, `NUL`, U+202E, and printable non-ASCII left bare
- [x] Property test over 13 control characters: none survives, the token stays one quoted string, and every character of the result is printable
- [x] Forgery test parametrised over `\n`, `\r`, `ESC`, `BS` — none can inject a second `key=value`
- [x] Astral non-printable widens to `\U` rather than truncating
