### PR TITLE
feat: collect logs from sensors on remote client machines

### DIFF
--- a/.env.client.example
+++ b/.env.client.example
@@ -23,3 +23,22 @@ INFLUXDB3_AUTH_TOKEN=
 #
 # Leave both unset to keep talking plain HTTP.
 #INFLUXDB_TLS_CA=/etc/labmon/labmon-ca.crt
+
+# Shipping this machine's logs to the server's Loki, with the "logs"
+# profile of docker-compose.client.yml. All four are needed together; see
+# docs/client-setup.md.
+#
+# The push endpoint on the server's proxy — note the port differs from
+# InfluxDB's and Grafana's, and the path is part of the URL.
+#LABMON_LOKI_URL=https://192.168.1.50:3444/loki/api/v1/push
+# The credential the server was configured with. Copy the password out of
+# band, as with the auth token; it is not the same secret.
+#LABMON_LOKI_PUSH_USER=labmon
+#LABMON_LOKI_PUSH_PASSWORD=
+# Names this machine in every line it sends. Without it two clients
+# running the same container names are one indistinguishable stream.
+#LABMON_CLIENT_NAME=pi-optics-bench
+
+# Shipping logs also requires INFLUXDB_TLS_CA above: reaching the server
+# means TLS, and the collector verifies it against the same root the
+# sensor already uses.

--- a/.env.client.example
+++ b/.env.client.example
@@ -37,6 +37,8 @@ INFLUXDB3_AUTH_TOKEN=
 #LABMON_LOKI_PUSH_PASSWORD=
 # Names this machine in every line it sends. Without it two clients
 # running the same container names are one indistinguishable stream.
+# Defaults to `unnamed-client`, which is conspicuous in Grafana rather
+# than blending into the server's own lines the way an empty name would.
 #LABMON_CLIENT_NAME=pi-optics-bench
 
 # Shipping logs also requires INFLUXDB_TLS_CA above: reaching the server

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,22 @@ GRAFANA_PLUGINS=briangann-gauge-panel@2.2.0
 LABMON_TLS_INFLUXDB_SITES=
 LABMON_TLS_GRAFANA_SITES=
 
+# Where the proxy accepts log pushes from sensors on other machines, when
+# both the "tls" and "logs" profiles are active. Same rules as the two
+# lists above. Loki itself is never published; this is the only way in.
+LABMON_TLS_LOKI_SITES=
+
+# The credential a remote machine sends with every log push. Loki's own
+# push API authenticates nothing, so this is what stands between the LAN
+# and a write-anything endpoint. Generate the hash on the server:
+#
+#     docker compose exec caddy caddy hash-password
+#
+# and give each client the plaintext. Left unset, the endpoint refuses
+# every credential — see docs/deployment.md.
+LABMON_LOKI_PUSH_USER=
+LABMON_LOKI_PUSH_HASH=
+
 # Which address to serve when a client sends no SNI (default: 127.0.0.1),
 # which is what addressing the server by IP does. Set it to the server's
 # LAN IP on a real deployment, or those clients fail the handshake before

--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,12 @@ LABMON_TLS_LOKI_SITES=
 #
 # and give each client the plaintext. Left unset, the endpoint refuses
 # every credential — see docs/deployment.md.
+#
+# Keep the single quotes around the hash. A bcrypt hash is full of `$`,
+# and compose reads an unquoted `$name` here as a variable, silently
+# dropping that part of the hash — after which no password matches.
 LABMON_LOKI_PUSH_USER=
-LABMON_LOKI_PUSH_HASH=
+LABMON_LOKI_PUSH_HASH=''
 
 # Which address to serve when a client sends no SNI (default: 127.0.0.1),
 # which is what addressing the server by IP does. Set it to the server's

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -86,7 +86,11 @@ jobs:
             printf 'LABMON_TLS_GRAFANA_SITES="https://127.0.0.1:3443, https://caddy:3443"\n'
             printf 'LABMON_TLS_LOKI_SITES="https://127.0.0.1:3444, https://caddy:3444"\n'
             printf 'LABMON_LOKI_PUSH_USER=labmon\n'
-            printf 'LABMON_LOKI_PUSH_HASH=%s\n' "$hash"
+            # Single-quoted: a bcrypt hash is full of `$`, and compose
+            # expands an unquoted `$name` in .env as a variable, cutting
+            # that span out of the hash. Every push would then 401, with
+            # the config looking correct.
+            printf "LABMON_LOKI_PUSH_HASH='%s'\n" "$hash"
           } >> .env
           COMPOSE_PROFILES=demo,logs,tls docker compose up -d --wait caddy
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -73,9 +73,20 @@ jobs:
       # a name the certificate actually covers.
       - name: Start the TLS proxy
         run: |
+          # A real push credential, generated here and used by the step
+          # below. The shipped default is bcrypt of random bytes nobody
+          # kept, so without this every push is refused — which is the
+          # point of it, but leaves nothing to test the open path with.
+          password="$(head -c 18 /dev/urandom | base64)"
+          hash="$(docker run --rm caddy:2.10-alpine \
+            caddy hash-password --plaintext "$password")"
+          echo "LOKI_PUSH_PASSWORD=$password" >> "$GITHUB_ENV"
           {
             printf 'LABMON_TLS_INFLUXDB_SITES="https://127.0.0.1:8443, https://caddy:8443"\n'
             printf 'LABMON_TLS_GRAFANA_SITES="https://127.0.0.1:3443, https://caddy:3443"\n'
+            printf 'LABMON_TLS_LOKI_SITES="https://127.0.0.1:3444, https://caddy:3444"\n'
+            printf 'LABMON_LOKI_PUSH_USER=labmon\n'
+            printf 'LABMON_LOKI_PUSH_HASH=%s\n' "$hash"
           } >> .env
           COMPOSE_PROFILES=demo,logs,tls docker compose up -d --wait caddy
 
@@ -175,6 +186,49 @@ jobs:
           if not rows or rows[0]["n"] < 1:
               raise SystemExit("the query path through the proxy sees no rows")
           PY
+
+      # Loki's push endpoint is the one the proxy authenticates, because
+      # Loki itself authenticates nothing — so the credential and the path
+      # restriction are the whole of its protection. Both are one line of
+      # Caddyfile, and removing either leaves a working endpoint that is
+      # simply open, which no other check here would notice.
+      - name: The Loki push endpoint is shut without a credential
+        run: |
+          line="$(printf '{"streams":[{"stream":{"container":"smoke"},')"
+          line="$line$(printf '"values":[["%s000000000","level=info msg=smoke"]]}]}' "$(date +%s)")"
+          probe() {
+            curl -s -o /dev/null -w '%{http_code}' --cacert labmon-ca.crt "$@"
+          }
+          push="https://127.0.0.1:3444/loki/api/v1/push"
+
+          no_credential="$(probe -X POST -H 'Content-Type: application/json' \
+            --data "$line" "$push")"
+          # Built from the real one rather than written out, so the line
+          # carries no literal user:password pair for a secret scanner to
+          # object to.
+          wrong_credential="labmon:not-$LOKI_PUSH_PASSWORD"
+          wrong="$(probe -u "$wrong_credential" -X POST \
+            -H 'Content-Type: application/json' --data "$line" "$push")"
+          accepted="$(probe -u "labmon:$LOKI_PUSH_PASSWORD" -X POST \
+            -H 'Content-Type: application/json' --data "$line" "$push")"
+          # The same credential on a read path: the endpoint is for writing
+          # log lines, not for reading back everything ever collected.
+          read_back="$(probe -u "labmon:$LOKI_PUSH_PASSWORD" \
+            'https://127.0.0.1:3444/loki/api/v1/label/container/values')"
+
+          echo "no credential=$no_credential wrong=$wrong ok=$accepted read=$read_back"
+          if [ "$no_credential" != "401" ] || [ "$wrong" != "401" ]; then
+            echo "the push endpoint accepted an unauthenticated client" >&2
+            exit 1
+          fi
+          if [ "$accepted" != "204" ]; then
+            echo "the push endpoint refused a valid credential" >&2
+            exit 1
+          fi
+          if [ "$read_back" != "404" ]; then
+            echo "the push credential also reads: got $read_back, wanted 404" >&2
+            exit 1
+          fi
 
       # Grafana through the proxy is the viewer's route, so both suites run
       # again against it. Cheap — the stack is already up and warm.

--- a/alloy/client.alloy
+++ b/alloy/client.alloy
@@ -71,7 +71,11 @@ discovery.relabel "journal" {
 }
 
 loki.source.journal "units" {
-	path          = "/var/log/journal"
+	// No `path`, which is what makes both journal layouts work: left
+	// empty, Alloy reads /var/log/journal and /run/log/journal. A client
+	// keeping logs in memory only (Storage=volatile, common on an SD-card
+	// host) has them in the second, and pinning the first would collect
+	// nothing from it while container logs kept arriving normally.
 	relabel_rules = discovery.relabel.journal.rules
 	labels        = {job = "systemd-journal"}
 	forward_to    = [loki.process.sensors.receiver]

--- a/alloy/client.alloy
+++ b/alloy/client.alloy
@@ -1,0 +1,124 @@
+// Collects this machine's logs and ships them to a labmon server.
+//
+// The server's own Alloy (alloy/config.alloy) collects the containers on
+// the server. A sensor on a different machine is invisible to it, so a
+// client that should appear in the same dashboards runs this instead —
+// same sources, same labelling, a remote destination.
+//
+// Reaching the server needs three things in the environment, all set in
+// the client's .env: LABMON_LOKI_URL, LABMON_LOKI_PUSH_PASSWORD, and
+// INFLUXDB_TLS_CA. See docs/client-setup.md.
+
+// Discovers containers, and re-reads the list so a sensor started later is
+// picked up without restarting Alloy.
+discovery.docker "containers" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "15s"
+}
+
+discovery.relabel "containers" {
+	targets = discovery.docker.containers.targets
+
+	// Docker reports names with a leading slash ("/labmon-sensor-1"), which
+	// would otherwise appear in every query.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
+}
+
+loki.source.docker "containers" {
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.containers.output
+	forward_to = [loki.process.sensors.receiver]
+}
+
+// A client running a bare install puts its sensor under systemd rather
+// than in a container (see deploy/), so both shapes are collected here for
+// the same reason they are on the server.
+discovery.relabel "journal" {
+	targets = []
+
+	rule {
+		source_labels = ["__journal__systemd_unit"]
+		target_label  = "unit"
+	}
+
+	// A user unit reports the manager rather than itself in _SYSTEMD_UNIT,
+	// naming user@1000.service for every one of them. Its own name is in
+	// _SYSTEMD_USER_UNIT, so that wins when it is there.
+	rule {
+		source_labels = ["__journal__systemd_user_unit"]
+		regex         = "(.+)"
+		target_label  = "unit"
+	}
+
+	// Only labmon's own units. A client is somebody's Raspberry Pi or lab
+	// PC, and collecting its whole journal would centralise every login
+	// session and system service on it — far more than was asked for, and
+	// far more than the sensor lines it is being collected for.
+	rule {
+		source_labels = ["unit"]
+		regex         = "labmon-.*"
+		action        = "keep"
+	}
+
+	rule {
+		source_labels = ["__journal_priority_keyword"]
+		target_label  = "level"
+	}
+}
+
+loki.source.journal "units" {
+	path          = "/var/log/journal"
+	relabel_rules = discovery.relabel.journal.rules
+	labels        = {job = "systemd-journal"}
+	forward_to    = [loki.process.sensors.receiver]
+}
+
+// The same per-line labelling the server does, so a client's lines are
+// queried exactly like a server's: `{sensor_id="cryo-diode"}` finds the
+// reading's own logs wherever the sensor happens to run.
+loki.process "sensors" {
+	stage.logfmt {
+		mapping = {"sensor_id" = ""}
+	}
+
+	stage.labels {
+		values = {"sensor_id" = ""}
+	}
+
+	// Which machine the line came from. Without it two clients both running
+	// a container called `labmon-sensor-1` are one indistinguishable
+	// stream, and the server's own lines are told apart from a client's
+	// only by guesswork.
+	stage.static_labels {
+		values = {"host" = sys.env("LABMON_CLIENT_NAME")}
+	}
+
+	forward_to = [loki.write.server.receiver]
+}
+
+loki.write "server" {
+	endpoint {
+		// The proxy's push endpoint on the server, not Loki itself: Loki
+		// stays unpublished and unauthenticated behind it.
+		url = sys.env("LABMON_LOKI_URL")
+
+		// Loki's push API checks nothing on its own, so the credential is
+		// the proxy's. It buys writing log lines and nothing else — the
+		// same host and port answers 404 to every other path.
+		basic_auth {
+			username = sys.env("LABMON_LOKI_PUSH_USER")
+			password = sys.env("LABMON_LOKI_PUSH_PASSWORD")
+		}
+
+		// The stack signs its own certificates, so the root exported from
+		// the server is what verifies this connection — the same file the
+		// sensor already uses to reach InfluxDB.
+		tls_config {
+			ca_file = sys.env("INFLUXDB_TLS_CA")
+		}
+	}
+}

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -84,10 +84,10 @@ discovery.relabel "journal" {
 }
 
 loki.source.journal "units" {
-	// The persistent journal. A host with volatile-only logging keeps it at
-	// /run/log/journal instead, in which case nothing is collected here and
-	// the mount in docker-compose.yml needs changing to match.
-	path          = "/var/log/journal"
+	// No `path`, which is what makes both journal layouts work: left
+	// empty, Alloy reads /var/log/journal and /run/log/journal. A host
+	// with volatile-only logging keeps its journal in the second, and
+	// both are mounted in docker-compose.yml so either is found.
 	relabel_rules = discovery.relabel.journal.rules
 	labels        = {job = "systemd-journal"}
 	forward_to    = [loki.process.sensors.receiver]

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -30,7 +30,7 @@ discovery.relabel "containers" {
 loki.source.docker "containers" {
 	host       = "unix:///var/run/docker.sock"
 	targets    = discovery.relabel.containers.output
-	forward_to = [loki.write.local.receiver]
+	forward_to = [loki.process.sensors.receiver]
 }
 
 // A sensor that cannot run in a container runs under systemd instead (see
@@ -90,7 +90,41 @@ loki.source.journal "units" {
 	path          = "/var/log/journal"
 	relabel_rules = discovery.relabel.journal.rules
 	labels        = {job = "systemd-journal"}
-	forward_to    = [loki.write.local.receiver]
+	forward_to    = [loki.process.sensors.receiver]
+}
+
+// Labels a line with the sensor it is about, rather than the container it
+// came from. A reading in InfluxDB is tagged `sensor_id`; without this its
+// log lines are findable only by `container`, so answering "what was this
+// instrument saying while its trace went flat" means knowing which
+// container ran which sensor and translating by hand.
+//
+// Per line rather than per container, because `sensor_id` describes a
+// *reading* and a container label would describe a *process*. Those two
+// coincide only while one container is one sensor — true of the mock
+// sensors, false of `serial-sensor`, where one process reads a calibration
+// file covering several channels and reports each under its own id.
+//
+// So there is one source of truth, the sensor that emitted the line, and
+// renaming a channel in calibration.toml changes the Loki label with no
+// other edit.
+loki.process "sensors" {
+	// Every emitter writes logfmt (see docs/logging.md), so the field is
+	// simply read out. A line without it — InfluxDB's, Grafana's, Alloy's
+	// own — extracts nothing and passes through untouched.
+	stage.logfmt {
+		mapping = {"sensor_id" = ""}
+	}
+
+	// Promotes the extracted value to a label. A line that extracted
+	// nothing gets no label at all rather than an empty one, which matters:
+	// `sensor_id=""` would be a stream of its own and would show up in
+	// every label browser in Grafana.
+	stage.labels {
+		values = {"sensor_id" = ""}
+	}
+
+	forward_to = [loki.write.local.receiver]
 }
 
 loki.write "local" {

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -10,10 +10,11 @@
 # Docker bridge on one host, where encryption buys nothing and would mean
 # distributing trust to every service as well as to every client.
 #
-# The two site-address lists are separate variables rather than one list of
+# The site-address lists are separate variables rather than one list of
 # hosts because a Caddyfile cannot build an address from a host and a port:
-# the site address is written out whole. Both should name the same hosts.
-# Separate them with a comma AND a space — Caddy rejects a bare comma.
+# the site address is written out whole. All three should name the same
+# hosts. Separate them with a comma AND a space — Caddy rejects a bare
+# comma.
 {
 	# Nothing here should be redirected to port 443: the plain ports stay
 	# reachable during the transition, and a redirect to a port that is
@@ -46,4 +47,41 @@
 {$LABMON_TLS_GRAFANA_SITES} {
 	tls internal
 	reverse_proxy grafana:3000
+}
+
+# Loki's push endpoint, for sensors on other machines (see docs/logging.md).
+# Loki itself stays unpublished; this is the only way in from outside the
+# compose network.
+#
+# Unlike the two above, this one authenticates. InfluxDB and Grafana check
+# a credential of their own behind the proxy, so TLS there only has to
+# protect one in transit. Loki's push API checks nothing at all, so
+# proxying it without a credential would put a write-anything endpoint on
+# the LAN — a second unauthenticated service where the deployment
+# currently has one.
+{$LABMON_TLS_LOKI_SITES} {
+	tls internal
+
+	basic_auth {
+		# Deny by default. The shipped hash is bcrypt of 32 random bytes
+		# that were never written down, so no password matches it and the
+		# port is useless until an operator sets a real one:
+		#
+		#     docker compose exec caddy caddy hash-password
+		#
+		# See docs/deployment.md.
+		{$LABMON_LOKI_PUSH_USER} {$LABMON_LOKI_PUSH_HASH}
+	}
+
+	# Only the push path. A client credential is copied to every machine
+	# that ships logs, so it should buy as little as possible if one leaks
+	# — writing log lines, not reading back everything the stack has ever
+	# collected through the same host and port.
+	handle /loki/api/v1/push {
+		reverse_proxy loki:3100
+	}
+
+	handle {
+		respond "labmon: only Loki's push endpoint is proxied here" 404
+	}
 }

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -47,6 +47,93 @@ x-labmon-sensor: &labmon-sensor
   #   - ${INFLUXDB_TLS_CA}:${INFLUXDB_TLS_CA}:ro
 
 services:
+  # Ships this machine's logs to the server's Loki, so a sensor running
+  # here appears in the same dashboards as one running on the server.
+  # Under a profile, because it is a considered step rather than the
+  # default: it needs a credential and the server's CA, and it sends log
+  # lines off this machine.
+  #
+  #     COMPOSE_PROFILES=logs docker compose -f docker-compose.client.yml up -d
+  #
+  # See docs/client-setup.md.
+  alloy:
+    image: grafana/alloy:v1.18.1
+    container_name: labmon-alloy
+    restart: unless-stopped
+    profiles: [logs]
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+      # Without this the UI binds to localhost inside the container and
+      # the port below reaches nothing.
+      - --server.http.listen-addr=0.0.0.0:12345
+    ports:
+      # Alloy's own UI, showing each component's health and what it last
+      # sent. The first place to look when a client's logs are not
+      # arriving — it reports a rejected credential here.
+      - "12345:12345"
+    environment:
+      # Where the server's proxy accepts pushes, and what to send with
+      # them. All four are required; there is no useful default for any.
+      - LABMON_LOKI_URL=${LABMON_LOKI_URL}
+      - LABMON_LOKI_PUSH_USER=${LABMON_LOKI_PUSH_USER:-labmon}
+      - LABMON_LOKI_PUSH_PASSWORD=${LABMON_LOKI_PUSH_PASSWORD}
+      # Names this machine in every line it sends. Two clients running the
+      # same container names are otherwise one indistinguishable stream.
+      - LABMON_CLIENT_NAME=${LABMON_CLIENT_NAME}
+      # The same CA the sensor verifies InfluxDB with, read inside the
+      # container from the mount below.
+      - INFLUXDB_TLS_CA=${INFLUXDB_TLS_CA}
+    volumes:
+      - type: bind
+        source: ./alloy/client.alloy
+        target: /etc/alloy/config.alloy
+        read_only: true
+      # Unlike the sensor services, this mount is not optional: reaching
+      # the server means TLS, and a private root is in no trust store.
+      #
+      # The default is a placeholder rather than a suggestion. An unset
+      # variable would expand to `::ro`, which fails to parse — so every
+      # client running `docker compose config` would see an error about
+      # this file whether or not it ships logs at all.
+      - ${INFLUXDB_TLS_CA:-/etc/labmon/labmon-ca.crt}:${INFLUXDB_TLS_CA:-/etc/labmon/labmon-ca.crt}:ro
+      # Reading container logs means talking to the Docker API, and access
+      # to this socket is equivalent to root on this machine. read_only
+      # does not meaningfully restrict it — the socket is still a full
+      # API. See docs/logging.md for what to do if that trade is wrong
+      # here.
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+      # The journal, for a bare install running under systemd rather than
+      # in a container. Both paths are mounted so a host keeping logs in
+      # memory only works too, and a missing one is an empty directory
+      # rather than an error.
+      - type: bind
+        source: /var/log/journal
+        target: /var/log/journal
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: /run/log/journal
+        target: /run/log/journal
+        read_only: true
+        bind:
+          create_host_path: true
+      # Journal entries are keyed by machine id; without this the reader
+      # cannot resolve which machine's journal it is looking at.
+      - type: bind
+        source: /etc/machine-id
+        target: /etc/machine-id
+        read_only: true
+      # Alloy's own bookkeeping — how far it has read in each log. A named
+      # volume rather than a bind, since Alloy runs as root and a bind
+      # would leave a root-owned directory in the checkout.
+      - alloy-data:/var/lib/alloy/data
+
   sensor-1:
     <<: *labmon-sensor
     container_name: labmon-sensor-1
@@ -84,3 +171,6 @@ services:
   #   command:
   #     - --port=/dev/labmon-due
   #     - --calibration=/app/calibration.toml
+
+volumes:
+  alloy-data:

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -81,7 +81,14 @@ services:
       - LABMON_LOKI_PUSH_PASSWORD=${LABMON_LOKI_PUSH_PASSWORD}
       # Names this machine in every line it sends. Two clients running the
       # same container names are otherwise one indistinguishable stream.
-      - LABMON_CLIENT_NAME=${LABMON_CLIENT_NAME}
+      #
+      # The default is deliberately conspicuous rather than empty. Loki
+      # treats an empty label value as absent, so an unset name would let
+      # a client's lines blend into the server's own — the exact
+      # ambiguity this label exists to remove. `unnamed-client` shows up
+      # in Grafana's label browser instead, where it reads as a machine
+      # somebody forgot to name.
+      - LABMON_CLIENT_NAME=${LABMON_CLIENT_NAME:-unnamed-client}
       # The same CA the sensor verifies InfluxDB with, read inside the
       # container from the mount below.
       - INFLUXDB_TLS_CA=${INFLUXDB_TLS_CA}

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -72,7 +72,12 @@ services:
       # Alloy's own UI, showing each component's health and what it last
       # sent. The first place to look when a client's logs are not
       # arriving — it reports a rejected credential here.
-      - "12345:12345"
+      #
+      # Loopback only. The UI has no authentication and lists component
+      # configuration, endpoints and recently sent data; a client is
+      # somebody's own lab machine, so this stays off the LAN. Reach it
+      # over SSH with `ssh -L 12345:127.0.0.1:12345 <host>`.
+      - "127.0.0.1:12345:12345"
     environment:
       # Where the server's proxy accepts pushes, and what to send with
       # them. All four are required; there is no useful default for any.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -380,12 +380,22 @@ services:
     ports:
       - "8443:8443"
       - "3443:3443"
+      # Loki's push endpoint, for sensors on other machines. Answers with
+      # 404 to anything but the push path, and denies every credential
+      # until one is configured — see the Caddyfile.
+      - "3444:3444"
     environment:
       # The addresses the proxy answers on, one list per port, each
       # entry becoming a site address Caddy issues a certificate for.
       # Separated by a comma AND a space; Caddy rejects a bare comma.
       - LABMON_TLS_INFLUXDB_SITES=${LABMON_TLS_INFLUXDB_SITES:-https://127.0.0.1:8443}
       - LABMON_TLS_GRAFANA_SITES=${LABMON_TLS_GRAFANA_SITES:-https://127.0.0.1:3443}
+      - LABMON_TLS_LOKI_SITES=${LABMON_TLS_LOKI_SITES:-https://127.0.0.1:3444}
+      # The credential a remote Alloy sends with every push. The default
+      # hash is bcrypt of random bytes nobody kept, so the endpoint refuses
+      # everything until this is set — see docs/deployment.md.
+      - LABMON_LOKI_PUSH_USER=${LABMON_LOKI_PUSH_USER:-labmon}
+      - LABMON_LOKI_PUSH_HASH=${LABMON_LOKI_PUSH_HASH:-$$2a$$14$$lGM8y2sOFhWF4TvWFA8kD.WH8nCwgejJLWuHR4fOkD/xIZg33kdV2}
       # Which of them to serve when a client sends no SNI, which is what
       # addressing the server by IP does.
       - LABMON_TLS_DEFAULT_SNI=${LABMON_TLS_DEFAULT_SNI:-127.0.0.1}

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -133,6 +133,7 @@ LABMON_LOKI_URL=https://192.168.1.50:3444/loki/api/v1/push
 LABMON_LOKI_PUSH_USER=labmon
 LABMON_LOKI_PUSH_PASSWORD=          # copied out of band, as the token was
 LABMON_CLIENT_NAME=pi-optics-bench  # names this machine in every line
+                                    # (default: unnamed-client)
 ```
 
 `LABMON_LOKI_PUSH_PASSWORD` is a different secret from

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -114,6 +114,53 @@ There is no need to move in step with the server. Its 8181 and 3000 stay
 open until its operator closes them, so each client switches over
 whenever it suits.
 
+## Shipping this machine's logs
+
+Optional, and independent of everything above: a sensor writes readings
+whether or not its logs go anywhere. Turning this on means the machine's
+logs appear in the same Grafana as the server's, labelled by sensor, so
+"what was this instrument saying when the trace went flat" is one query
+rather than an ssh session.
+
+It requires the server to be running the `tls` profile with a push
+credential configured — see [Logs from other
+machines](logging.md#logs-from-other-machines) for that side.
+
+Four settings, alongside the `INFLUXDB_TLS_CA` you already have:
+
+```bash
+LABMON_LOKI_URL=https://192.168.1.50:3444/loki/api/v1/push
+LABMON_LOKI_PUSH_USER=labmon
+LABMON_LOKI_PUSH_PASSWORD=          # copied out of band, as the token was
+LABMON_CLIENT_NAME=pi-optics-bench  # names this machine in every line
+```
+
+`LABMON_LOKI_PUSH_PASSWORD` is a different secret from
+`INFLUXDB3_AUTH_TOKEN` and buys much less: writing log lines, to a port
+that answers 404 to anything else. `INFLUXDB_TLS_CA` is reused rather
+than duplicated — the collector verifies the server against the same root
+the sensor does.
+
+Then start the collector:
+
+```bash
+COMPOSE_PROFILES=logs docker compose -f docker-compose.client.yml up -d
+```
+
+It reads container output through this machine's Docker socket, and the
+journal for a bare install running under systemd, so both shapes are
+collected the same way. Access to the Docker socket is equivalent to root
+here, which is the price of collecting logs without modifying each
+container — [`docs/logging.md`](logging.md) covers that trade.
+
+### When lines do not arrive
+
+Alloy publishes its own UI on port 12345, which shows each component's
+health and what it last sent. A rejected credential shows there as a 401
+against `loki.write`, which is the difference between "the password is
+wrong" and "the server cannot be reached" — and worth checking before
+anything else.
+
 ## From mock sensor to real hardware
 
 `mock-sensor` only simulates a reading (a mean-reverting random walk) and

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -162,6 +162,15 @@ against `loki.write`, which is the difference between "the password is
 wrong" and "the server cannot be reached" — and worth checking before
 anything else.
 
+It is bound to loopback, since it has no authentication and lists
+component configuration and recently sent data. On the machine itself
+that is [http://localhost:12345](http://localhost:12345); from anywhere
+else, forward it over SSH:
+
+```bash
+ssh -L 12345:127.0.0.1:12345 <client-host>
+```
+
 ## From mock sensor to real hardware
 
 `mock-sensor` only simulates a reading (a mean-reverting random walk) and

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,7 +162,10 @@ each client is given one root certificate to trust.
    Grafana changes.
 
 5. **Move the firewall over.** Open 8443 and 3443; close 8181 and 3000 to
-   the LAN once the last client and viewer has switched.
+   the LAN once the last client and viewer has switched. Add 3444 if
+   clients will ship logs as well as readings — see [Logs from other
+   machines](logging.md#logs-from-other-machines), which also covers the
+   credential that port needs before it accepts anything.
 
 ### What is encrypted, and what is not
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -153,6 +153,33 @@ still works exactly as before and is often quicker for a glance; Loki is
 for history, for correlating two containers, and for looking at a machine
 you are not sitting in front of.
 
+### The `sensor_id` label
+
+A reading in InfluxDB is tagged `sensor_id`. Its log lines carry the same
+label, so the two sides are queried by the same identifier:
+
+```logql
+{sensor_id="cryo-diode"}
+```
+
+Alloy reads it out of the line rather than off the container, with a
+`logfmt` stage feeding a `labels` stage. That distinction is the whole
+point. A container label would describe a *process*, while `sensor_id`
+describes a *reading*, and the two only coincide while one container runs
+one sensor. `serial-sensor` breaks that: one process reads a calibration
+file covering several channels and reports each under its own id, so the
+demo's `demo-serial-sensor` container produces six labelled streams, one
+per channel in `demo/calibration.demo.toml`.
+
+Because the label comes from the line, renaming a channel in a
+calibration file changes it with no other edit — there is no second copy
+in `docker-compose.yml` to drift out of sync.
+
+A line with no `sensor_id` field — InfluxDB's, Grafana's, Alloy's own —
+gets no such label at all, rather than an empty one. An empty value would
+be a stream of its own and would appear in every label browser in
+Grafana.
+
 ### If a container's output never appears
 
 Almost always buffering rather than collection. Python block-buffers stdout

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -237,6 +237,17 @@ That prompts for a password and prints a bcrypt hash. The hash goes in
 `LABMON_TLS_LOKI_SITES` lists the addresses clients dial — the same form
 as the other two lists in `.env.example`.
 
+Quote the hash, exactly as `.env.example` has it:
+
+```dotenv
+LABMON_LOKI_PUSH_HASH='$2a$14$...'
+```
+
+Bcrypt hashes are full of `$`, and compose expands an unquoted `$name`
+in `.env` as a variable — an unset one, so that span of the hash is
+replaced by nothing and every push is refused with no indication why.
+Single quotes are what suppresses it; double quotes do not.
+
 Until that is set the endpoint refuses every credential. The hash shipped
 in `docker-compose.yml` is bcrypt of random bytes nobody kept, so no
 password matches it: publishing the port does not open anything.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -192,6 +192,72 @@ labmon's own image sets `PYTHONUNBUFFERED=1` for this reason. A container
 built from something else may need the same, or to log through `logging`
 rather than `print`.
 
+## Logs from other machines
+
+Alloy collects from the host it runs on, so a sensor on a client machine
+is invisible to the server's collector. Such a client runs its own Alloy,
+which ships to the server rather than to a Loki of its own — one place to
+look, with the same labels either way.
+
+That needs a way into Loki from outside the compose network, and Loki is
+deliberately not published. The route is the `tls` profile's proxy, on a
+third port:
+
+```
+client Alloy ──https──► caddy:3444 ──http──► loki:3100
+                        (basic auth)          (never published)
+```
+
+Two things are true of that endpoint and not of the other two the proxy
+serves. It **authenticates**, and it **only accepts pushes**.
+
+Authentication is not symmetry for its own sake. InfluxDB and Grafana
+check a credential of their own behind the proxy, so TLS there only has
+to keep one from being read in transit. Loki's push API checks nothing,
+so proxying it bare would put a write-anything endpoint on the LAN —
+anything that could reach it could fill the log store, or bury a real
+line under invented ones.
+
+Restricting the path limits what a leaked credential is worth. It is
+copied to every machine that ships logs, so it should buy writing log
+lines and nothing more; the same host and port answers 404 to every
+other request, including the query API that would otherwise read back
+everything the stack has collected.
+
+### On the server
+
+Generate a credential and put the hash in `.env`:
+
+```bash
+docker compose exec caddy caddy hash-password
+```
+
+That prompts for a password and prints a bcrypt hash. The hash goes in
+`LABMON_LOKI_PUSH_HASH`, the password goes to each client, and
+`LABMON_TLS_LOKI_SITES` lists the addresses clients dial — the same form
+as the other two lists in `.env.example`.
+
+Until that is set the endpoint refuses every credential. The hash shipped
+in `docker-compose.yml` is bcrypt of random bytes nobody kept, so no
+password matches it: publishing the port does not open anything.
+
+### On the client
+
+See [`docs/client-setup.md`](client-setup.md#shipping-this-machines-logs).
+
+### What arrives
+
+The same labels a local container gets, plus `host`, which names the
+machine the line came from:
+
+```logql
+{host="pi-optics-bench"}
+{sensor_id="cryo-diode"}
+```
+
+The second finds that sensor's lines wherever it runs — which is the
+point of labelling by reading rather than by container.
+
 ## Sensors that run under systemd
 
 A sensor that cannot run in a container runs under systemd instead (see
@@ -261,9 +327,6 @@ the few seconds before Loki is ready cost nothing.
 
 ## What is not here yet
 
-- **Logs from other machines.** Alloy collects from the host it runs on. A
-  sensor on a *different* machine needs its own Alloy forwarding here, which
-  also means exposing Loki's push endpoint beyond this network.
 - **Devices that speak syslog.** Instruments, switches and UPS units that
   can be pointed at a syslog collector — Alloy has a listener for it,
   unconfigured for want of a device to test against.

--- a/tests/test_alloy_config.py
+++ b/tests/test_alloy_config.py
@@ -1,0 +1,71 @@
+"""The collector's wiring, pinned where a reformat would not notice.
+
+`alloy/config.alloy` is not exercised by anything else here: it runs
+inside a container, against the Docker API, in a profile the test suite
+does not start. These check the few properties that would fail silently
+— a source wired straight past the processing stage still collects logs,
+it just stops labelling them, and nothing complains.
+"""
+
+import re
+from pathlib import Path
+
+_CONFIG = Path(__file__).resolve().parent.parent / "alloy" / "config.alloy"
+
+
+def _config() -> str:
+    return _CONFIG.read_text(encoding="utf-8")
+
+
+def _block(name: str) -> str:
+    """The body of one top-level block, by its `type "label"` header."""
+    text = _config()
+    start = text.index(f"{name} {{")
+    depth = 0
+    for offset in range(start, len(text)):
+        if text[offset] == "{":
+            depth += 1
+        elif text[offset] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : offset + 1]
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+def test_both_sources_forward_through_the_processing_stage() -> None:
+    """Docker and journal alike, or one shape of deployment loses labels.
+
+    A source pointed straight at `loki.write` keeps working — the lines
+    arrive, unlabelled — so this is the failure that survives review.
+    """
+    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
+        body = _block(source)
+
+        assert "loki.process.sensors.receiver" in body, (
+            f"{source} does not forward through loki.process.sensors, so its "
+            "lines reach Loki without a sensor_id label"
+        )
+
+
+def test_the_processing_stage_reaches_loki() -> None:
+    body = _block('loki.process "sensors"')
+
+    assert "loki.write.local.receiver" in body
+
+
+def test_sensor_id_is_read_from_the_line_and_promoted_to_a_label() -> None:
+    """Extraction alone is invisible: `stage.labels` is what publishes it."""
+    body = _block('loki.process "sensors"')
+
+    assert re.search(r"stage\.logfmt\s*\{[^}]*\"sensor_id\"", body), (
+        "no logfmt stage extracting sensor_id"
+    )
+    assert re.search(r"stage\.labels\s*\{[^}]*\"sensor_id\"", body), (
+        "sensor_id is extracted but never promoted to a label"
+    )
+
+
+def test_no_source_writes_to_loki_directly() -> None:
+    """The stage is only load-bearing while everything goes through it."""
+    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
+        assert "loki.write.local.receiver" not in _block(source)

--- a/tests/test_alloy_config.py
+++ b/tests/test_alloy_config.py
@@ -120,6 +120,23 @@ def test_only_labmon_units_are_collected_from_the_journal(config: Path) -> None:
     )
 
 
+@_EITHER
+def test_the_journal_source_finds_both_journal_layouts(config: Path) -> None:
+    """Pinning `path` collects nothing on a volatile-journal host.
+
+    Left empty, Alloy reads `/var/log/journal` and `/run/log/journal`
+    both. Setting it to the persistent one alone still works on most
+    machines, so the failure only appears on a host with
+    `Storage=volatile` — where container logs keep arriving and the
+    systemd sensor's silently do not.
+    """
+    body = _block(config, 'loki.source.journal "units"')
+
+    assert not re.search(r"^\s*path\s*=", body, re.MULTILINE), (
+        "the journal source pins a path, so only that directory is read"
+    )
+
+
 def test_a_client_stamps_its_own_name_on_every_line() -> None:
     """Without `host`, two clients are one stream and cannot be separated.
 

--- a/tests/test_alloy_config.py
+++ b/tests/test_alloy_config.py
@@ -1,25 +1,43 @@
-"""The collector's wiring, pinned where a reformat would not notice.
+"""The collectors' wiring, pinned where a reformat would not notice.
 
-`alloy/config.alloy` is not exercised by anything else here: it runs
-inside a container, against the Docker API, in a profile the test suite
-does not start. These check the few properties that would fail silently
-— a source wired straight past the processing stage still collects logs,
-it just stops labelling them, and nothing complains.
+Neither `alloy/config.alloy` nor `alloy/client.alloy` is exercised by
+anything else here: they run inside a container, against the Docker API,
+in a profile the test suite does not start. These check the few
+properties that would fail silently — a source wired straight past the
+processing stage still collects logs, it just stops labelling them, and
+nothing complains.
 """
 
 import re
 from pathlib import Path
 
-_CONFIG = Path(__file__).resolve().parent.parent / "alloy" / "config.alloy"
+import pytest
+
+_ALLOY = Path(__file__).resolve().parent.parent / "alloy"
+
+_SERVER = _ALLOY / "config.alloy"
+_CLIENT = _ALLOY / "client.alloy"
+
+# Each config's own destination. The server writes to the Loki beside it;
+# a client writes to the proxy in front of the server's, which is a
+# `loki.write` under a different name rather than a different mechanism.
+_WRITES_TO = {
+    _SERVER: "loki.write.local.receiver",
+    _CLIENT: "loki.write.server.receiver",
+}
+
+_SOURCES = ('loki.source.docker "containers"', 'loki.source.journal "units"')
+
+# Both files collect the same two sources through the same processing
+# stage, so the wiring checks below hold for either.
+_EITHER = pytest.mark.parametrize(
+    "config", [_SERVER, _CLIENT], ids=["server", "client"]
+)
 
 
-def _config() -> str:
-    return _CONFIG.read_text(encoding="utf-8")
-
-
-def _block(name: str) -> str:
+def _block(config: Path, name: str) -> str:
     """The body of one top-level block, by its `type "label"` header."""
-    text = _config()
+    text = config.read_text(encoding="utf-8")
     start = text.index(f"{name} {{")
     depth = 0
     for offset in range(start, len(text)):
@@ -32,14 +50,20 @@ def _block(name: str) -> str:
     raise AssertionError(f"unbalanced braces in {name}")
 
 
-def test_both_sources_forward_through_the_processing_stage() -> None:
+def _rules(body: str) -> list[str]:
+    """The bodies of every `rule { ... }` in a relabel block."""
+    return re.findall(r"rule\s*\{([^}]*)\}", body)
+
+
+@_EITHER
+def test_both_sources_forward_through_the_processing_stage(config: Path) -> None:
     """Docker and journal alike, or one shape of deployment loses labels.
 
     A source pointed straight at `loki.write` keeps working — the lines
     arrive, unlabelled — so this is the failure that survives review.
     """
-    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
-        body = _block(source)
+    for source in _SOURCES:
+        body = _block(config, source)
 
         assert "loki.process.sensors.receiver" in body, (
             f"{source} does not forward through loki.process.sensors, so its "
@@ -47,15 +71,17 @@ def test_both_sources_forward_through_the_processing_stage() -> None:
         )
 
 
-def test_the_processing_stage_reaches_loki() -> None:
-    body = _block('loki.process "sensors"')
+@_EITHER
+def test_the_processing_stage_reaches_its_destination(config: Path) -> None:
+    body = _block(config, 'loki.process "sensors"')
 
-    assert "loki.write.local.receiver" in body
+    assert _WRITES_TO[config] in body
 
 
-def test_sensor_id_is_read_from_the_line_and_promoted_to_a_label() -> None:
+@_EITHER
+def test_sensor_id_is_read_from_the_line_and_promoted_to_a_label(config: Path) -> None:
     """Extraction alone is invisible: `stage.labels` is what publishes it."""
-    body = _block('loki.process "sensors"')
+    body = _block(config, 'loki.process "sensors"')
 
     assert re.search(r"stage\.logfmt\s*\{[^}]*\"sensor_id\"", body), (
         "no logfmt stage extracting sensor_id"
@@ -65,7 +91,58 @@ def test_sensor_id_is_read_from_the_line_and_promoted_to_a_label() -> None:
     )
 
 
-def test_no_source_writes_to_loki_directly() -> None:
+@_EITHER
+def test_no_source_writes_to_loki_directly(config: Path) -> None:
     """The stage is only load-bearing while everything goes through it."""
-    for source in ('loki.source.docker "containers"', 'loki.source.journal "units"'):
-        assert "loki.write.local.receiver" not in _block(source)
+    for source in _SOURCES:
+        assert _WRITES_TO[config] not in _block(config, source)
+
+
+@_EITHER
+def test_only_labmon_units_are_collected_from_the_journal(config: Path) -> None:
+    """Widening this ships the whole machine's journal, and looks fine.
+
+    The host journal is every login session and system service on the
+    box. Nothing downstream would report a problem — Loki would simply
+    fill with logs nobody asked to centralise, which on a client is
+    somebody's own lab machine.
+    """
+    keeps = [
+        rule
+        for rule in _rules(_block(config, 'discovery.relabel "journal"'))
+        if '"keep"' in rule
+    ]
+
+    assert len(keeps) == 1, "expected exactly one keep rule bounding the journal"
+    assert '"unit"' in keeps[0], "the keep rule does not match on the unit name"
+    assert '"labmon-.*"' in keeps[0], (
+        "the journal is no longer restricted to labmon's own units"
+    )
+
+
+def test_a_client_stamps_its_own_name_on_every_line() -> None:
+    """Without `host`, two clients are one stream and cannot be separated.
+
+    The label is only added client-side, so the server's config has no
+    equivalent to check: its lines are the ones with no `host` at all.
+    """
+    body = _block(_CLIENT, 'loki.process "sensors"')
+
+    assert re.search(
+        r"stage\.static_labels\s*\{[^}]*\"host\"\s*=\s*sys\.env\(\"LABMON_CLIENT_NAME\"\)",
+        body,
+    ), "a client's lines carry no host label naming the machine they came from"
+
+
+def test_a_client_reads_its_credentials_from_the_environment() -> None:
+    """A literal here would work, and would be committed.
+
+    Nothing about the push would look wrong — which is the point of
+    pinning it rather than trusting review to catch it.
+    """
+    body = _block(_CLIENT, 'loki.write "server"')
+
+    for setting in ("username", "password", "ca_file"):
+        assert re.search(rf"{setting}\s*=\s*sys\.env\(", body), (
+            f"{setting} is not read from the environment"
+        )


### PR DESCRIPTION
Closes #63. Builds on the TLS work in #73.

Alloy collects from the host it runs on, so a sensor on a client machine was invisible to the server's collector — container or systemd, it made no difference. Such a client now runs its own Alloy, shipping to the server rather than to a Loki of its own.

```
client Alloy ──https──► caddy:3444 ──http──► loki:3100
                        basic auth           (still unpublished)
```

## The decision the issue asked to be made deliberately

#63 offered two ways forward and asked that this be chosen rather than fallen into. Taking the first: **Loki behind the same TLS story as everything else**, now that #73 has merged.

But TLS alone was not enough here, and this is the part worth reviewing. InfluxDB and Grafana each check a credential of their own behind the proxy, so TLS there only has to keep one from being read in transit. **Loki's push API checks nothing at all.** Proxying it bare would put a write-anything endpoint on the LAN — reachable by everything, able to fill the log store or bury a real line under invented ones. That was the objection that kept this issue parked, and encrypting the link does not answer it.

So the push site authenticates, and it serves exactly one path:

- **`basic_auth`**, because Loki will not.
- **Only `/loki/api/v1/push`; everything else 404s.** The credential is copied to every machine that ships logs, so it should be worth as little as possible if one leaks — writing log lines, not reading back everything the stack has ever collected through the same host and port.

## Deny by default, without breaking anyone

`LABMON_LOKI_PUSH_HASH` ships as bcrypt of 32 random bytes generated once and never written down. No password matches it, so publishing 3444 opens nothing until an operator runs `caddy hash-password`.

It reads like a hardcoded credential and is the opposite of one. The alternative — failing to start when the variable is unset — would break the `tls` profile for every deployment that does not want remote logs.

### The hash has to be quoted in `.env`

Caught by CI, and it would have hit every operator following the setup guide. Compose interpolates `.env` values, and a bcrypt hash is mostly `$`-delimited fields — in a hash opening `$2a$14$lGM8y2sO...`, the span starting `$lGM8y2sO` parses as a variable reference, is unset, and is replaced by nothing:

```
written:  $2a$14$lGM8y2sOFhWF4TvWFA8kD.WH8nCwgejJLWuHR4fOkD/xIZg33kdV2
resolved: $2a$14.WH8nCwgejJLWuHR4fOkD/xIZg33kdV2
```

Caddy then refuses every password with 401 while `.env` still reads correctly to a person looking at it. Single quotes suppress the expansion; double quotes do not, following shell rather than dotenv convention. `.env.example`, the docs and the smoke workflow all now quote it; the shipped default in `docker-compose.yml` was already `$$`-escaped and needed no change.

My earlier end-to-end check missed this by exporting the variable — a real environment variable reaches compose uninterpolated, so the documented path was never taken until CI ran it.

## Verified end to end

Against a running stack, with a real credential:

| Probe | Result |
|---|---|
| No credential | **401** |
| Wrong password | **401** |
| Correct credential | **204**, and the line is queryable in Loki |
| Correct credential, read path | **404** |
| No CA | connection refused |

Then the real thing: `alloy/client.alloy` run as a container against the proxy shipped its lines, arriving as `{container="mock-cryo-77k", host="test-client", sensor_id="cryo-77k"}` — the full label set over the remote path.

## The `host` label

Lines gain `host`, naming the machine they came from. Without it two clients running the same container names are one indistinguishable stream, and telling a client's lines from the server's is guesswork.

## Fixes from review

Three issues found reviewing the branch, each its own commit:

**The journal source only read the persistent journal.** Both compose files mount `/var/log/journal` and `/run/log/journal` and say either layout works, but both Alloy configs pinned `path` to the first. On a host with `Storage=volatile` — the sensible setting on an SD-card machine — container logs arrived normally while the systemd sensor's silently did not. Alloy reads both directories when `path` is left empty, which is what the mounts were always written for. Fixed in `config.alloy` as well as `client.alloy`: the server had the same gap, and its compose comment made the same claim its config did not honour. Pinned by a test, since the failure needs a volatile-journal host to appear at all.

**An unconfigured client had no name.** `LABMON_CLIENT_NAME` defaulted to empty, and Loki treats an empty label value as absent — so such a client's lines carried no `host` at all and blended into the server's own, the exact ambiguity the label exists to remove. Now defaults to `unnamed-client`, which is visible in Grafana's label browser. `${LABMON_CLIENT_NAME:?}` is not an option: compose interpolates regardless of profile, so a client not shipping logs would fail on a variable it has no reason to set — the same trap as the unset CA path expanding to `::ro`.

**Alloy's UI was published to the LAN.** It has no authentication and lists component configuration, endpoints and recently sent data. A client is somebody's own lab machine, so it now binds `127.0.0.1:12345:12345`; the docs give the `ssh -L` forward. Alloy still listens on `0.0.0.0` inside the container, which is what makes the mapping work. The server publishes the same UI the same way and is left to #136 rather than widened into this branch.

Two follow-ups filed rather than bundled: **#135** (run `client.alloy` itself in CI — the smoke probes prove the proxy, not the collector) and **#136** (the server's UI binding).

## Test plan

- [x] `pytest` — 338 passed, including 14 in `tests/test_alloy_config.py` that now cover `alloy/client.alloy` as well as the server's collector
- [x] Each of those assertions checked against a deliberately broken config — widening either journal `keep` rule, dropping the `host` label, hardcoding the password or the CA path, and pointing a source straight at `loki.write` each fail the expected test
- [x] `typos` clean; every doc link and anchor resolves
- [x] `alloy validate` accepts both Alloy configs (and rejects a deliberately broken config, so silence means valid)
- [x] Server Alloy recreated on the fixed config: `loki.source.journal.units` reports `healthy / journal tailer is running`, and Loki still returns all 12 `sensor_id` values with lines arriving
- [x] `docker compose config` resolves `LABMON_CLIENT_NAME` to `unnamed-client` and the UI port to `host_ip: 127.0.0.1`
- [x] `caddy validate` accepts the Caddyfile
- [x] `docker compose config` valid for the server with `demo,logs,tls`
- [x] `docker compose config` valid for the client **with the variable unset** — an unset CA path expanded to `::ro` and broke parsing for every client, profile or not; caught by pre-commit, now a placeholder default
- [x] All five probes above, against a live proxy
- [x] The real client collector shipped through the proxy and the lines are queryable
- [x] Smoke step rehearsed against a proxy with `basic_auth` deleted: `no credential` goes 401 → 204 and the step fails
