### PR TITLE
build(deps): pin uv like everything else in the supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - run: uv run --locked ruff check .
       - run: uv run --locked ruff format --check .
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - run: uv run --locked basedpyright
 
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
       - run: uv run --locked typos
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          version: "0.12.5"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - run: uv run --locked pytest --cov=src --cov-report=xml --cov-fail-under=100

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@
 # templates/custom-sensor/Dockerfile, which starts FROM this image.
 
 FROM python:3.14-slim-trixie
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Pinned like every other executable this build pulls in. `latest` has
+# broken builds before, and a build that breaks with no change in the
+# repository is expensive to diagnose precisely because the diff is empty.
+COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /uvx /bin/
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #115.

Two mutable version pointers remained in a supply chain that is otherwise pinned throughout — actions by commit SHA, gitleaks by commit SHA, every service image by version tag. `.pre-commit-config.yaml` already carries the argument for why executable code should not be fetched from a moving pointer; these two were the same risk in the same repository.

- `Dockerfile` — `ghcr.io/astral-sh/uv:latest` → `uv:0.12.5`
- `.github/workflows/ci.yml` — `version: "latest"` → `version: "0.12.5"`, in all four jobs

A `latest` that breaks produces a failing build from an unchanged tree, which is the most expensive kind to diagnose: the diff that would explain it is empty.

## Staying current

Dependabot's `docker` ecosystem already covers the repository root, so the Dockerfile pin is bumped automatically from here.

The four setup-uv inputs are **not** covered — the `github-actions` ecosystem bumps an action's SHA, not the values passed to it. Those move by hand, or with each release. Worth knowing rather than assuming they track.

## Test plan

- [x] `docker build` succeeds on the pinned image
- [x] `uv --version` inside the built image reports `0.12.5`
- [x] Pinned to the current release, so this is a pin rather than a downgrade