### PR TITLE
fix(mock-sensor): round simulated readings to a plausible resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,6 +290,7 @@ services:
       - --setpoint=21
       - --noise=0.15
       - --unit=°C
+      - --resolution=0.001
 
   mock-room-2:
     <<: *mock-sensor
@@ -300,6 +301,7 @@ services:
       - --setpoint=22
       - --noise=0.15
       - --unit=°C
+      - --resolution=0.001
 
   mock-cryo-77k:
     <<: *mock-sensor
@@ -310,6 +312,7 @@ services:
       - --setpoint=77
       - --noise=0.3
       - --unit=K
+      - --resolution=0.001
 
   mock-cryo-4k:
     <<: *mock-sensor
@@ -320,6 +323,7 @@ services:
       - --setpoint=4.2
       - --noise=0.05
       - --unit=K
+      - --resolution=0.001
 
   mock-pressure:
     <<: *mock-sensor
@@ -345,6 +349,10 @@ services:
       - --noise=400000
       - --interval=2
       - --unit=Hz
+      # 100 kHz steps. The default rounds to six significant digits,
+      # which at 276 THz is a 1 GHz step — coarser than the whole drift,
+      # so consecutive readings would come back identical.
+      - --resolution=1e5
 
   # The demo's second acquisition path. Unlike the mock sensors above,
   # which invent a value already in physical units, these two run the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,8 @@ describing hardware. Full description in
 | `--setpoint` | `21.0` | Baseline the walk reverts toward |
 | `--noise` | `0.1` | Standard deviation of the step noise |
 | `--log-scale` | off | Walk in log₁₀ space, for a quantity spanning decades |
+| `--resolution` | *(none)* | Absolute step readings are rounded to, in their own units |
+| `--significant-digits` | `6` | Digits a reading carries when `--resolution` is unset |
 | `--log-level` | `INFO` | `DEBUG` adds a line per reading |
 | `--summary-interval` | `30.0` | Seconds between "still writing" lines; `0` turns them off |
 

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -47,6 +47,8 @@ process closes its InfluxDB connection cleanly on SIGINT/SIGTERM.
 | `--field`          | `value`        | InfluxDB field name for the reading                                |
 | `--noise`          | `0.1`          | Std dev of Gaussian noise added each step                         |
 | `--log-scale`      | off            | Perform the walk in log10 space (see below)                       |
+| `--resolution`     | unset          | Absolute step the reading is rounded to, in its own units (see below) |
+| `--significant-digits` | `6`        | Digits a reading carries when `--resolution` is not given          |
 | `--unit`           | `""`           | Unit of the reading (e.g. `°C`, `K`, `mbar`) — written as an InfluxDB `unit` tag when set |
 | `--log-level`      | `INFO`         | `DEBUG` adds a line per reading                                   |
 | `--summary-interval` | `30.0`       | Seconds between "still writing" lines; `0` turns them off         |
@@ -65,6 +67,38 @@ pressure. With `--log-scale`, the walk operates on `log10(reading)`
 internally, so `--noise` becomes a proportional (log10) quantity — jitter
 and mean-reversion scale with magnitude, and the reading can never go
 non-positive. `--setpoint` stays in ordinary linear units either way.
+
+### `--resolution` and `--significant-digits`
+
+A random walk in floating point produces a reading like
+`76.85006139177405` — sixteen digits, claiming a precision no
+thermometer has. Somebody opening the exported column cannot tell
+simulated jitter from a real millikelvin, so readings are rounded before
+they are written.
+
+`--resolution` is an absolute step, in the reading's own units, and is
+how an instrument with a fixed least-significant digit is described:
+
+```bash
+uv run labmon mock-sensor --sensor-id cryo-77k --setpoint 77 --unit K \
+  --resolution 0.001        # 76.85006139177405 -> 76.85
+```
+
+Without one, readings are rounded to `--significant-digits` instead.
+That is the default because it stays meaningful wherever the sensor sits
+on the scale: an absolute step large enough for a thermometer reports a
+vacuum gauge walking at `1e-7 mbar` as exactly zero, whereas six
+significant digits resolves it to `1e-12 mbar`.
+
+The one case needing care is a large value with fine structure. Six
+significant digits at a 276 THz carrier is a 1 GHz step, so a wavemeter
+drifting by a few MHz would return the same number every time — the demo
+therefore gives it `--resolution 1e5`. As a rule, pick a step at least
+an order of magnitude below `--noise`.
+
+The walk itself keeps full precision internally. Rounding its state
+would change how it reverts toward the setpoint, and a step coarser than
+the noise would freeze it outright; only the reported value is rounded.
 
 ### `--unit`
 

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -23,6 +23,7 @@ import math
 import random
 import time
 from datetime import UTC, datetime
+from decimal import ROUND_HALF_EVEN, Decimal
 from typing import cast
 
 from influxdb_client_3 import Point
@@ -32,6 +33,47 @@ from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# How many digits a reading carries when no absolute step is given.
+# Significant digits rather than decimal places because a mock sensor may
+# sit anywhere on the scale: the demo alone spans 4 K and 1.5e-7 mbar, and
+# a fixed number of decimals reports one of those as zero.
+DEFAULT_SIGNIFICANT_DIGITS = 6
+
+
+def quantise(
+    value: float,
+    resolution: float | None = None,
+    significant_digits: int = DEFAULT_SIGNIFICANT_DIGITS,
+) -> float:
+    """Round a reading to the precision the simulated instrument has.
+
+    A walk in floating point produces sixteen digits, and writing them
+    claims a precision no instrument has — someone reading the exported
+    column cannot tell simulated jitter from a real millikelvin.
+
+    `resolution` is an absolute step in the reading's own units, which is
+    how an instrument with a fixed least-significant digit is specified
+    (a thermometer resolving 0.001 K). Without one, the value is rounded
+    to `significant_digits` instead, which stays meaningful at any
+    magnitude — the safe default, since an absolute step large enough for
+    a thermometer reports a vacuum gauge as zero.
+
+    Stepping is done in Decimal rather than as `round(value / step) *
+    step`: the arithmetic form puts back the noise it is removing, giving
+    76.85000000000001 where the decimal form gives 76.85.
+    """
+    if not math.isfinite(value):
+        # `polling` refuses a non-finite value before it becomes a field;
+        # rounding should not be the thing that raises first.
+        return value
+    if resolution is not None:
+        step = Decimal(str(resolution))
+        return float(
+            (Decimal(repr(value)) / step).quantize(Decimal(1), rounding=ROUND_HALF_EVEN)
+            * step
+        )
+    return float(f"{value:.{significant_digits}g}")
 
 
 class RandomWalk:
@@ -73,6 +115,8 @@ def run(
     noise: float = 0.1,
     log_scale: bool = False,
     unit: str = "",
+    resolution: float | None = None,
+    significant_digits: int = DEFAULT_SIGNIFICANT_DIGITS,
     summary_interval: float | None = DEFAULT_SUMMARY_INTERVAL_SECONDS,
 ) -> None:
     """Write simulated readings for `sensor_id` to InfluxDB until interrupted.
@@ -97,7 +141,15 @@ def run(
     )
     while True:
         reading_time = datetime.now(UTC)
-        reading = walk.next()
+        # Rounded here rather than inside the walk: quantising the walk's
+        # own state would change how it reverts to the setpoint, and a
+        # step coarser than the noise would freeze it outright. The gate
+        # then sees the value that will actually be recorded.
+        reading = quantise(
+            walk.next(),
+            resolution=resolution,
+            significant_digits=significant_digits,
+        )
         # The walk cannot currently produce one, but this file is also the
         # template a user copies and edits, and the guard belongs wherever
         # a value becomes a field. Guarding the write rather than skipping
@@ -163,6 +215,22 @@ def main() -> None:
         + "InfluxDB tag when set, and omitted entirely when not.",
     )
     _ = parser.add_argument(
+        "--resolution",
+        type=float,
+        default=None,
+        help="Absolute step the reading is rounded to, in its own units "
+        + "(e.g. 0.001 for a thermometer resolving a millikelvin). "
+        + "Without it, readings are rounded to --significant-digits, "
+        + "which stays meaningful at any magnitude",
+    )
+    _ = parser.add_argument(
+        "--significant-digits",
+        type=int,
+        default=DEFAULT_SIGNIFICANT_DIGITS,
+        help="Digits a reading carries when --resolution is not given "
+        + f"(default: {DEFAULT_SIGNIFICANT_DIGITS})",
+    )
+    _ = parser.add_argument(
         "--log-level",
         default="INFO",
         choices=logs.LEVEL_NAMES,
@@ -187,6 +255,8 @@ def main() -> None:
     noise = cast(float, args.noise)
     log_scale = cast(bool, args.log_scale)
     unit = cast(str, args.unit)
+    resolution = cast(float | None, args.resolution)
+    significant_digits = cast(int, args.significant_digits)
     # argparse cannot hand back None from a float flag, so zero is the off
     # switch — and "summarise every zero seconds" has no other meaning.
     summary_interval = cast(float, args.summary_interval) or None
@@ -200,6 +270,8 @@ def main() -> None:
         noise=noise,
         log_scale=log_scale,
         unit=unit,
+        resolution=resolution,
+        significant_digits=significant_digits,
         summary_interval=summary_interval,
     )
 

--- a/tests/test_mock_sensor.py
+++ b/tests/test_mock_sensor.py
@@ -164,6 +164,8 @@ def test_main_parses_defaults_and_calls_run(monkeypatch: pytest.MonkeyPatch) -> 
             "noise": 0.1,
             "log_scale": False,
             "unit": "",
+            "resolution": None,
+            "significant_digits": 6,
             "summary_interval": 30.0,
         }
     ]
@@ -202,6 +204,8 @@ def test_main_parses_custom_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
             "noise": 0.1,
             "log_scale": False,
             "unit": "",
+            "resolution": None,
+            "significant_digits": 6,
             "summary_interval": 30.0,
         }
     ]
@@ -247,6 +251,8 @@ def test_main_parses_pressure_gauge_arguments(monkeypatch: pytest.MonkeyPatch) -
             "noise": 0.05,
             "log_scale": True,
             "unit": "mbar",
+            "resolution": None,
+            "significant_digits": 6,
             "summary_interval": 30.0,
         }
     ]
@@ -344,3 +350,66 @@ def test_run_passes_its_summary_interval_to_the_loop(
         )
 
     assert "wrote readings" not in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Reported resolution
+#
+# A simulated instrument that reports 76.85006139177405 K is claiming a
+# precision no thermometer has. The walk itself stays at full precision —
+# quantising its internal state would change how it reverts and drifts —
+# so only the reported value is rounded.
+
+
+def test_a_reading_is_rounded_to_the_resolution_step() -> None:
+    assert mock_sensor.quantise(76.85006139177405, resolution=0.001) == 76.85
+
+
+def test_a_step_that_is_not_a_power_of_ten_still_lands_on_the_grid() -> None:
+    assert mock_sensor.quantise(76.85006139177405, resolution=0.25) == 76.75
+
+
+def test_rounding_to_a_step_does_not_reintroduce_float_noise() -> None:
+    # The arithmetic form, round(v / step) * step, gives
+    # 76.85000000000001 here — putting back exactly the digits this is
+    # meant to remove.
+    rounded = mock_sensor.quantise(76.85006139177405, resolution=0.001)
+
+    assert repr(rounded) == "76.85"
+
+
+def test_a_reading_is_rounded_to_significant_digits_by_default() -> None:
+    assert mock_sensor.quantise(76.85006139177405, significant_digits=4) == 76.85
+
+
+def test_significant_digits_survive_a_reading_near_zero() -> None:
+    # The reason this is the default: a vacuum gauge walks at 1e-7 mbar,
+    # and an absolute step of 1e-3 would report every reading as zero.
+    quantised = mock_sensor.quantise(5.594587307076873e-09, significant_digits=4)
+
+    assert quantised == 5.595e-09
+
+
+def test_an_explicit_resolution_wins_over_significant_digits() -> None:
+    quantised = mock_sensor.quantise(
+        76.85006139177405, resolution=0.001, significant_digits=4
+    )
+
+    assert quantised == 76.85
+
+
+def test_quantising_leaves_a_non_finite_value_alone() -> None:
+    # float("nan") never reaches a field — polling refuses it — but the
+    # rounding primitive should not be the thing that raises.
+    assert math.isnan(mock_sensor.quantise(float("nan"), resolution=0.001))
+
+
+def test_the_walk_keeps_full_precision_internally() -> None:
+    # Quantising the walk's own state would change how it reverts, and a
+    # small enough step would freeze it entirely.
+    walk = RandomWalk(setpoint=21.0, noise=0.5)
+
+    for _ in range(20):
+        _ = walk.next()
+
+    assert walk.value != round(walk.value, 3)


### PR DESCRIPTION
Closes #152.

A simulated reading is now rounded to the precision the instrument it stands in for would actually have, instead of reporting wherever a float64 random walk happened to land. The database was filling with values like `76.85006139177405 K`.

## Surface

Two new options on `mock-sensor`:

- `--resolution` — an absolute step in the reading's own units
- `--significant-digits` — applies when no step is given, default 6

## Why significant digits are the default

A mock sensor can sit anywhere on the scale. The demo spans 4 K and 1.5e-7 mbar, and `chamber-1` walks linearly rather than in log space, so an absolute default large enough for a thermometer reports every pressure reading as exactly zero. A relative default degrades gracefully across the whole range, and the instruments with a genuine quantum name it explicitly.

The wavemeter is the case that forces the explicit step: six significant figures at its 276 THz carrier is a 1 GHz quantum, coarser than the entire 0.4 MHz drift the panel exists to show, so consecutive readings came back identical. It passes `--resolution=1e5`.

## Details worth noting

Stepping goes through `Decimal` rather than `round(value / step) * step`. The arithmetic form puts back the noise it is removing — it gives `76.85000000000001` where the decimal form gives `76.85`.

Only the reported value is rounded. The walk keeps full precision internally, because quantising its own state would change how it reverts to the setpoint, and a step coarser than the noise would freeze it outright.

The calibrated path that `serial-sensor` writes is untouched. Its resolution is derivable from ADC bits, reference voltage and the local slope of the conversion, and a flat constant would be wrong in both directions — that is #148.

## Demo stack

The four temperature sensors gain `--resolution=0.001`; the wavemeter gains `--resolution=1e5`. Everything else takes the six-significant-digit default.

## Test plan

- [x] `pytest tests` — 363 passed, 100% coverage
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors, 0 warnings
- [ ] bring the demo stack up and confirm the exported columns read as plausible instrument output
