### PR TITLE
fix(logs): quieten influxdb's once-a-second WAL flush line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,17 @@ services:
       - --node-id=${INFLUXDB_NODE_ID}
       - --object-store=file
       - --data-dir=/var/lib/influxdb3/data
+      # Everything influxdb3 emits at steady state is one line per WAL
+      # flush — 86,400 a day, ~2.6M over the default retention window,
+      # and with the `logs` profile on that is the entire stored log.
+      # The line is genuinely diagnostic, so it is lowered rather than
+      # dropped: it reappears at `warn` and above, and `debug` brings it
+      # back in full.
+      #
+      # The two directives before it are influxdb3's own default, which
+      # passing this flag would otherwise replace — dropping them would
+      # re-enable the query-log noise they exist to suppress.
+      - --log-filter=info,iox_query::query_log=warn,influxdb3_query_executor::query_planner=warn,influxdb3_wal::object_store=warn
     volumes:
       - type: bind
         # Path to store data on host system

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,9 +70,14 @@ services:
       - --node-id=${INFLUXDB_NODE_ID}
       - --object-store=file
       - --data-dir=/var/lib/influxdb3/data
-      # Everything influxdb3 emits at steady state is one line per WAL
-      # flush — 86,400 a day, ~2.6M over the default retention window,
-      # and with the `logs` profile on that is the entire stored log.
+      # Everything influxdb3 emits at steady state is one line per
+      # write-ahead-log flush: a write is appended to the WAL for
+      # durability, and once a second that buffer is flushed to the
+      # object store and the flush is logged. That is 86,400 lines a
+      # day, ~2.6M over the default retention window, and with the
+      # `logs` profile on it is the entire stored log. See
+      # docs/logging.md, and docs/latency.md for why the same interval
+      # sets the cost of a single write.
       # The line is genuinely diagnostic, so it is lowered rather than
       # dropped: it reappears at `warn` and above, and `debug` brings it
       # back in full.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ Only meaningful on the machine running `docker-compose.yml`.
 | `COMPOSE_PROFILES` | *(unset)* | Which optional services start — see below |
 | `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Unset means Grafana needs no network at boot |
 | `LOKI_RETENTION_PERIOD` | `720h` | How long a log line is kept, with the `logs` profile active. Never below `24h` — Loki accepts less and cannot honour it |
+| *(not a variable)* `--log-filter` | see `docker-compose.yml` | InfluxDB's log level per module. Lowers the once-a-second WAL flush line, which is otherwise its entire output — see docs/logging.md |
 | `LABMON_TLS_INFLUXDB_SITES` | `https://127.0.0.1:8443` | Addresses the proxy answers on for InfluxDB, with the `tls` profile active. Comma-*and-space* separated; each entry a whole `https://host:port` |
 | `LABMON_TLS_GRAFANA_SITES` | `https://127.0.0.1:3443` | The same for Grafana |
 | `LABMON_TLS_DEFAULT_SNI` | `127.0.0.1` | Which certificate to serve when a client sends no server name, which is what dialling a bare IP does |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -182,10 +182,22 @@ Grafana.
 
 ### InfluxDB's WAL flush line
 
-InfluxDB emits one line per WAL flush, once a second. At steady state
-that was *everything* it emitted — 86,400 lines a day, around 2.6
-million over the default 30-day retention, and with the `logs` profile
-on it was the entire stored log.
+A write does not go straight into InfluxDB's long-term storage. It is
+validated in memory and appended to a **write-ahead log** — a WAL, an
+append-only file that makes the write durable before the slower work of
+organising it into queryable form happens. Once a second by default,
+InfluxDB flushes that buffer to the object store and logs a line saying
+so ([InfluxDB 3 Core
+internals](https://docs.influxdata.com/influxdb3/core/reference/internals/durability/)).
+
+That once-a-second interval is the same one that makes a single
+unbatched write cost about a second, which is why `PointWriter` batches
+at all — [`docs/latency.md`](latency.md#why-the-influxdb-write-costs-a-second)
+has the measurements.
+
+One line per second is 86,400 a day and around 2.6 million over the
+default 30-day retention. At steady state it was *everything* InfluxDB
+emitted, so with the `logs` profile on it was the entire stored log.
 
 It is lowered rather than dropped, with a `--log-filter` directive in
 `docker-compose.yml`. The line is genuinely diagnostic — it carries

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -180,6 +180,23 @@ gets no such label at all, rather than an empty one. An empty value would
 be a stream of its own and would appear in every label browser in
 Grafana.
 
+### InfluxDB's WAL flush line
+
+InfluxDB emits one line per WAL flush, once a second. At steady state
+that was *everything* it emitted — 86,400 lines a day, around 2.6
+million over the default 30-day retention, and with the `logs` profile
+on it was the entire stored log.
+
+It is lowered rather than dropped, with a `--log-filter` directive in
+`docker-compose.yml`. The line is genuinely diagnostic — it carries
+`n_ops` and `wal_file_number` — so it comes back by raising InfluxDB's
+level for that module, and `debug` restores it in full.
+
+Lowering one module's level is a blunt instrument: what is worth
+keeping for a day and worthless after thirty is a general problem, and
+suppression is the wrong shape for it. A retention tier for
+noisy-but-useful signals is tracked separately.
+
 ### If a container's output never appears
 
 Almost always buffering rather than collection. Python block-buffers stdout


### PR DESCRIPTION
Closes #86.

## What a WAL flush is

A write does not go straight into InfluxDB's long-term storage. It is validated in memory and appended to a **write-ahead log** — an append-only file that makes the write durable before the slower work of organising it into queryable form happens. Once a second by default, InfluxDB flushes that buffer to the object store, and logs a line saying it did ([InfluxDB 3 Core internals](https://docs.influxdata.com/influxdb3/core/reference/internals/durability/)).

One line per second, forever, whether or not anything interesting happened.

That interval is also the reason a single unbatched write costs about a second, and therefore the reason `PointWriter` batches at all — see [`docs/latency.md`](https://github.com/quentinmarolleau/labmon/blob/main/docs/latency.md#why-the-influxdb-write-costs-a-second). The log volume and the shape of the write path have one cause.

## The measurement

Measured on the demo + logs stack, thirty seconds at steady state:

```
total          30
wal flush      30
other           0
```

Every line InfluxDB emits is the same one. That is 86,400 a day, ~2.6M over the default 30-day retention, and with the `logs` profile on it *is* the stored log.

## Lowered, not dropped

The line carries `n_ops` and `wal_file_number` and is genuinely diagnostic, so it is moved below `info` rather than discarded:

```
--log-filter=info,iox_query::query_log=warn,influxdb3_query_executor::query_planner=warn,influxdb3_wal::object_store=warn
```

It comes back by raising InfluxDB's level for that module, and `debug` restores it in full. Dropping it in Alloy would have thrown it away for good and cost a pipeline stage on every line to do it.

## The repeated directives are not redundant

`--log-filter` **replaces** influxdb3's default rather than extending it. The first two directives are that default, repeated deliberately — omitting them would re-enable the query-log noise they exist to suppress, trading one source of volume for another.

## This is the narrow fix

Lowering one module's level is blunt. The general problem — some signals are worth a day and worthless after thirty — is #87, and suppression is the wrong shape for it. This is the one-line fix for the case currently drowning everything else.

## Test plan

- [x] **Counted before and after against a live stack**: 30 WAL lines / 30s → **0**
- [x] The running process's `/proc/1/cmdline` confirms all four directives reached it
- [x] Non-WAL lines still logged — startup lines still present after the restart, so `info` is not globally suppressed
- [x] Data still flowing: sensors report `wrote readings ... skipped=0`, no errors or warnings across the stack, 12 `sensor_id` values still in Loki
- [x] `typos` clean; documented in `docs/logging.md` and indexed in `docs/configuration.md`
- [x] `docs/logging.md` and the compose comment both explain what a WAL flush is and link upstream, rather than naming it and assuming the reader knows
