### PR TITLE
docs(contributing): write down the signed-commit requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ All four must pass before a PR is opened — this is exactly what CI (`.github/w
   admins too). Always work on a branch, open a PR.
 - Commit messages must be Conventional Commits format, verified with
   `cog verify "<message>"` before committing (cocogitto is installed).
+- Every commit must be signed. `main` has `required_signatures` enabled,
+  so an unsigned commit anywhere in a branch blocks the merge even with
+  all checks green. Verify with `git log --format='%h %G? %s' main..HEAD`
+  — your own commits must show `G` (`N` is unsigned; `E` on a GitHub
+  merge commit is fine, its key is not held locally).
 - Coverage must stay at 100% (`--cov-fail-under=100` in CI). Don't add
   `# pragma: no cover` to dodge writing a real test — only use it for
   code that's genuinely untestable in a meaningful way.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,69 @@ Common types used in this repo: `feat`, `fix`, `docs`, `test`, `ci`,
 `chore`. Write the message body around *why*, not just *what* — the diff
 already shows what changed.
 
+## Signed commits
+
+> [!CAUTION]
+> **Every commit that reaches `main` must be signed**, and this is
+> enforced rather than requested: `main` has GitHub's
+> `required_signatures` protection turned on, so an unsigned commit
+> makes the merge button refuse no matter who is merging or how green
+> the checks are.
+>
+> It applies to every commit in a pull request, not just the tip — one
+> unsigned commit five back blocks the whole branch. Set this up before
+> you start, or you will be re-signing history later.
+
+Either signing method GitHub accepts works. SSH is the shorter setup if
+you already push over SSH:
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub   # your key
+git config --global commit.gpgsign true
+```
+
+Signing now works, but *checking your own* signatures locally does not
+yet — git needs to be told which keys it should trust, and with SSH
+there is no keyring to consult. Without this one extra step the check
+below reports `N`, as though nothing had been signed at all:
+
+```bash
+printf '%s %s\n' "your@email" "$(cat ~/.ssh/id_ed25519.pub)" \
+  >> ~/.config/git/allowed_signers
+git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+```
+
+This affects only your local view. A commit signed without it is a
+properly signed commit, and GitHub verifies it either way.
+
+For GPG, see [GitHub's guide][gh-signing]. Whichever you pick, the key
+also has to be added to your GitHub account, under the **Signing keys**
+section rather than the authentication one — a key that signs locally
+but is not registered shows as *Unverified*, which counts as unsigned.
+
+Check before pushing:
+
+```bash
+git log --show-signature -1                # one commit, in detail
+git log --format='%h %G? %s' main..HEAD    # your commits on this branch
+```
+
+`G` is what you want on each of your own commits; `N` means unsigned —
+or, if you sign over SSH, that `allowed_signers` above is missing.
+`E` shows up on merge commits GitHub created, and is not a problem —
+GitHub signs those with a key your machine has no copy of, so git cannot
+check it locally even though GitHub reports it verified.
+
+If you have already committed unsigned, re-sign the whole branch rather
+than adding a new commit on top:
+
+```bash
+git rebase --exec 'git commit --amend --no-edit -S' main
+```
+
+[gh-signing]: https://docs.github.com/en/authentication/managing-commit-signature-verification
+
 ## Git hooks
 
 Optional, and worth the one command:
@@ -80,6 +143,10 @@ uv run typos
 All five must pass locally — they're exactly what CI runs. Drop
 `--check` to have the formatter apply its changes instead of reporting
 them.
+
+Check your commits are signed while you are here — see [Signed
+commits](#signed-commits). It is the one requirement no CI run reports,
+because it is the merge that refuses rather than a check that fails.
 
 With the hooks installed, pushing has already run the last three of
 these, so this list is the belt to their braces — and the one to reach


### PR DESCRIPTION
`main` has GitHub's `required_signatures` branch protection enabled, so an unsigned commit anywhere in a branch makes the merge button refuse — regardless of who is merging or how green the checks are. Neither `CONTRIBUTING.md` nor `AGENTS.md` mentioned it, which left the greyed-out button as the only place the rule appeared.

Two open PRs (#143, #147) are blocked by exactly this, having followed every rule that *was* written down.

## What the section covers

- the requirement, and that it applies to every commit in a PR rather than just the tip
- SSH and GPG setup
- that the key must be registered under GitHub's **Signing keys**, not the authentication ones — a key that signs locally but is not registered shows as *Unverified*, which counts as unsigned
- how to check before pushing, and how to read `%G?`
- how to repair a branch that is already unsigned

## One detail worth calling out

The obvious check has a confusing result. GitHub signs its own merge commits with a key no contributor holds, so on `main` they show as `E` locally while GitHub reports them verified:

```
1eb1f6f E Merge pull request #157 from quentinmarolleau/docs/changelog-and-cli-callout
10ea563 G docs: add a changelog and surface the CLI in the README
2072aef E Merge pull request #154 from quentinmarolleau/feat/58-export-cli
```

Without a note saying so, somebody checking their branch would reasonably conclude the requirement was already broken on `main`. The section explains it.

The repair is given as a rebase that re-signs every commit, rather than a new commit on top, which does not help.

## Test plan

- [x] `typos` clean on both files
- [x] `git log --format='%h %G? %s'` output in the docs reproduced against this repo
- [x] the SSH setup block followed end to end with a throwaway key in a scratch repo — this caught a real bug, see below

## The SSH instructions were wrong, and are now fixed

Following the three `git config` lines produces a correctly signed commit, but the verification command this same document recommends then reports the opposite:

```
error: gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification
1178112 N test: signed with ssh
```

`N` means unsigned. A contributor following the guide would have concluded signing was broken and gone round in circles fixing something that already worked.

The cause is that SSH signing has no keyring, so git has to be told which keys to trust before it can check a signature it just made. The section now includes that step, and notes that it affects only the local view — GitHub verifies such a commit either way.

Verified both directions with a throwaway key in a scratch repo: without `allowed_signers` the check reports `N`, with it `G`. The keys were deleted afterwards, and nothing global on this machine was touched.

