### PR TITLE
test(writer): wait for the writer instead of sleeping

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import threading
 import time
+from collections.abc import Callable
 
 import pytest
 
@@ -16,6 +17,32 @@ def _field(record: logging.LogRecord, name: str) -> object:
     so this says plainly that the lookup is dynamic.
     """
     return getattr(record, name)  # pyright: ignore[reportAny]
+
+
+def _eventually(
+    predicate: Callable[[], bool], *, within: float, description: str
+) -> None:
+    """Block until `predicate` holds, or fail once `within` has passed.
+
+    The writer drains on a background thread, so the work a test is
+    waiting for finishes after an unpredictable amount of wall clock —
+    a poll tick, then a backoff, then a retry, all at the mercy of
+    whatever else the machine is doing. Sleeping a fixed interval and
+    asserting afterwards is therefore a race: it passes on a quiet
+    laptop and fails on a shared CI runner.
+
+    Waiting on the condition removes the race without weakening a test
+    that uses its deadline as the assertion. `within` stays far below
+    the time the behaviour under test would need if it were broken, so
+    such a test still fails for the right reason — it just no longer
+    fails for the wrong one.
+    """
+    deadline = time.monotonic() + within
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError(f"{description} within {within}s")
 
 
 class FakeClient[T]:
@@ -245,7 +272,11 @@ def test_write_retries_transient_failures_then_succeeds(
 
     with caplog.at_level(logging.WARNING):
         writer.write(1)
-        time.sleep(0.1)
+        _eventually(
+            lambda: client.attempts == 3,
+            within=5.0,
+            description="the write was never retried to success",
+        )
         writer.close()
 
     written = [point for batch in client.batches for point in batch]
@@ -263,7 +294,11 @@ def test_close_drops_a_batch_still_failing_at_shutdown(
     writer = PointWriter[int](client, poll_interval=0.01)
 
     writer.write(1)
-    time.sleep(0.05)
+    _eventually(
+        lambda: client.attempts >= 1,
+        within=5.0,
+        description="the client was never called",
+    )
 
     start = time.monotonic()
     with caplog.at_level(logging.ERROR):
@@ -305,9 +340,17 @@ def test_the_first_retry_waits_the_backoff_it_was_given(
         client, poll_interval=0.01, initial_backoff=0.01, max_backoff=0.01
     )
 
+    # 1.5s is the assertion: the 1.0s default backoff doubles, so a third
+    # attempt would land near 3s and miss this deadline. It is also fifteen
+    # times the window this test used to allow, which is what stopped a
+    # loaded runner from failing it.
     with caplog.at_level(logging.CRITICAL, logger="labmon.writer"):
         writer.write(1)
-        time.sleep(0.1)
+        _eventually(
+            lambda: client.attempts == 3,
+            within=1.5,
+            description="three attempts did not fit the configured backoff",
+        )
         writer.close()
 
     assert client.attempts == 3
@@ -326,9 +369,16 @@ def test_the_cap_stops_the_backoff_doubling_away(
         client, poll_interval=0.001, initial_backoff=0.001, max_backoff=0.002
     )
 
+    # Uncapped, the twenty-first wait alone would be 1ms doubled twenty
+    # times — around seventeen minutes — so this deadline still proves the
+    # cap is holding, with room for a slow runner.
     with caplog.at_level(logging.CRITICAL, logger="labmon.writer"):
         writer.write(1)
-        time.sleep(0.2)
+        _eventually(
+            lambda: client.attempts > 20,
+            within=2.0,
+            description="the backoff did not stay capped",
+        )
         writer.close()
 
     assert client.attempts > 20


### PR DESCRIPTION
`tests/test_writer.py::test_write_retries_transient_failures_then_succeeds` failed CI on Python 3.12 and 3.14 while passing on 3.13 **in the same run** — the signature of a race, not a version difference. It turned up on #159, a documentation-only PR.

```
assert [] == [1]
ERROR labmon.writer:writer.py:164 dropping an unwritten batch at shutdown
```

## Cause

The test wrote a point, slept 100 ms, then closed. In that window the drain thread has to poll, fail, back off, fail, back off, and succeed. On a shared runner it does not always get there — `close()` drops the unwritten batch and the assertion sees an empty list.

Forty runs on a quiet machine reproduced nothing, and neither did twenty-five more with every core pinned. That is consistent with a race that only opens on contended hardware.

## Fix

`_eventually(predicate, within=..., description=...)` polls until the condition holds or the deadline passes. Four tests converted; the fifth `time.sleep` is deliberate (it exercises idle polling before any point arrives) and is not racy, since `close()` flushes.

The file already had this shape — `StalledClient` waits on a `threading.Event` with a timeout rather than guessing at durations.

## The part worth reviewing

Two of the four use their window **as the assertion**, so an unbounded wait would have quietly gutted them. Both keep a deadline chosen to sit far below what the behaviour would need if it were broken:

| test | deadline | what it would take if broken |
|---|---|---|
| `test_the_first_retry_waits_the_backoff_it_was_given` | 1.5 s | third attempt near 3 s with the 1.0 s default backoff |
| `test_the_cap_stops_the_backoff_doubling_away` | 2 s | ~17 minutes for a 21st attempt with uncapped doubling from 1 ms |

Both were checked by mutation rather than by argument:

- restoring `initial_backoff=1.0` → `test_the_first_retry_waits_the_backoff_it_was_given` fails
- removing the cap (`max_backoff=30.0`) → `test_the_cap_stops_the_backoff_doubling_away` fails

So the pair still fail for the reason they exist, and no longer fail for a slow machine.

## Test plan

- [x] `pytest` — 561 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `basedpyright` clean
- [x] both deadline-based assertions mutation-tested (above)
- [x] `tests/test_writer.py` runs in 0.25 s, down from the 0.5 s of fixed sleeps
