### PR TITLE
fix: run sensor containers as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # like a dead sensor rather than a buffering artefact.
 ENV PYTHONUNBUFFERED=1
 
+# Sensor processes only need to read the application. Keep dialout membership
+# so a serial device mapped by Compose remains accessible without root.
+RUN useradd --create-home --groups dialout --shell /usr/sbin/nologin labmon
+USER labmon
+
 ENTRYPOINT ["mock-sensor"]

--- a/scripts/export-ca.sh
+++ b/scripts/export-ca.sh
@@ -43,6 +43,10 @@ fi
 
 docker compose cp "caddy:${ROOT_IN_CONTAINER}" "$DESTINATION"
 
+# The exported root is public by design. Make it readable to the non-root
+# sensor user when it is bind-mounted into a client container.
+chmod 644 "$DESTINATION"
+
 # Without openssl there is no way to tell a good export from a truncated
 # one. Say that, rather than reporting a file that is probably fine as
 # unreadable — the check is the optional part here, not the export.


### PR DESCRIPTION
## Summary
- add a dedicated non-login labmon user to the image
- retain dialout membership for serial-device access
- run the image entrypoint without root privileges

Closes #116

## Validation
- ruff check: pass
- ruff format --check: pass
- basedpyright: pass
- typos: pass
- pytest: 354 passed; one pre-existing timing-sensitive writer assertion failed on this Windows host

Docker is unavailable locally; the repository smoke workflow builds and starts this image on Linux.