### PR TITLE
fix(serial): validate channel names off the wire

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,8 @@ the source, so grepping for that finds them all.
 | `CALIBRATION_ID_LENGTH`, `FINGERPRINT_SIGNIFICANT_DIGITS` | Re-tags every calibration, so a new id never matches one in the database |
 | `VOLTAGE_SYMBOL` | Invalidates every `expression` conversion in every calibration file at once |
 | `_FIELD_SEPARATOR`, `_FIELDS_PER_LINE` | Breaks the wire contract: readings stop parsing until the board is reflashed to match |
+| `_CHANNEL_PATTERN` | Widening it lets arbitrary text become a permanent InfluxDB tag; narrowing it stops a board's existing channels parsing |
+| `MAX_WARNED_CHANNELS` | Only how many uncalibrated channels are named in the log before the warnings stop naming them |
 
 Everything else with a `DEFAULT_` prefix is the default of a parameter
 next to it, and can be changed by passing a value — which survives an

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -57,6 +57,13 @@ measurement = "temperature"
 conversion_factor = "42.5 kelvin / volt"
 ```
 
+A channel name is what the board sends before the comma, and it may use
+letters, digits, `_`, `.` and `-`, up to 32 characters. A reading whose
+channel falls outside that is discarded with a warning rather than
+recorded: the name becomes an indexed InfluxDB tag and appears in every
+log line for that channel, so line noise that happens to split on a
+comma must not be able to write into either.
+
 Where the unit can be **derived** it is, rather than declared: volts
 times a factor in `kelvin / volt` gives kelvin, so `linear` and `affine`
 have no unit to state (or get wrong). The interpolation and expression

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -48,6 +48,12 @@ from labmon.sensors.serial_source import (
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# How many uncalibrated channels are named individually before the
+# warnings give up. Comfortably above any real board — the reference
+# sketch has six analog inputs — and low enough that the set cannot
+# become a memory problem on a process left running for months.
+MAX_WARNED_CHANNELS = 64
+
 # INVARIANT (see docs/configuration.md): the three names below are the
 # schema every stored reading was written under. Changing one splits the
 # history in two — rows already in InfluxDB keep the old name, and no
@@ -125,7 +131,15 @@ def run(
 
     # A board may stream channels this host has no calibration for;
     # warn once each rather than on every reading forever.
+    #
+    # Bounded, because remembering every channel seen is a leak if the
+    # names never stop being novel. Parsing constrains a channel to 32
+    # characters from a small alphabet, which rules out most line noise
+    # but still leaves far more names than a board could legitimately
+    # have. Past the cap the warnings stop naming channels; the readings
+    # were already being discarded either way.
     warned_channels: set[str] = set()
+    warned_channel_cap_reported = False
 
     # One gate per channel, since each carries its own deadband state:
     # sharing one would let an instrument being off silence a channel
@@ -155,11 +169,18 @@ def run(
             calibration = calibrations.get(reading.channel)
             if calibration is None:
                 if reading.channel not in warned_channels:
-                    warned_channels.add(reading.channel)
-                    logger.warning(
-                        "no calibration for channel; ignoring its readings",
-                        extra={"channel": reading.channel},
-                    )
+                    if len(warned_channels) < MAX_WARNED_CHANNELS:
+                        warned_channels.add(reading.channel)
+                        logger.warning(
+                            "no calibration for channel; ignoring its readings",
+                            extra={"channel": reading.channel},
+                        )
+                    elif not warned_channel_cap_reported:
+                        warned_channel_cap_reported = True
+                        logger.warning(
+                            "too many uncalibrated channels; not naming any more",
+                            extra={"limit": MAX_WARNED_CHANNELS},
+                        )
                 continue
 
             voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)

--- a/src/labmon/sensors/serial_source.py
+++ b/src/labmon/sensors/serial_source.py
@@ -20,6 +20,7 @@ physical quantity is `labmon.calibration`'s job.
 
 import logging
 import math
+import re
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -33,6 +34,19 @@ logger: logging.Logger = logging.getLogger(__name__)
 # to match.
 _FIELD_SEPARATOR = ","
 _FIELDS_PER_LINE = 2
+
+# What a channel name is allowed to be. A name that survives parsing
+# becomes an InfluxDB tag — indexed, and effectively permanent — and
+# reaches every log line reporting that channel, so line noise that
+# happens to split on a comma must not be able to put arbitrary text in
+# either place.
+#
+# Derived from the names that actually occur rather than guessed: the
+# reference firmware and every calibration file in the repository use
+# `A0`-`A5`. This admits those with room to spare, and rejects the two
+# things that motivated it — terminal escape sequences, and names long
+# or novel enough to grow `warned_channels` without bound.
+_CHANNEL_PATTERN = re.compile(r"[A-Za-z0-9_.-]{1,32}\Z")
 
 # Long enough not to spin, short enough that a stop request is noticed
 # promptly: read() returns None on timeout, so the caller's loop keeps
@@ -99,6 +113,16 @@ def parse_reading(line: bytes) -> RawReading | None:
         logger.warning(
             "skipping malformed line",
             extra={"reason": "empty channel", "line": line},
+        )
+        return None
+
+    if not _CHANNEL_PATTERN.match(channel):
+        logger.warning(
+            "skipping malformed line",
+            extra={
+                "reason": "channel name has a disallowed character or length",
+                "line": line,
+            },
         )
         return None
 

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -14,7 +14,7 @@ from labmon.calibration import Calibration, LinearConversion, ureg
 from labmon.gate import StopRecordingRule
 from labmon.sensors import loop as sensor_loop
 from labmon.sensors import serial_sensor
-from labmon.sensors.serial_sensor import main, run
+from labmon.sensors.serial_sensor import MAX_WARNED_CHANNELS, main, run
 from labmon.sensors.serial_source import RawReading
 
 SignalHandler = Callable[[int, FrameType | None], None]
@@ -369,6 +369,51 @@ def test_run_warns_once_per_uncalibrated_channel(
     assert _field(warnings[0], "channel") == "A7"
     [batch] = fake_client.batches
     assert len(batch) == 1
+
+
+def test_run_stops_tracking_uncalibrated_channels_past_the_cap(
+    fake_client: FakeInfluxClient,
+    registered_handlers: dict[int, SignalHandler],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The warned-channel set must not grow with the input forever.
+
+    Warning once per channel means remembering every channel seen. A
+    board — or line noise that parses — producing endlessly novel names
+    would otherwise grow that set for as long as the process runs, which
+    on a sensor left up for months is a leak.
+    """
+    novel: list[RawReading | None] = [
+        RawReading(channel=f"ch{index}", raw_count=1)
+        for index in range(MAX_WARNED_CHANNELS + 5)
+    ]
+    source = FakeRawSource(novel)
+
+    with caplog.at_level(logging.WARNING), pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    per_channel = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "no calibration for channel; ignoring its readings"
+    ]
+    assert len(per_channel) == MAX_WARNED_CHANNELS
+
+    # And it says so once, rather than going quiet and leaving the
+    # operator to wonder why the warnings stopped.
+    [capped] = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "too many uncalibrated channels; not naming any more"
+    ]
+    assert _field(capped, "limit") == MAX_WARNED_CHANNELS
+
+    # None of it was recorded: an uncalibrated channel has no conversion,
+    # so there is nothing to write whether or not it was warned about.
+    assert fake_client.batches == []
 
 
 def test_run_honours_a_custom_adc_resolution_and_reference(

--- a/tests/test_serial_source.py
+++ b/tests/test_serial_source.py
@@ -72,6 +72,9 @@ def test_parse_reading_ignores_an_empty_read() -> None:
     assert parse_reading(b"") is None
 
 
+_DISALLOWED_CHANNEL = "channel name has a disallowed character or length"
+
+
 def test_parse_reading_ignores_a_blank_line() -> None:
     assert parse_reading(b"\r\n") is None
 
@@ -89,6 +92,19 @@ def test_parse_reading_ignores_a_blank_line() -> None:
         pytest.param(b"A0,-inf\n", "count is not finite", id="negative-inf-count"),
         pytest.param(b",2048\n", "empty channel", id="empty-channel"),
         pytest.param(b"\xff\xfe\n", "not valid UTF-8", id="undecodable-bytes"),
+        # A channel name becomes a permanent, indexed InfluxDB tag and
+        # reaches every log line, so line noise that happens to parse
+        # must not be able to put arbitrary text in either.
+        pytest.param(
+            b"A0\x1b[31m,2048\n", _DISALLOWED_CHANNEL, id="ansi-escape-in-channel"
+        ),
+        pytest.param(b"A 0,2048\n", _DISALLOWED_CHANNEL, id="space-in-channel"),
+        pytest.param(
+            "\u00b5m,2048\n".encode(), _DISALLOWED_CHANNEL, id="non-ascii-channel"
+        ),
+        pytest.param(
+            b"A" * 33 + b",2048\n", _DISALLOWED_CHANNEL, id="over-long-channel"
+        ),
     ],
 )
 def test_parse_reading_skips_a_malformed_line(
@@ -104,6 +120,24 @@ def test_parse_reading_skips_a_malformed_line(
     assert record.getMessage() == "skipping malformed line"
     assert _field(record, "reason") == reason
     assert _field(record, "line") == line
+
+
+@pytest.mark.parametrize(
+    "channel",
+    ["A0", "A15", "temp_1", "ch.2", "x-3", "a" * 32],
+    ids=["board-style", "two-digit", "underscore", "dot", "hyphen", "max-length"],
+)
+def test_parse_reading_accepts_a_reasonable_channel_name(channel: str) -> None:
+    """The constraint has to admit every name a real board would send.
+
+    Guarding the tag namespace is worthless if it also rejects the
+    firmware's own channels, so the accepted set is pinned alongside the
+    rejected one.
+    """
+    reading = parse_reading(f"{channel},2048\n".encode())
+
+    assert reading is not None
+    assert reading.channel == channel
 
 
 def test_read_returns_successive_readings() -> None:


### PR DESCRIPTION
Closes #114.

`parse_reading` checked that a channel was non-empty and nothing else, so any UTF-8 that survived decoding became a channel name. Two commits, because the issue describes two problems and neither fix subsumes the other.

## 1. Tag and log contamination

A channel name becomes an InfluxDB tag — indexed, and effectively permanent — and appears in every log line for that channel. Arbitrary bytes, including ANSI escape sequences, reached both.

Channels are now `[A-Za-z0-9_.-]{1,32}`, and a reading outside that is discarded with a warning rather than recorded.

The pattern is **derived rather than guessed**: the reference firmware and every calibration file in the repo use `A0`–`A5`, so this admits real names with room to spare. Anchored with `\Z`, not `$` — `$` accepts a trailing newline and would reopen the hole:

```python
p.match("A0\n")   # \Z → False      $ → True
```

The accepted set is pinned alongside the rejected one, since a constraint that rejects the firmware's own channels would be worse than none.

## 2. Unbounded memory

Warning once per uncalibrated channel means remembering every channel seen, and that set grew for as long as the process ran.

**Validation alone does not close this**, contrary to what the issue assumed: 32 characters from a 64-symbol alphabet is still far more names than a board could legitimately have. So the set is now capped at `MAX_WARNED_CHANNELS = 64` — well above the reference sketch's six analog inputs.

Hitting the cap logs once rather than going quiet, so an operator is not left wondering why the warnings stopped. Those readings were already discarded for want of a calibration, so nothing else changes.

## Test plan

- [x] TDD — both fixes written test-first and confirmed RED before implementing
- [x] Rejected: ANSI escape, embedded space, non-ASCII, 33 characters
- [x] Accepted: `A0`, `A15`, `temp_1`, `ch.2`, `x-3`, 32 characters
- [x] The cap emits exactly 64 per-channel warnings out of 69 novel channels, plus one "not naming any more", and writes nothing
- [x] `pytest` 349 passed, coverage 100% (`--cov-fail-under=100`)
- [x] ruff, basedpyright (0 errors 0 warnings), typos all clean
- [x] Both constants indexed in `docs/configuration.md`; the constraint documented for users in `docs/serial-sensor.md`