### PR TITLE
fix(writer): shed load instead of blocking acquisition

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,12 @@ ten thousand points is about a hundred seconds at 100 Hz, or most of a
 day at one reading every five seconds. [`docs/latency.md`](latency.md)
 has the measurements.
 
+Once it is full, the oldest point is dropped to make room for the newest
+and acquisition continues — a monitoring system is better served by
+current data than by a stalled sampling loop. Drops are counted, warned
+about once, and reported per summary window, so shedding load is never
+silent.
+
 A sensor built on `SensorLoop` takes a writer rather than forwarding each
 of these:
 

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -129,18 +129,25 @@ the queue grows at whatever rate the board is streaming.
 | 10 readings/s | ~17 min |
 | 50 readings/s | ~3 min |
 
-Past that, `queue.put()` blocks, and with it the read loop. Backpressure
-then propagates back down the serial link: a measurement against a
-virtual serial port showed roughly 20 KB buffering in the tty layer
-(~2,560 short lines) before the *sender* blocked in turn. Nothing is
-corrupted or silently dropped, but a board whose firmware blocks in
-`SerialUSB.print()` stops sampling on its own schedule until the host
-catches up.
+Past that, the oldest queued point is discarded to make room for the
+newest, and acquisition carries on. For a live instrument the most
+recent reading is the valuable one, and the alternative is worse than
+losing the oldest: blocking there turns a storage outage into an
+acquisition outage. The recording gates stop being evaluated, the
+serial buffer overflows anyway, and the periodic summary that would
+report any of it stops being emitted — so the failure hides precisely
+because the code that reports failures is part of what stopped.
 
-The difference from `mock-sensor` is worth stating plainly: a mock sensor
-paces itself, so a stalled loop simply samples less often. A real board
-sets its own pace and cannot be told to wait, so the consequence lands on
-the firmware instead of on the script.
+Discards are counted and reported. The first one logs a warning
+immediately, and each summary window that lost points reports how many
+as `dropped readings to keep acquiring`. That count is writer-wide
+rather than per-sensor, because one `PointWriter` carries every
+channel.
+
+Note what this policy does **not** preserve: the queue holds a fixed
+number of points, so a long outage is recorded as its final stretch
+rather than its whole span. Keeping the entire window at reduced
+resolution is a better answer and is tracked separately.
 
 At the rates this project actually runs, the queue is oversized by orders
 of magnitude and none of this is reachable. It matters only for a

--- a/src/labmon/sensors/loop.py
+++ b/src/labmon/sensors/loop.py
@@ -82,6 +82,7 @@ class SensorLoop:
         self._sensors: frozenset[str] = frozenset(sensors)
         self._written: Counter[str] = Counter()
         self._skipped: Counter[str] = Counter()
+        self._reported_dropped: int = 0
         self._warned: set[str] = set()
         self._next_summary: float = time.monotonic() + (summary_interval or 0.0)
 
@@ -157,6 +158,22 @@ class SensorLoop:
                     "sensor_id": sensor_id,
                     "readings": self._written[sensor_id],
                     "skipped": self._skipped[sensor_id],
+                    "window_s": f"{self._summary_interval:.0f}",
+                },
+            )
+        # Reported apart from `skipped`, and only when it happens.
+        # `skipped` means a reading arrived and could not be converted;
+        # a drop means the reading was fine and storage could not keep
+        # up, which points somewhere else entirely. It is also
+        # writer-wide — one PointWriter carries every channel — so it
+        # cannot honestly be attributed to a single sensor_id.
+        dropped = self.writer.dropped - self._reported_dropped
+        if dropped:
+            self._reported_dropped = self.writer.dropped
+            logger.warning(
+                "dropped readings to keep acquiring",
+                extra={
+                    "dropped": dropped,
                     "window_s": f"{self._summary_interval:.0f}",
                 },
             )

--- a/src/labmon/writer.py
+++ b/src/labmon/writer.py
@@ -70,12 +70,53 @@ class PointWriter[T]:
         self._initial_backoff: float = initial_backoff
         self._max_backoff: float = max_backoff
         self._stop: threading.Event = threading.Event()
+        self._dropped: int = 0
+        self._warned_full: bool = False
         self._thread: threading.Thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
+    @property
+    def dropped(self) -> int:
+        """How many points have been discarded to keep acquisition running."""
+        return self._dropped
+
     def write(self, point: T) -> None:
-        """Queue a point to be written; never blocks on network I/O."""
-        self._queue.put(point)
+        """Queue a point to be written; never blocks, on I/O or on space.
+
+        When the queue is full the oldest point is discarded to make room
+        for this one. The newest reading is worth more than the oldest
+        for a live instrument, and the alternative — blocking until the
+        writer catches up — turns a storage outage into an acquisition
+        outage: the serial buffer then overflows anyway, the recording
+        gates stop being evaluated, and the periodic summary that would
+        report any of it stops being emitted. The failure is invisible
+        precisely because the code that reports failures is part of what
+        stops running.
+
+        Drops are counted, and `dropped` is what the caller reports.
+        """
+        while True:
+            try:
+                self._queue.put_nowait(point)
+                return
+            except queue.Full:
+                self._discard_oldest()
+
+    def _discard_oldest(self) -> None:
+        """Make room for one point, counting what that cost."""
+        try:
+            _ = self._queue.get_nowait()
+        except queue.Empty:
+            # The drain thread emptied it between the failed put and
+            # here, which is the outcome we wanted anyway.
+            return
+        self._dropped += 1
+        if not self._warned_full:
+            self._warned_full = True
+            logger.warning(
+                "queue full; dropping oldest readings",
+                extra={"maxsize": self._queue.maxsize},
+            )
 
     def close(self) -> None:
         """Flush any remaining queued points, then stop the writer thread."""

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -268,6 +268,61 @@ def test_the_summary_counts_what_was_skipped(
     ]
 
 
+def test_the_summary_reports_points_dropped_by_a_full_queue(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Reported apart from `skipped`, because it is a different failure.
+
+    `skipped` counts readings that arrived and could not be converted —
+    a problem with the reading. A drop means the reading was fine and
+    storage could not keep up, which points somewhere else entirely.
+
+    It is also writer-wide rather than per-sensor: one PointWriter
+    carries every channel, so the count cannot honestly be attributed to
+    one of them.
+    """
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    loop.record(_point(1.0), "cryo-diode")
+
+    # Stand in for a writer that has been shedding load.
+    def _seven(_self: object) -> int:
+        return 7
+
+    monkeypatch.setattr(type(loop.writer), "dropped", property(_seven))
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    [dropped] = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "dropped readings to keep acquiring"
+    ]
+    assert _field(dropped, "dropped") == 7
+    assert dropped.levelno == logging.WARNING
+
+
+def test_the_summary_is_silent_about_drops_when_there_are_none(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A line every window saying `dropped=0` is noise, not reassurance."""
+    ticks = iter([0.0, sensor_loop.DEFAULT_SUMMARY_INTERVAL_SECONDS + 1.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(ticks))
+    loop = SensorLoop()
+    loop.record(_point(1.0), "cryo-diode")
+
+    with caplog.at_level(logging.INFO, logger=sensor_loop.logger.name):
+        loop.summarise_if_due()
+
+    assert not [
+        r
+        for r in caplog.records
+        if r.getMessage() == "dropped readings to keep acquiring"
+    ]
+
+
 @pytest.mark.usefixtures("fake_client", "registered_handlers")
 def test_a_sensor_that_only_skipped_is_still_reported(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -268,6 +268,7 @@ def test_the_summary_counts_what_was_skipped(
     ]
 
 
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
 def test_the_summary_reports_points_dropped_by_a_full_queue(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -304,6 +305,7 @@ def test_the_summary_reports_points_dropped_by_a_full_queue(
     assert dropped.levelno == logging.WARNING
 
 
+@pytest.mark.usefixtures("fake_client", "registered_handlers")
 def test_the_summary_is_silent_about_drops_when_there_are_none(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 import logging
+import queue
 import threading
 import time
 
@@ -61,6 +62,139 @@ class AlwaysFailingClient[T]:
 
     def close(self) -> None:
         self.closed.set()
+
+
+class StalledClient[T]:
+    """Blocks inside write() until released, so the queue can be filled.
+
+    Parking the drain thread *inside* the client makes the queue's
+    contents deterministic: nothing is being taken off it while the test
+    puts points on.
+    """
+
+    def __init__(self) -> None:
+        self.entered: threading.Event = threading.Event()
+        self.release: threading.Event = threading.Event()
+        self.batches: list[list[T]] = []
+        self.closed: threading.Event = threading.Event()
+
+    def write(self, batch: list[T]) -> None:
+        self.batches.append(list(batch))
+        self.entered.set()
+        _ = self.release.wait(timeout=5)
+
+    def close(self) -> None:
+        self.closed.set()
+
+
+def _stalled_writer(maxsize: int) -> tuple[PointWriter[int], StalledClient[int]]:
+    """A writer whose drain thread is parked inside the client."""
+    client = StalledClient[int]()
+    writer = PointWriter[int](client, maxsize=maxsize)
+    writer.write(0)
+    assert client.entered.wait(timeout=5), "drain thread never reached the client"
+    return writer, client
+
+
+def test_a_full_queue_drops_the_oldest_and_keeps_acquiring() -> None:
+    """The point of the policy: an outage must not stop acquisition.
+
+    Blocking here would convert a storage outage into an acquisition
+    outage, and silently — the summary that would report it is emitted
+    by the loop that would have stopped.
+    """
+    writer, client = _stalled_writer(maxsize=3)
+
+    for point in (1, 2, 3, 4, 5):
+        writer.write(point)
+
+    assert writer.dropped == 2
+
+    client.release.set()
+    writer.close()
+
+    written = [point for batch in client.batches for point in batch]
+    assert written == [0, 3, 4, 5], "the newest points should survive, not the oldest"
+
+
+def test_dropping_warns_once_rather_than_per_point(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A full queue is a per-point event; one line is enough to say so."""
+    writer, client = _stalled_writer(maxsize=2)
+
+    with caplog.at_level(logging.WARNING):
+        for point in range(1, 8):
+            writer.write(point)
+
+    client.release.set()
+    writer.close()
+
+    dropped = [
+        r
+        for r in caplog.records
+        if r.getMessage() == "queue full; dropping oldest readings"
+    ]
+    assert len(dropped) == 1
+    assert dropped[0].__dict__["maxsize"] == 2
+
+
+def test_dropped_is_zero_while_the_queue_has_room() -> None:
+    client = FakeClient[int]()
+    writer = PointWriter[int](client, maxsize=100)
+
+    for point in range(10):
+        writer.write(point)
+    writer.close()
+
+    assert writer.dropped == 0
+
+
+def test_a_queue_drained_mid_discard_costs_no_point() -> None:
+    """The narrow race between a failed put and the discard that follows.
+
+    `put_nowait` can fail on a full queue, and the drain thread can then
+    empty it before `_discard_oldest` reaches for a point. Nothing should
+    be counted as dropped: the space it was trying to make appeared on
+    its own, which is the outcome that was wanted.
+
+    Modelled by failing the *first* get only, which is what the real race
+    looks like — a genuinely empty queue accepts the retried put, so the
+    loop terminates rather than spinning.
+    """
+    client = StalledClient[int]()
+    writer = PointWriter[int](client, maxsize=1)
+    writer.write(0)
+    assert client.entered.wait(timeout=5)
+
+    queue_ = writer._queue  # pyright: ignore[reportPrivateUsage]
+    real_get = queue_.get_nowait
+    calls = 0
+
+    def _empty_once() -> int:
+        """Stand in for the drain thread winning the race.
+
+        It takes the point *and* reports the queue as empty, which is
+        exactly what `_discard_oldest` observes when the drain thread
+        gets there first.
+        """
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            _ = real_get()
+            raise queue.Empty
+        return real_get()
+
+    queue_.put_nowait(1)
+    queue_.get_nowait = _empty_once
+    writer.write(2)
+    queue_.get_nowait = real_get
+
+    assert calls == 1, "the discard should have reached for a point exactly once"
+    assert writer.dropped == 0, "no point was actually discarded"
+
+    client.release.set()
+    writer.close()
 
 
 def test_write_does_not_block_the_caller() -> None:


### PR DESCRIPTION
Closes #110.

`PointWriter.write()` documented that it never blocks on network I/O, and it did not — but `queue.put()` blocked indefinitely once the queue was full, which during an outage stopped the acquisition loop *inside* `write()`.

The consequences were worse than the points that could not be stored:

- the serial buffer overflowed anyway, so data was lost regardless, without a count
- the recording gates stopped being evaluated
- the periodic summary stopped being emitted

So nothing reported it. **The failure was invisible precisely because the code that reports failures was part of what stopped running.**

## Policy: drop oldest, and count it

The newest reading is the valuable one for a live instrument; preserving stale data over current data is backwards.

It also behaves correctly with the queue as it actually is. `SensorLoop` runs **every channel through one writer**, so the queue interleaves them — `A0, A1, A2, A3, A0, ...`. Removing the *globally oldest* point thins channels in proportion. Positional strategies do not have that property: with an even number of channels, removing every other point deletes whole sensors outright. That constraint is the main reason #141 is filed separately rather than done here.

## Reported, not silent

- First drop logs a warning immediately, naming `maxsize`
- Each summary window that lost points reports `dropped readings to keep acquiring`

Kept **apart from `skipped`** deliberately. `skipped` counts readings that arrived and could not be converted — a problem with the reading. A drop means the reading was fine and storage could not keep up, which points somewhere else. The count is writer-wide rather than per-sensor, because one writer carries every channel and attributing it to one would be a guess.

## What this does not fix

A fixed *number* of points means a long outage is recorded as its final stretch rather than its whole span — at 100 Hz, the last 100 seconds of a six-hour gap. Keeping the entire window at reduced resolution is the better answer and is **#141**, which needs the writer to stop being agnostic about what a point contains.

## Test plan

- [x] TDD — all five tests written first and confirmed RED
- [x] Full queue drops oldest and keeps the newest: `[0, 3, 4, 5]` survives from `0..5` at `maxsize=3`
- [x] Warns once, not per point
- [x] `dropped == 0` while the queue has room
- [x] The narrow race where the drain thread empties the queue between the failed `put` and the discard costs no point — and the test models it honestly, taking the point *and* reporting empty, which is what the code actually observes
- [x] Summary reports drops, and stays silent when there are none
- [x] `pytest` 355 passed, coverage **100%**; ruff, basedpyright (0/0), typos clean
- [x] `docs/latency.md` rewrote its backpressure passage, which documented the old blocking behaviour explicitly; `docs/configuration.md` documents the policy next to the queue-depth guidance