### PR TITLE
docs: add a changelog and surface the CLI in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to labmon are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/),
+so the sections below map onto commit types.
+
+## [Unreleased]
+
+### Added
+
+- **A command line for reading recorded data.** `labmon query` prints
+  readings as an aligned table; `labmon export` writes them to a file.
+  Both take the same selection flags — `--measurement`, `--sensor-id`,
+  `--since`, `--until` — so whichever is learned first teaches the
+  other.
+  [`docs/export.md`](docs/export.md) —
+  [#154](https://github.com/quentinmarolleau/labmon/pull/154)
+  - **Four export formats.** CSV, Parquet and Feather need nothing
+    extra, since pyarrow already arrives with the InfluxDB client.
+    netCDF is opt-in as `labmon[netcdf]`, so a sensor host that only
+    writes does not pay for it.
+  - **The unit travels with the readings**, as a column in every format
+    and additionally as Arrow field metadata in Parquet and Feather,
+    and as a CF `units` attribute in netCDF. pandas and polars both
+    discard schema metadata on read, which is why the column is not
+    optional.
+  - **Tab completion** for bash, zsh, fish and powershell, via
+    `labmon --install-completion`. Completing a flag shows its help
+    text beside it.
+  - `--split-per-sensor`, writing one file per sensor rather than one
+    monolithic file.
+  - `--no-raw-input`, leaving the `input_volts` and `calibration_id`
+    provenance columns out of an export.
+  - **Documentation for loading an export back**, covering all four
+    files in pandas, polars and xarray, and what the shape of the data
+    means once it is there.
+    [`docs/loading-exports.md`](docs/loading-exports.md)
+- Simulated readings are rounded to a plausible instrument resolution,
+  through `--resolution` for an absolute step or `--significant-digits`
+  otherwise.
+  [#153](https://github.com/quentinmarolleau/labmon/pull/153)
+
+### Changed
+
+- **`mock-sensor` and `serial-sensor` are now `labmon mock-sensor` and
+  `labmon serial-sensor`.** The old spellings still work and print a
+  deprecation warning, so unit files already installed on lab machines
+  keep running.
+- Startup no longer imports pyarrow, pint, numpy and the InfluxDB
+  client unless the command being run needs them. `labmon query --help`
+  goes from 0.79 s to 0.19 s, and a tab completion from roughly 1.8 s
+  to 0.4 s.
+
+### Fixed
+
+- Simulated sensors reported values to full float64 precision, filling
+  the database with readings like `76.85006139177405 K` that no
+  thermometer could produce.
+  [#152](https://github.com/quentinmarolleau/labmon/issues/152)
+
+## [0.2.0-beta.1] — 2026-08-23
+
+The first beta. See
+[`RELEASE_NOTE.md`](RELEASE_NOTE.md) for the full announcement.
+
+[Unreleased]: https://github.com/quentinmarolleau/labmon/compare/v0.2.0-beta.1...HEAD
+[0.2.0-beta.1]: https://github.com/quentinmarolleau/labmon/releases/tag/v0.2.0-beta.1

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ chamber pressure, laser power, a magnet's current) into a time-series
 database, and puts it on a live dashboard anyone in the room can open in
 a browser. Two commands to start, no database or web experience needed.
 
+> [!TIP]
+> **🎉 New — `labmon`, a command line for your data.**
+>
+> Recorded readings no longer have to be clicked out of Grafana one
+> panel at a time.
+>
+> ```bash
+> labmon query  --measurement temperature --since 5m        # look at it now
+> labmon export --measurement temperature --since 24h -o run # keep it
+> ```
+>
+> Same four selection flags for both — `--measurement`, `--sensor-id`,
+> `--since`, `--until`. Exports to **CSV, Parquet, Feather and netCDF**
+> 📦, ready to load in pandas, polars or xarray, with the unit
+> travelling alongside every reading so nobody has to guess whether a
+> column is kelvin or celsius. Tab completion included ⚡, and it doubles
+> as documentation — completing a flag shows its help text beside it.
+>
+> [`docs/export.md`](docs/export.md) — getting data out ·
+> [`docs/loading-exports.md`](docs/loading-exports.md) — loading it back
+
 ![The Lab Overview dashboard: a row of current-value tiles for cold finger, chamber pressure, laser power and bias rail; a panel plotting a calibrated temperature against the raw ADC voltage it came from; cryogenic and room temperature, vacuum and laser power time series; a needle dial for laser detuning; an XY plot of beam position; and a table listing every sensor with its unit, raw input, calibration id and whether it is simulated or calibrated](docs/assets/images/lab-overview-screenshot.png)
 
 *The **Lab Overview** dashboard you get out of the box, running against
@@ -426,6 +447,11 @@ What is planned next lives in
 open issue carries a decision: `validated` is agreed and scheduled, and
 `waiting-for-need` is understood and wanted *if* a concrete case appears
 — each of those says in its own thread what would bring it back.
+
+## Changelog
+
+[`CHANGELOG.md`](CHANGELOG.md) records what changed in each release, and
+what is waiting in `Unreleased`.
 
 ## Contributing
 


### PR DESCRIPTION
Two small things, both about visibility.

## `CHANGELOG.md`

New file, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. `Unreleased` covers everything that has landed since `v0.2.0-beta.1` — the CLI from #154, the mock-sensor resolution fix from #153 — split into Added / Changed / Fixed. The `0.2.0-beta.1` entry points at `RELEASE_NOTE.md` rather than restating it, since the two documents do different jobs: the release note is the announcement for one version, the changelog is the running record between them.

Written by hand rather than generated. `cog changelog` aborts on every merge commit, because the default GitHub merge subject is not a conventional commit. Setting `ignore_merge_commits = true` in a `cog.toml` gets past that, but the output is one flat list of every commit since the tag, with no room for the *why* that makes an entry worth reading. Worth revisiting if the file becomes a chore to maintain.

## README callout

A GitHub `[!TIP]` alert directly under the opening paragraph, with the two commands, the four formats, and links to both export docs. The CLI landed after the beta tag, so until the next release it is otherwise only visible to someone who reads as far as "Getting the data out".

A `## Changelog` section near the bottom links the new file.

## Test plan

- [x] `typos` clean on both files
- [x] every relative link in `README.md` and `CHANGELOG.md` resolves to a file that exists
- [x] the alert renders as expected on GitHub (only checkable once pushed)
