### PR TITLE
fix(mock-sensor): require a measurement and a unit

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -123,9 +123,9 @@ jobs:
           token="$(grep '^INFLUXDB3_AUTH_TOKEN=' .env | cut -d= -f2-)"
           network="$(docker inspect influxdb \
             --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}')"
-          # --entrypoint, because the image's own is `mock-sensor`: without
-          # it `timeout` and its arguments are appended to the sensor's
-          # command line instead of wrapping it.
+          # --entrypoint, because the image's own is `labmon mock-sensor`:
+          # without it `timeout` and its arguments are appended to the
+          # sensor's command line instead of wrapping it.
           # --preserve-status reports the sensor's own fate rather than
           # timeout's, so a crash on the TLS path reads differently in the
           # log from the SIGTERM that ends a healthy run.
@@ -138,8 +138,8 @@ jobs:
             -e INFLUXDB_DATABASE=lab \
             -e INFLUXDB3_AUTH_TOKEN="$token" \
             labmon:latest \
-            --preserve-status 12 mock-sensor --sensor-id tls-smoke \
-              --measurement temperature --interval 1 || status=$?
+            --preserve-status 12 labmon mock-sensor --sensor-id tls-smoke \
+              --measurement temperature --unit K --interval 1 || status=$?
           # 0 if it handled the signal, 143 if it took SIGTERM as it was.
           case "$status" in
             0|143) echo "sensor ended on the timeout (status $status)" ;;

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -138,7 +138,8 @@ one produces no line.
 To see every reading while bringing a board up:
 
 ```bash
-uv run labmon mock-sensor --log-level debug
+uv run labmon mock-sensor --measurement temperature --unit "°C" \
+  --log-level debug
 uv run labmon serial-sensor --port … --calibration … --log-level debug
 ```
 

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -13,15 +13,17 @@ For reading an actual board rather than simulating one, see
 ## Usage
 
 ```bash
-# Defaults: sensor-id "mock-sensor-1", measurement "temperature", setpoint
-# 21, one reading every 5s
-uv run labmon mock-sensor
+# --measurement and --unit are required; the rest default to sensor-id
+# "mock-sensor-1", setpoint 21, one reading every 5s
+uv run labmon mock-sensor --measurement temperature --unit "°C"
 
 # A second room temperature sensor, sampled every second
-uv run labmon mock-sensor --sensor-id room-2 --setpoint 22 --interval 1 --unit "°C"
+uv run labmon mock-sensor --sensor-id room-2 --measurement temperature \
+  --setpoint 22 --interval 1 --unit "°C"
 
 # A cryogenic zone sensor
-uv run labmon mock-sensor --sensor-id cryo-77k --setpoint 77 --noise 0.3 --unit K
+uv run labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
+  --setpoint 77 --noise 0.3 --unit K
 
 # A vacuum gauge: values spanning orders of magnitude need --log-scale
 # (see below) so noise/mean-reversion scale multiplicatively, not by a
@@ -36,6 +38,22 @@ uv run labmon mock-sensor --help
 Stop with Ctrl+C (or `docker stop`/`kill` if run as a service) — the
 process closes its InfluxDB connection cleanly on SIGINT/SIGTERM.
 
+## Why `--measurement` and `--unit` are required
+
+Neither can be guessed from the others. A walk around the default
+setpoint of 21.0 is a plausible room in celsius and a plausible
+cryostat stage in kelvin, and a reading that cannot say which is not
+worth recording — it is the one thing an exported column cannot
+reconstruct later.
+
+Defaulting them was worse than requiring them. A default `°C` would
+have quietly labelled a `--measurement pressure` run in celsius, and a
+wrong unit is more dangerous than a missing one: a missing unit sends
+somebody to check, a wrong one does not.
+
+An empty string is refused too. `--unit ""` is otherwise the same
+unlabelled reading with an extra step.
+
 ## Options
 
 | Flag             | Default        | Purpose                                                        |
@@ -43,13 +61,13 @@ process closes its InfluxDB connection cleanly on SIGINT/SIGTERM.
 | `--sensor-id`      | `mock-sensor-1`| Tag identifying the sensor                                       |
 | `--interval`       | `5.0`          | Seconds between readings                                          |
 | `--setpoint`       | `21.0`         | Baseline reading the walk reverts toward                          |
-| `--measurement`    | `temperature`  | InfluxDB measurement (table) to write to                          |
+| `--measurement`    | **required**   | InfluxDB measurement (table) to write to                          |
 | `--field`          | `value`        | InfluxDB field name for the reading                                |
 | `--noise`          | `0.1`          | Std dev of Gaussian noise added each step                         |
 | `--log-scale`      | off            | Perform the walk in log10 space (see below)                       |
 | `--resolution`     | unset          | Absolute step the reading is rounded to, in its own units (see below) |
 | `--significant-digits` | `6`        | Digits a reading carries when `--resolution` is not given          |
-| `--unit`           | `""`           | Unit of the reading (e.g. `°C`, `K`, `mbar`) — written as an InfluxDB `unit` tag when set |
+| `--unit`           | **required**   | Unit of the reading (e.g. `°C`, `K`, `mbar`) — written as an InfluxDB `unit` tag |
 | `--log-level`      | `INFO`         | `DEBUG` adds a line per reading                                   |
 | `--summary-interval` | `30.0`       | Seconds between "still writing" lines; `0` turns them off         |
 
@@ -80,7 +98,8 @@ they are written.
 how an instrument with a fixed least-significant digit is described:
 
 ```bash
-uv run labmon mock-sensor --sensor-id cryo-77k --setpoint 77 --unit K \
+uv run labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
+  --setpoint 77 --unit K \
   --resolution 0.001        # 76.85006139177405 -> 76.85
 ```
 

--- a/src/labmon/cli/commands/mock_sensor.py
+++ b/src/labmon/cli/commands/mock_sensor.py
@@ -20,17 +20,56 @@ HELP = (
     + " in log10 space, so jitter scales multiplicatively — which suits a"
     + " quantity spanning decades, such as vacuum pressure."
     + "\n\n"
+    + "[bold]--measurement[/bold] and [bold]--unit[/bold] are required."
+    + " Neither can be guessed: a walk around 21.0 is a plausible room in"
+    + " celsius and a plausible cryostat stage in kelvin, and a reading"
+    + " that cannot say which is not worth recording."
+    + "\n\n"
     + "[bold]Examples[/bold]\n\n"
-    + "    labmon mock-sensor\n"
-    + "    labmon mock-sensor --sensor-id room-2 --setpoint 22 --unit °C\n"
-    + "    labmon mock-sensor --sensor-id cryo-77k --setpoint 77 --unit K"
-    + " --resolution 0.001\n"
+    + "    labmon mock-sensor --measurement temperature --unit °C\n"
+    + "    labmon mock-sensor --sensor-id room-2 --measurement temperature"
+    + " --setpoint 22 --unit °C\n"
+    + "    labmon mock-sensor --sensor-id cryo-77k --measurement temperature"
+    + " --setpoint 77 --unit K --resolution 0.001\n"
     + "    labmon mock-sensor --sensor-id chamber-1 --measurement pressure"
     + " --setpoint 1e-7 --log-scale --unit mbar"
 )
 
 
+def _required_text(value: str) -> str:
+    """Refuse an option given as an empty string.
+
+    Typer treats `--unit ""` as the option having been supplied, so
+    requiring it is not on its own enough — without this, the unlabelled
+    reading this guards against is still one argument away.
+    """
+    if not value.strip():
+        raise typer.BadParameter("cannot be empty")
+    return value
+
+
 def mock_sensor(
+    # Required, so they come before every option that has a default.
+    # Neither can be inferred: a walk around 21.0 is a plausible room in
+    # celsius and a plausible cryostat stage in kelvin, and a reading
+    # that says which is the whole point of recording one.
+    measurement: Annotated[
+        str,
+        typer.Option(
+            "--measurement",
+            help="InfluxDB measurement (table) to write to, e.g. 'temperature'",
+            callback=_required_text,
+        ),
+    ],
+    unit: Annotated[
+        str,
+        typer.Option(
+            "--unit",
+            help="Unit of the reading, e.g. '°C', 'K', 'mbar'. Written as an"
+            + " InfluxDB tag",
+            callback=_required_text,
+        ),
+    ],
     sensor_id: Annotated[
         str, typer.Option("--sensor-id", help="Tag identifying the sensor")
     ] = "mock-sensor-1",
@@ -41,10 +80,6 @@ def mock_sensor(
         float,
         typer.Option("--setpoint", help="Baseline reading the walk reverts toward"),
     ] = 21.0,
-    measurement: Annotated[
-        str,
-        typer.Option("--measurement", help="InfluxDB measurement (table) to write to"),
-    ] = "temperature",
     field: Annotated[
         str, typer.Option("--field", help="InfluxDB field name for the reading")
     ] = "value",
@@ -64,14 +99,6 @@ def mock_sensor(
             + "--setpoint stays in linear units; --noise becomes log10",
         ),
     ] = False,
-    unit: Annotated[
-        str,
-        typer.Option(
-            "--unit",
-            help="Unit of the reading (e.g. '°C', 'K', 'mbar'). Written as an "
-            + "InfluxDB tag when set, and omitted entirely when not",
-        ),
-    ] = "",
     resolution: Annotated[
         float | None,
         typer.Option(

--- a/tests/test_cli_sensors.py
+++ b/tests/test_cli_sensors.py
@@ -32,10 +32,12 @@ def captured_run(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
     return calls
 
 
-def test_the_defaults_reach_the_sensor(
+def test_the_remaining_defaults_reach_the_sensor(
     captured_run: list[dict[str, object]],
 ) -> None:
-    result = _run("mock-sensor")
+    # `--measurement` and `--unit` are required, so they are named here
+    # rather than defaulted; everything else still has a default.
+    result = _run("mock-sensor", "--measurement", "temperature", "--unit", "°C")
 
     assert result.exit_code == 0
     assert captured_run == [
@@ -47,7 +49,7 @@ def test_the_defaults_reach_the_sensor(
             "field": "value",
             "noise": 0.1,
             "log_scale": False,
-            "unit": "",
+            "unit": "°C",
             "resolution": None,
             "significant_digits": 6,
             "summary_interval": 30.0,
@@ -115,7 +117,15 @@ def test_a_summary_interval_of_zero_turns_the_heartbeat_off(
 ) -> None:
     # Typer cannot hand back None from a float option, so zero is the off
     # switch — "summarise every zero seconds" has no other meaning.
-    result = _run("mock-sensor", "--summary-interval", "0")
+    result = _run(
+        "mock-sensor",
+        "--measurement",
+        "temperature",
+        "--unit",
+        "K",
+        "--summary-interval",
+        "0",
+    )
 
     assert result.exit_code == 0
     assert captured_run[0]["summary_interval"] is None
@@ -135,9 +145,63 @@ def test_an_unknown_log_level_is_rejected(
 
 @pytest.mark.usefixtures("captured_run")
 def test_a_lower_case_log_level_is_accepted() -> None:
-    result = _run("mock-sensor", "--log-level", "debug")
+    result = _run(
+        "mock-sensor",
+        "--measurement",
+        "temperature",
+        "--unit",
+        "K",
+        "--log-level",
+        "debug",
+    )
 
     assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("captured_run")
+def test_the_mock_sensor_requires_a_measurement() -> None:
+    # A bare run used to write a 21.0 into `temperature` with no unit at
+    # all, which is a number nobody can act on: 21 °C is a warm room and
+    # 21 K is a cryostat stage, and the reading said neither.
+    result = _run("mock-sensor")
+
+    assert result.exit_code != 0
+    assert "--measurement" in result.output
+
+
+@pytest.mark.usefixtures("captured_run")
+def test_the_mock_sensor_requires_a_unit() -> None:
+    result = _run("mock-sensor", "--measurement", "temperature")
+
+    assert result.exit_code != 0
+    assert "--unit" in result.output
+
+
+@pytest.mark.usefixtures("captured_run")
+def test_naming_both_is_enough_to_run() -> None:
+    result = _run("mock-sensor", "--measurement", "temperature", "--unit", "K")
+
+    assert result.exit_code == 0
+
+
+def test_a_measurement_cannot_be_left_empty(
+    captured_run: list[dict[str, object]],
+) -> None:
+    # Requiring the option and then accepting "" for it would be the same
+    # unlabelled reading with an extra step.
+    result = _run("mock-sensor", "--measurement", "", "--unit", "K")
+
+    assert result.exit_code != 0
+    assert captured_run == []
+
+
+def test_a_unit_cannot_be_left_empty(
+    captured_run: list[dict[str, object]],
+) -> None:
+    result = _run("mock-sensor", "--measurement", "temperature", "--unit", "")
+
+    assert result.exit_code != 0
+    assert captured_run == []
 
 
 def test_the_serial_sensor_requires_a_port_and_a_calibration() -> None:
@@ -202,7 +266,18 @@ def test_the_serial_sensor_passes_its_settings_through(
 def test_the_mock_sensor_alias_still_runs_the_command(
     captured_run: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("sys.argv", ["mock-sensor", "--sensor-id", "room-1"])
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "mock-sensor",
+            "--sensor-id",
+            "room-1",
+            "--measurement",
+            "temperature",
+            "--unit",
+            "°C",
+        ],
+    )
 
     with pytest.raises(SystemExit) as exit_info:
         deprecated.mock_sensor_main()


### PR DESCRIPTION
Closes #158.

A bare `labmon mock-sensor` wrote a walk around 21.0 into the `temperature` table with no unit tag, because `--measurement` defaulted to `temperature` and `--unit` defaulted to `""` — which is documented as omitting the tag entirely. A demo database was found holding 929 such rows.

Both options are now required, and neither accepts an empty string.

```
$ labmon mock-sensor
Usage: labmon mock-sensor [OPTIONS]
│ Missing option '--measurement'.

$ labmon mock-sensor --measurement temperature
│ Missing option '--unit'.

$ labmon mock-sensor --measurement temperature --unit ""
│ Invalid value for '--unit': cannot be empty

$ labmon mock-sensor --measurement temperature --unit K --sensor-id probe-158
2026-08-26 10:25:48.546  probe-158  temperature  21.0691  K
```

## Why required rather than defaulted

Neither can be guessed from the others. 21 °C is a warm room and 21 K is a cryostat stage — both plausible for the default setpoint, and nothing in the row said which. It is also the one thing an export cannot reconstruct afterwards, which is why the unit is written as a column in every format rather than only as metadata.

Defaulting `--unit` to `°C` was rejected: it makes the zero-argument case correct while introducing a worse one, since a `--measurement pressure` run would then silently label pressures in celsius. **A wrong unit is more dangerous than a missing one** — a missing unit sends somebody to check, a wrong one does not.

Requiring the unit alone is not enough either. With the measurement still defaulting, `--unit mbar` would file a correctly labelled pressure in the `temperature` table.

The empty-string refusal is a `callback`, because Typer treats `--unit ""` as the option having been supplied — requiring it would otherwise leave the unlabelled reading one argument away.

## What this breaks

Both compose files and the systemd example already name both flags, so the demo stack and every deployment example are unaffected.

**One thing did break, and CI caught it**: the TLS step in `.github/workflows/smoke.yml` named a measurement but no unit. Fixed here — and while on that line, it was also still invoking the deprecated `mock-sensor` alias (the deprecation warning is visible in the failing run), with a comment above it describing an entrypoint that changed in #154. All three corrected.

The rest of the cost is documentation: the bare invocation and three examples in `docs/mock-sensor.md`, one in `docs/logging.md`, the defaults table, and the first example in the command's own help.

## Test plan

- [x] `pytest` — 566 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean
- [x] all four paths above exercised against the real CLI, not only through `CliRunner`
- [x] every runnable `labmon mock-sensor` example in the docs now names both flags
