### PR TITLE
feat: label log lines with the sensor they report

### DIFF
--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -30,7 +30,7 @@ discovery.relabel "containers" {
 loki.source.docker "containers" {
 	host       = "unix:///var/run/docker.sock"
 	targets    = discovery.relabel.containers.output
-	forward_to = [loki.write.local.receiver]
+	forward_to = [loki.process.sensors.receiver]
 }
 
 // A sensor that cannot run in a container runs under systemd instead (see
@@ -90,7 +90,41 @@ loki.source.journal "units" {
 	path          = "/var/log/journal"
 	relabel_rules = discovery.relabel.journal.rules
 	labels        = {job = "systemd-journal"}
-	forward_to    = [loki.write.local.receiver]
+	forward_to    = [loki.process.sensors.receiver]
+}
+
+// Labels a line with the sensor it is about, rather than the container it
+// came from. A reading in InfluxDB is tagged `sensor_id`; without this its
+// log lines are findable only by `container`, so answering "what was this
+// instrument saying while its trace went flat" means knowing which
+// container ran which sensor and translating by hand.
+//
+// Per line rather than per container, because `sensor_id` describes a
+// *reading* and a container label would describe a *process*. Those two
+// coincide only while one container is one sensor — true of the mock
+// sensors, false of `serial-sensor`, where one process reads a calibration
+// file covering several channels and reports each under its own id.
+//
+// So there is one source of truth, the sensor that emitted the line, and
+// renaming a channel in calibration.toml changes the Loki label with no
+// other edit.
+loki.process "sensors" {
+	// Every emitter writes logfmt (see docs/logging.md), so the field is
+	// simply read out. A line without it — InfluxDB's, Grafana's, Alloy's
+	// own — extracts nothing and passes through untouched.
+	stage.logfmt {
+		mapping = {"sensor_id" = ""}
+	}
+
+	// Promotes the extracted value to a label. A line that extracted
+	// nothing gets no label at all rather than an empty one, which matters:
+	// `sensor_id=""` would be a stream of its own and would show up in
+	// every label browser in Grafana.
+	stage.labels {
+		values = {"sensor_id" = ""}
+	}
+
+	forward_to = [loki.write.local.receiver]
 }
 
 loki.write "local" {

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -153,6 +153,33 @@ still works exactly as before and is often quicker for a glance; Loki is
 for history, for correlating two containers, and for looking at a machine
 you are not sitting in front of.
 
+### The `sensor_id` label
+
+A reading in InfluxDB is tagged `sensor_id`. Its log lines carry the same
+label, so the two sides are queried by the same identifier:
+
+```logql
+{sensor_id="cryo-diode"}
+```
+
+Alloy reads it out of the line rather than off the container, with a
+`logfmt` stage feeding a `labels` stage. That distinction is the whole
+point. A container label would describe a *process*, while `sensor_id`
+describes a *reading*, and the two only coincide while one container runs
+one sensor. `serial-sensor` breaks that: one process reads a calibration
+file covering several channels and reports each under its own id, so the
+demo's `demo-serial-sensor` container produces six labelled streams, one
+per channel in `demo/calibration.demo.toml`.
+
+Because the label comes from the line, renaming a channel in a
+calibration file changes it with no other edit — there is no second copy
+in `docker-compose.yml` to drift out of sync.
+
+A line with no `sensor_id` field — InfluxDB's, Grafana's, Alloy's own —
+gets no such label at all, rather than an empty one. An empty value would
+be a stream of its own and would appear in every label browser in
+Grafana.
+
 ### If a container's output never appears
 
 Almost always buffering rather than collection. Python block-buffers stdout

--- a/tests/test_alloy_config.py
+++ b/tests/test_alloy_config.py
@@ -1,0 +1,71 @@
+"""The collector's wiring, pinned where a reformat would not notice.
+
+`alloy/config.alloy` is not exercised by anything else here: it runs
+inside a container, against the Docker API, in a profile the test suite
+does not start. These check the few properties that would fail silently
+— a source wired straight past the processing stage still collects logs,
+it just stops labelling them, and nothing complains.
+"""
+
+import re
+from pathlib import Path
+
+_CONFIG = Path(__file__).resolve().parent.parent / "alloy" / "config.alloy"
+
+
+def _config() -> str:
+    return _CONFIG.read_text(encoding="utf-8")
+
+
+def _block(name: str) -> str:
+    """The body of one top-level block, by its `type "label"` header."""
+    text = _config()
+    start = text.index(f"{name} {{")
+    depth = 0
+    for offset in range(start, len(text)):
+        if text[offset] == "{":
+            depth += 1
+        elif text[offset] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : offset + 1]
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+def test_both_sources_forward_through_the_processing_stage() -> None:
+    """Docker and journal alike, or one shape of deployment loses labels.
+
+    A source pointed straight at `loki.write` keeps working — the lines
+    arrive, unlabelled — so this is the failure that survives review.
+    """
+    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
+        body = _block(source)
+
+        assert "loki.process.sensors.receiver" in body, (
+            f"{source} does not forward through loki.process.sensors, so its "
+            "lines reach Loki without a sensor_id label"
+        )
+
+
+def test_the_processing_stage_reaches_loki() -> None:
+    body = _block('loki.process "sensors"')
+
+    assert "loki.write.local.receiver" in body
+
+
+def test_sensor_id_is_read_from_the_line_and_promoted_to_a_label() -> None:
+    """Extraction alone is invisible: `stage.labels` is what publishes it."""
+    body = _block('loki.process "sensors"')
+
+    assert re.search(r"stage\.logfmt\s*\{[^}]*\"sensor_id\"", body), (
+        "no logfmt stage extracting sensor_id"
+    )
+    assert re.search(r"stage\.labels\s*\{[^}]*\"sensor_id\"", body), (
+        "sensor_id is extracted but never promoted to a label"
+    )
+
+
+def test_no_source_writes_to_loki_directly() -> None:
+    """The stage is only load-bearing while everything goes through it."""
+    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
+        assert "loki.write.local.receiver" not in _block(source)


### PR DESCRIPTION
Closes #64.

A reading in InfluxDB is tagged `sensor_id`. Its log lines were findable only by `container`, so "what was this instrument saying while its trace went flat" meant knowing which container ran which sensor and translating by hand.

## Per line, not per container

`sensor_id` identifies a **reading**; a container label identifies a **process**. They coincide only while one container runs one sensor — true of the mock sensors, false of the acquisition path that actually matters, where `serial-sensor` reads one calibration file covering several channels and reports each under its own id.

This is why #61 was closed unmerged, and the reason holds: a Docker label would give that whole process a single name and put a second copy of the identifier in compose, free to drift out of sync with `calibration.toml`.

```alloy
loki.process "sensors" {
  stage.logfmt { mapping = {"sensor_id" = ""} }
  stage.labels { values  = {"sensor_id" = ""} }
  forward_to = [loki.write.local.receiver]
}
```

Both sources — Docker and journal — now forward through it instead of straight to `loki.write`.

## Verified against a running stack

All three of the issue's "verification that matters" points, checked against live Loki rather than reasoned about:

**A multi-channel container yields one stream per channel.** `{container="demo-serial-sensor"}` returns six labelled streams — `beam-x`, `beam-y`, `bias-monitor`, `cryo-diode`, `laser-1`, `pirani-1` — plus one unlabelled stream for its own startup lines, which carry no `sensor_id` field. Those six are **exactly** the six `sensor_id` values in `demo/calibration.demo.toml`, which is the single-source-of-truth property in evidence.

**A non-sensor container has no key at all.** `{container="influxdb"}` returns `{container, service_name}` — no `sensor_id`, empty or otherwise.

**Renaming a channel changes the label with no other edit**, since the label is read from the line the sensor emits.

Across the whole stack the label now takes twelve values: `beam-x beam-y bias-monitor chamber-1 cryo-4k cryo-77k cryo-diode laser-1 pirani-1 room-1 room-2 wavemeter-1`.

## Why there are tests for a config file

Nothing else here exercises `alloy/config.alloy` — it runs in a container, against the Docker API, in a profile the suite does not start. The failure worth pinning is quiet: a source wired straight to `loki.write` still collects everything, it just stops labelling, and no assertion anywhere would notice.

`tests/test_alloy_config.py` checks both sources forward through the processing stage, that neither writes to Loki directly, and that `sensor_id` is both extracted **and** promoted — extraction alone is invisible.

## Test plan

- [x] `pytest --cov=src --cov-fail-under=100` — 328 passed, 100%
- [x] ruff / ruff format / typos / basedpyright clean
- [x] `alloy fmt` accepts the config
- [x] Alloy restarted against it with no configuration error
- [x] Six per-channel streams from one container, matching the calibration file exactly
- [x] `influxdb` and the other non-sensor containers carry no `sensor_id` key
