### PR TITLE
build(release): derive versions and the changelog from the commit history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,43 @@ for when you've been using `--no-verify`.
   testing it would only prove Python's own import mechanism works, not
   our code). Don't reach for it to avoid writing a real test.
 
+## Releasing
+
+Versions and the changelog are both derived from the commit history by
+[cocogitto](https://docs.cocogitto.io), configured in `cog.toml`. Nothing
+here is written by hand, which is the reason the commit conventions above
+are enforced rather than encouraged.
+
+One GitHub milestone is one minor version. A release is cut when its
+milestone closes:
+
+```bash
+git switch main && git pull
+cog bump --dry-run --auto      # inspect the version it derives
+cog bump --auto                # or --version 0.2.0-beta.1 to pin it
+git push --follow-tags
+```
+
+That writes `CHANGELOG.md`, updates the version in `pyproject.toml` and
+`uv.lock`, commits, and tags. Then publish a GitHub release against the
+tag, with prose that says what the version *does* — the generated
+changelog says what changed, which is not the same thing.
+
+Two things that will stop a bump, both deliberately:
+
+- **A dirty or untracked tree.** Releases are cut from exactly what is
+  committed. Working files belong in `.gitignore`.
+- **Being on the wrong branch.** `branch_whitelist` is `main`.
+
+Tags are SemVer (`v0.2.0-beta.1`) because that is what cog and the
+milestones use. `pyproject.toml` is PEP 440 (`0.2.0b1`) because that is
+what Python packaging requires. `uv version` converts between them; the
+two spellings are the same version, not a drift.
+
+Before 1.0, a minor version may change behaviour a deployment has to act
+on. Say so in the release notes, under its own heading, with the change
+required — see `v0.2.0-beta.1` and the port binding.
+
 ## Conduct
 
 Participation is covered by the

--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,52 @@
+# Release configuration for cocogitto (https://docs.cocogitto.io).
+#
+# The commit history already follows Conventional Commits, so the
+# changelog and the version number are both derived from it rather than
+# maintained by hand. `cog bump` writes CHANGELOG.md, updates the version
+# in pyproject.toml through the hook below, commits, and tags.
+
+# Merge commits carry no type and would appear as noise in every entry.
+# Every change reaches main through a squashed or merged PR whose own
+# commits are conventional, and those are what the changelog is built
+# from.
+ignore_merge_commits = true
+
+# Releases are cut from main only.
+branch_whitelist = ["main"]
+
+# Tags are `v0.2.0`, matching the milestone names and the repository's
+# existing references to them.
+tag_prefix = "v"
+
+# `cog bump --auto --pre` produces beta.1, beta.2, ... rather than the
+# alpha default: the project is past alpha as of the first tagged
+# release.
+pre = "beta.*"
+
+# The version in pyproject.toml is the one users see in `pip show` and
+# in the built image, so it has to move with the tag rather than drift
+# behind it. `uv version` rewrites it in place; adding the file to the
+# bump commit is what keeps the two in step.
+#
+# The two are spelled differently on purpose. Tags are SemVer, which is
+# what cog speaks and what the milestones are named after; pyproject is
+# PEP 440, which is what Python packaging requires. `uv version`
+# normalises between them, so `v0.2.0-beta.1` becomes `0.2.0b1` in the
+# package. Same version, two conventions — not a drift to correct.
+pre_bump_hooks = [
+    "uv version {{version}}",
+    "uv lock",
+    "git add pyproject.toml uv.lock",
+]
+
+[changelog]
+path = "CHANGELOG.md"
+# Links commit hashes, issues and authors back to GitHub, which is where
+# the changelog is read.
+template = "remote"
+remote = "github.com"
+repository = "labmon"
+owner = "quentinmarolleau"
+authors = [
+    { signature = "Quentin Marolleau", username = "quentinmarolleau" },
+]


### PR DESCRIPTION
Release plumbing for the beta. The commit conventions have been enforced since the beginning without anything consuming them — this is what they were for.

`cog bump` reads the history, derives the version, writes `CHANGELOG.md`, updates `pyproject.toml` and `uv.lock`, commits and tags. One GitHub milestone is one minor version, which is already how the work has been organised: `v0.2.0-beta` closed at 14/14.

## Verified by actually running it

In a throwaway clone, so nothing touched this repository:

```
$ cog bump --version 0.2.0-beta.1
Bumped version: ... -> v0.2.0-beta.1

$ git tag                    v0.2.0-beta.1
$ grep ^version pyproject.toml   version = "0.2.0b1"
$ git log --oneline -1       chore(version): v0.2.0-beta.1
```

`CHANGELOG.md` came out grouped by type, with every commit linked to GitHub and attributed.

## Two spellings of the same version

Tags are SemVer (`v0.2.0-beta.1`) because that is what cog and the milestones use. `pyproject.toml` is PEP 440 (`0.2.0b1`) because that is what Python packaging requires. `uv version` converts between them.

This is recorded in both `cog.toml` and `CONTRIBUTING.md` because it reads like a drift somebody should fix, and is not.

## Releases are cut from a clean tree

`cog bump` refuses while anything is uncommitted **or untracked**:

```
Error: Untracked files :
	new: <file>
```

That is the right behaviour — a release should be exactly what is committed — but the error does not explain itself, so `CONTRIBUTING.md` says what it means. Anything a working copy is carrying has to be dealt with before a bump.

## Merge commits are excluded

`ignore_merge_commits = true`. Every change reaches `main` through a PR whose own commits are conventional, and those are what an entry should be built from. The merge commit carries no type and would be noise in every release.

## Test plan

- [x] `cog changelog` renders the full history, grouped and linked
- [x] A real `cog bump` in a throwaway clone produces the tag, the PEP 440 version, the bump commit and the changelog
- [x] The untracked-file guard reproduced, so the constraint is documented rather than assumed
- [x] The `branch_whitelist = ["main"]` guard confirmed to refuse elsewhere
- [x] `typos` clean

Nothing here tags anything. The bump runs on `main` after this merges.
