### PR TITLE
fix(compose): bind the plaintext ports to loopback by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,19 @@ INFLUXDB3_AUTH_TOKEN=
 # InfluxDB 3 database name (default: lab).
 INFLUXDB_DATABASE=
 
-# Grafana admin password (default: admin).
+# Grafana admin password (default: admin). Change it before publishing
+# Grafana's port with LABMON_BIND_ADDRESS below.
 GRAFANA_ADMIN_PASSWORD=
+
+# Which address InfluxDB's and Grafana's ports bind to (default:
+# 127.0.0.1). Loopback means a fresh install is reachable only from the
+# machine running it, which is what the quickstart wants on a laptop.
+#
+# A server that clients push to sets this to 0.0.0.0 — see
+# docs/deployment.md. It does not affect the tls profile, whose proxy is
+# published on every interface either way: that path is encrypted and
+# authenticated, which is the point of it.
+LABMON_BIND_ADDRESS=
 
 # Which docker-compose profiles are active, comma-separated. "demo" brings
 # up the five mock sensors alongside InfluxDB/Grafana (today's full local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,11 @@ services:
       init-state-dirs:
         condition: service_completed_successfully
     ports:
-      - "8181:8181"
+      # Loopback by default. Short syntax (`"8181:8181"`) binds every
+      # interface, which on a laptop following the quickstart publishes
+      # this to whatever network it is attached to. A server that clients
+      # push to sets LABMON_BIND_ADDRESS=0.0.0.0 — see docs/deployment.md.
+      - "${LABMON_BIND_ADDRESS:-127.0.0.1}:8181:8181"
     command:
       - influxdb3
       - serve
@@ -113,7 +117,10 @@ services:
       influxdb:
         condition: service_healthy
     ports:
-      - "3000:3000"
+      # Loopback by default, for the reason given on InfluxDB's port
+      # above — more sharply here, since this one answers a login prompt
+      # whose default password is `admin`.
+      - "${LABMON_BIND_ADDRESS:-127.0.0.1}:3000:3000"
     environment:
       - INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN}
       - INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-lab}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,7 @@ Only meaningful on the machine running `docker-compose.yml`.
 |---|---|---|
 | `INFLUXDB_NODE_ID` | *(required)* | Node identifier for the InfluxDB instance |
 | `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana admin login |
+| `LABMON_BIND_ADDRESS` | `127.0.0.1` | Which address InfluxDB's and Grafana's ports bind to. Loopback by default; a server clients push to sets `0.0.0.0`. Does not affect the `tls` profile's proxy |
 | `COMPOSE_PROFILES` | *(unset)* | Which optional services start — see below |
 | `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Unset means Grafana needs no network at boot |
 | `LOKI_RETENTION_PERIOD` | `720h` | How long a log line is kept, with the `logs` profile active. Never below `24h` — Loki accepts less and cannot honour it |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,18 +76,30 @@ other services wait for it via `service_completed_successfully`.
 
 ## Exposing the server to the LAN
 
-`docker-compose.yml`'s port bindings (`8181:8181` for InfluxDB, `3000:3000`
-for Grafana) already bind to `0.0.0.0` by default — Compose's short port
-syntax doesn't restrict to `127.0.0.1`. So making the server reachable
-from the rest of the LAN needs no compose changes, just:
+InfluxDB and Grafana bind to `127.0.0.1` by default, so a fresh install
+is reachable only from the machine running it. Making the server
+reachable from the rest of the LAN takes three things:
 
-1. **A stable address for the server.** Either set a DHCP reservation for
+1. **Set `LABMON_BIND_ADDRESS=0.0.0.0` in `.env`**, which publishes both
+   ports on every interface.
+
+   The default is loopback because the quickstart is run on laptops as
+   well as servers, and Grafana answers a login prompt whose default
+   password is `admin`. Publishing that to a café or campus network by
+   default is the wrong trade; a server is a deliberate deployment and
+   can say so in one line.
+
+   **Set a real `GRAFANA_ADMIN_PASSWORD` at the same time.** Opening the
+   port is the moment the default password stops being a local
+   convenience.
+
+2. **A stable address for the server.** Either set a DHCP reservation for
    its LAN IP on your router, or give it a fixed hostname (e.g. via
    `/etc/hosts` on each client, or your router's local DNS if it has one).
    Clients point at this address directly (see
    [`docs/client-setup.md`](client-setup.md)) — there's no service
    discovery (mDNS/Avahi) here, by design, to keep the setup simple.
-2. **Open the two ports on the server's firewall**, if one is active.
+3. **Open the two ports on the server's firewall**, if one is active.
    e.g. on a `ufw`-managed host:
    ```bash
    sudo ufw allow 8181/tcp   # InfluxDB


### PR DESCRIPTION
Closes #109.

Compose's short port syntax binds every interface. Combined with `GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}`, following the quickstart on a laptop published a Grafana admin login, password `admin`, to whatever network the machine was attached to.

Both plaintext ports now go through a new variable:

```yaml
- "${LABMON_BIND_ADDRESS:-127.0.0.1}:8181:8181"
- "${LABMON_BIND_ADDRESS:-127.0.0.1}:3000:3000"
```

## Why a default rather than a removal

On the intended lab server that exposure is the documented feature. A server is a deliberate deployment and can say so in one line; a laptop trying the demo should not have to know to close something.

## What this settles about the port model

- **Plaintext ports are loopback.** InfluxDB, Grafana.
- **The LAN-facing path is the `tls` profile**, whose proxy stays published on every interface — it is encrypted and authenticated, which is the point of it. With `tls` active the plaintext ports *stay* loopback, so the proxy becomes the only way in.
- **Loki was already `expose`d rather than published**, so it was never part of this.

## ⚠️ Behaviour change

An existing **plaintext LAN deployment** must set `LABMON_BIND_ADDRESS=0.0.0.0` after upgrading, or clients and viewers lose access. TLS deployments are unaffected. `docs/deployment.md`'s "Exposing the server to the LAN" section is rewritten around this — it previously documented the old behaviour explicitly, so it could not just be appended to. That section now also says to set a real `GRAFANA_ADMIN_PASSWORD` at the same moment, since opening the port is when the default stops being a local convenience.

## Test plan

- [x] `docker compose config` resolves `host_ip: 127.0.0.1` by default for both ports
- [x] `LABMON_BIND_ADDRESS=0.0.0.0` resolves `host_ip: 0.0.0.0` for both
- [x] With `COMPOSE_PROFILES=tls`, the proxy's 8443/3443/3444 have no `host_ip` (all interfaces) while the plaintext ports stay loopback
- [x] **Live sockets checked, not just the config**: `ss -ltn` reports `127.0.0.1:3000` and `127.0.0.1:8181` where both were previously `0.0.0.0`
- [x] Quickstart unaffected — `http://localhost:3000` still resolves, and both smoke scripts already use `127.0.0.1`
- [x] `LABMON_BIND_ADDRESS` indexed in `docs/configuration.md` and documented in `.env.example`