### PR TITLE
feat(export): query the latest reading from every sensor

### DIFF
--- a/src/labmon/export/query.py
+++ b/src/labmon/export/query.py
@@ -173,3 +173,143 @@ def fetch(
         extra={"measurement": measurement, "sensors": len(wanted_sensors)},
     )
     return client.query(sql, query_parameters=parameters)
+
+
+# --------------------------------------------------------------------------
+# The latest reading from each sensor
+# --------------------------------------------------------------------------
+
+SENSOR_COLUMN = "sensor_id"
+
+
+# The SQL type each optional column is cast to when a table lacks it.
+# Needed because a UNION arm that selects a bare NULL has no type for the
+# planner to reconcile against the arm that selects a real column.
+_NULL_TYPES: dict[str, str] = {
+    "unit": "VARCHAR",
+    "calibration_id": "VARCHAR",
+    "input_volts": "DOUBLE",
+}
+
+
+def _latest_branch(
+    measurement: str,
+    present: frozenset[str],
+    shared: Sequence[str],
+    sensor_placeholders: Sequence[str],
+) -> str:
+    """One arm of the UNION, reducing a table to a row per sensor.
+
+    `last_value(x ORDER BY time)` rather than a window function: it says
+    what is wanted in one line, and measured marginally faster than
+    `ROW_NUMBER() OVER (PARTITION BY ...)` across six tables.
+
+    The measurement is a literal here because the tables are separate and
+    nothing in the rows says which one a reading came from. It is safe to
+    interpolate for the same reason the FROM clause is — the name was
+    matched against what the server reported, never against what a user
+    typed.
+    """
+    columns = [
+        f"'{measurement}' AS \"measurement\"",
+        f'"{SENSOR_COLUMN}"',
+        f'max("{TIME_COLUMN}") AS "{TIME_COLUMN}"',
+        f'last_value("{VALUE_COLUMN}" ORDER BY "{TIME_COLUMN}") AS "{VALUE_COLUMN}"',
+    ]
+    for optional in shared:
+        if optional in present:
+            columns.append(
+                f'last_value("{optional}" ORDER BY "{TIME_COLUMN}") AS "{optional}"'
+            )
+        else:
+            # Every arm must project the same columns, so a table that
+            # lacks one contributes a typed NULL rather than being narrower.
+            columns.append(f'CAST(NULL AS {_NULL_TYPES[optional]}) AS "{optional}"')
+
+    conditions = [
+        f'"{TIME_COLUMN}" >= CAST($since AS TIMESTAMP)',
+        f'"{TIME_COLUMN}" < CAST($until AS TIMESTAMP)',
+    ]
+    if sensor_placeholders:
+        conditions.append(f'"{SENSOR_COLUMN}" IN ({", ".join(sensor_placeholders)})')
+
+    return (
+        f"SELECT {', '.join(columns)}"
+        + f' FROM "{measurement}"'
+        + f" WHERE {' AND '.join(conditions)}"
+        + f' GROUP BY "{SENSOR_COLUMN}"'
+    )
+
+
+def fetch_latest(
+    client: Queryable,
+    measurements: Sequence[str],
+    window: Window,
+    sensor_ids: Iterable[str] = (),
+) -> pa.Table:
+    """The most recent reading each sensor produced within `window`.
+
+    One round trip for every measurement, as a UNION of one arm per
+    table. The round trips are what cost — the scan itself is cheap — so
+    asking six times would be six times the latency for the same answer.
+
+    A table with no `sensor_id` is skipped rather than refused: "the
+    latest per sensor" has no meaning there, and a measurement written by
+    something other than labmon may legitimately not have one. Refusing
+    the whole command because one table is unusual would be worse than
+    leaving it out.
+    """
+    parameters: dict[str, str] = {
+        "since": window.since.isoformat(),
+        "until": window.until.isoformat(),
+    }
+    placeholders: list[str] = []
+    for index, sensor in enumerate(sensor_ids):
+        name = f"sensor_{index}"
+        parameters[name] = sensor
+        placeholders.append(f"${name}")
+
+    usable: list[tuple[str, frozenset[str]]] = []
+    for measurement in measurements:
+        present = columns_of(client, measurement)
+        if not {TIME_COLUMN, VALUE_COLUMN, SENSOR_COLUMN} <= present:
+            logger.debug(
+                "measurement has no per-sensor readings",
+                extra={"measurement": measurement},
+            )
+            continue
+        usable.append((measurement, present))
+
+    # The optional columns any usable table has, so every arm can project
+    # the same set — the union of what is available, not the intersection,
+    # so one plain table does not hide another's provenance.
+    shared = [
+        optional
+        for optional in OPTIONAL_COLUMNS
+        if optional != SENSOR_COLUMN
+        and any(optional in present for _, present in usable)
+    ]
+
+    branches = [
+        _latest_branch(measurement, present, shared, placeholders)
+        for measurement, present in usable
+    ]
+
+    if not branches:
+        return _empty_latest()
+
+    sql = "\nUNION ALL\n".join(branches)
+    logger.debug("querying latest", extra={"measurements": len(branches)})
+    return client.query(sql, query_parameters=parameters)
+
+
+def _empty_latest() -> pa.Table:
+    """The shape `fetch_latest` returns when nothing can be asked."""
+    return pa.table(
+        {
+            "measurement": pa.array([], pa.string()),
+            SENSOR_COLUMN: pa.array([], pa.string()),
+            TIME_COLUMN: pa.array([], pa.timestamp("ms", tz="UTC")),
+            VALUE_COLUMN: pa.array([], pa.float64()),
+        }
+    )

--- a/src/labmon/export/query.py
+++ b/src/labmon/export/query.py
@@ -200,15 +200,65 @@ def _latest_branch(
 ) -> str:
     """One arm of the UNION, reducing a table to a row per sensor.
 
-    `last_value(x ORDER BY time)` rather than a window function: it says
-    what is wanted in one line, and measured marginally faster than
-    `ROW_NUMBER() OVER (PARTITION BY ...)` across six tables.
+    Builds SQL text; it does not touch the database. `fetch_latest`
+    calls this once per measurement and sends the arms together as a
+    single query.
 
-    The measurement is a literal here because the tables are separate and
-    nothing in the rows says which one a reading came from. It is safe to
-    interpolate for the same reason the FROM clause is — the name was
-    matched against what the server reported, never against what a user
-    typed.
+    **`GROUP BY sensor_id` is the whole idea.** It sorts every row in
+    the table into piles, one per sensor, and yields one output row per
+    pile — twenty thousand `cryo-77k` readings become a single
+    `cryo-77k` row.
+
+    Collapsing a pile means every column has to answer "which of these
+    values do I show?", which is what the functions are for.
+    `max(time)` is the newest timestamp in the pile, and
+    `last_value(value ORDER BY time)` sorts the pile by time and takes
+    the value from the end — the reading that goes with that timestamp.
+    A bare `value` would not compile: "the value of twenty thousand
+    rows" is not a question with one answer, and SQL insists on being
+    told which one is wanted.
+
+    `last_value` was chosen over `DISTINCT ON (sensor_id)` and over
+    `ROW_NUMBER() OVER (PARTITION BY sensor_id ORDER BY time DESC)`. All
+    three plan on this server; this one is the shortest to generate and
+    measured marginally the fastest.
+
+    The `WHERE` runs before the grouping, so it shrinks the piles first
+    — only rows inside the window, and only the sensors asked for.
+
+    Three details that are not obvious:
+
+    - the measurement is selected as a constant, the same on every row.
+      Each measurement is a separate table, so once rows from several of
+      them are stacked nothing in the data says which table a row came
+      from. This stamps it on.
+    - `$since`, `$until` and `$sensor_0` are placeholders. Their values
+      travel beside the query and are never pasted into its text, so a
+      sensor named `\'; DROP TABLE` is only a sensor that does not
+      exist. The table name *is* interpolated, safe because it came from
+      `resolve_measurements` matching it against the list the server
+      itself reported.
+    - a column this table lacks is selected as `CAST(NULL AS ...)`.
+      `UNION ALL` stacks rows vertically and requires every arm to have
+      the same columns in the same order; the cast is needed because a
+      bare NULL has no type for the planner to reconcile against the arm
+      holding the real column.
+
+    What comes out, for one table with every optional column and a
+    request narrowed to one sensor::
+
+        SELECT \'temperature\' AS "measurement",
+               "sensor_id",
+               max("time")                                  AS "time",
+               last_value("value" ORDER BY "time")          AS "value",
+               last_value("unit" ORDER BY "time")           AS "unit",
+               last_value("calibration_id" ORDER BY "time") AS "calibration_id",
+               last_value("input_volts" ORDER BY "time")    AS "input_volts"
+        FROM "temperature"
+        WHERE "time" >= CAST($since AS TIMESTAMP)
+          AND "time" <  CAST($until AS TIMESTAMP)
+          AND "sensor_id" IN ($sensor_0)
+        GROUP BY "sensor_id"
     """
     columns = [
         f"'{measurement}' AS \"measurement\"",

--- a/tests/test_export_query.py
+++ b/tests/test_export_query.py
@@ -1,7 +1,7 @@
 """Building and running the SQL an export needs."""
 
 from datetime import UTC, datetime
-from typing import cast
+from typing import cast, override
 
 import pyarrow as pa
 import pytest
@@ -10,6 +10,7 @@ from labmon.export.query import (
     QueryError,
     columns_of,
     fetch,
+    fetch_latest,
     list_measurements,
     resolve_measurements,
 )
@@ -209,3 +210,144 @@ def test_filtering_a_table_that_records_no_sensor_says_so() -> None:
 
     with pytest.raises(QueryError, match="no sensor_id column"):
         _ = fetch(client, "probe", _WINDOW, ["cryo-77k"])
+
+
+# --------------------------------------------------------------------------
+# The latest reading from each sensor
+# --------------------------------------------------------------------------
+
+
+def test_latest_reads_every_measurement_in_one_round_trip() -> None:
+    # One query rather than one per table: the round trips are what cost,
+    # not the scan. Measured at 84ms for six tables over 24 hours.
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature", "pressure"), _WINDOW)
+
+    selects = [sql for sql, _ in client.calls if sql.startswith("SELECT '")]
+    assert len(selects) == 1
+    assert selects[0].count("UNION ALL") == 1
+
+
+def test_latest_names_the_measurement_each_row_came_from() -> None:
+    # The tables are separate, so nothing in the rows themselves says
+    # which one a reading belongs to.
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature",), _WINDOW)
+
+    sql = client.calls[-1][0]
+    assert "'temperature' AS \"measurement\"" in sql
+
+
+def test_latest_takes_the_most_recent_row_per_sensor() -> None:
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature",), _WINDOW)
+
+    sql = client.calls[-1][0]
+    assert "last_value" in sql
+    assert 'GROUP BY "sensor_id"' in sql
+
+
+def test_latest_binds_its_time_bounds_as_parameters() -> None:
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature",), _WINDOW)
+
+    sql, parameters = client.calls[-1]
+    assert "$since" in sql
+    assert parameters["since"] == _WINDOW.since.isoformat()
+    assert "2026-08-01" not in sql
+
+
+def test_latest_binds_requested_sensors_as_parameters() -> None:
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature",), _WINDOW, ["cryo-77k", "room-1"])
+
+    sql, parameters = client.calls[-1]
+    assert "cryo-77k" not in sql
+    assert set(parameters.values()) >= {"cryo-77k", "room-1"}
+
+
+def test_a_table_without_a_sensor_id_is_left_out_rather_than_failing() -> None:
+    # A measurement written by something else may have no sensor_id at
+    # all. "The latest per sensor" is meaningless there, and refusing the
+    # whole command because one table is unusual would be worse.
+    client = FakeClient(("time", "value"))
+
+    _ = fetch_latest(client, ("temperature",), _WINDOW)
+
+    selects = [sql for sql, _ in client.calls if sql.startswith("SELECT '")]
+    assert selects == []
+
+
+class UnevenClient(FakeClient):
+    """Answers with a different column set per table, as a real server does.
+
+    A measurement written by a calibrated sensor has `input_volts` and
+    `calibration_id`; a simulated one has neither. Every arm of a UNION
+    must still project the same columns or the server refuses to plan it.
+    """
+
+    def __init__(self, per_table: dict[str, tuple[str, ...]]) -> None:
+        super().__init__()
+        self._per_table: dict[str, tuple[str, ...]] = per_table
+        self._asked: list[str] = []
+
+    @override
+    def query(self, query: str, *args: object, **kwargs: object) -> pa.Table:
+        if "information_schema.columns" in query:
+            raw = kwargs.get("query_parameters")
+            parameters = cast(dict[str, str], raw) if isinstance(raw, dict) else {}
+            table = parameters.get("table", "")
+            self._asked.append(table)
+            self.calls.append((query, dict(parameters)))
+            return pa.table({"column_name": pa.array(list(self._per_table[table]))})
+        return super().query(query, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+
+
+def test_every_union_arm_projects_the_same_columns() -> None:
+    # The server refuses to plan a UNION whose arms differ in width, so a
+    # calibrated table and a simulated one cannot each select only what
+    # they happen to have.
+    client = UnevenClient(
+        {
+            "temperature": _FULL,
+            "pressure": ("time", "value", "sensor_id", "unit"),
+        }
+    )
+
+    _ = fetch_latest(client, ("temperature", "pressure"), _WINDOW)
+
+    sql = client.calls[-1][0]
+    arms = sql.split("UNION ALL")
+    # Counting aliases rather than the word AS: `CAST(NULL AS VARCHAR)`
+    # carries one of its own, so a bare count says the arms differ when
+    # their projections match exactly.
+    widths = {arm.count('AS "') for arm in arms}
+    assert len(widths) == 1, f"arms differ in width: {widths}"
+
+
+def test_a_missing_column_is_selected_as_null() -> None:
+    client = UnevenClient(
+        {
+            "temperature": _FULL,
+            "pressure": ("time", "value", "sensor_id", "unit"),
+        }
+    )
+
+    _ = fetch_latest(client, ("temperature", "pressure"), _WINDOW)
+
+    pressure_arm = client.calls[-1][0].split("UNION ALL")[1]
+    assert "NULL" in pressure_arm
+    assert '"input_volts"' in pressure_arm
+
+
+def test_latest_of_no_usable_measurements_is_empty() -> None:
+    client = FakeClient(("time", "value"))
+
+    result = fetch_latest(client, ("temperature",), _WINDOW)
+
+    assert result.num_rows == 0


### PR DESCRIPTION
First of three stacked PRs for #155. **Query layer only — nothing calls it yet.** Stack:

1. **this PR** — `fetch_latest`, the SQL
2. `labmon query --latest` and the age column
3. the cached roster and `labmon sensors`

## What it does

Reduces every measurement to one row per sensor, in a single round trip:

```
sensor_id      measurement       value  unit  time
beam-x         position        19.2744  µm    2026-08-26 11:12:28.921
chamber-1      pressure    1.64218e-07  mbar  2026-08-26 11:12:27.527
cryo-77k       temperature      75.464  K     2026-08-26 11:12:27.565
probe-158      temperature     21.0691  K     2026-08-26 10:25:48.546   <- 47 min stale
...
13 rows
```

One `UNION ALL` arm per table rather than one query per table, because the round trip is what costs and the scan is not — 21 ms over a five-minute lookback, 84 ms over twenty-four hours, for thirteen sensors across six tables.

`last_value(value ORDER BY time)` with `GROUP BY sensor_id` was chosen over `DISTINCT ON` and `ROW_NUMBER() OVER (PARTITION BY ...)`. All three plan on this server; this one is shortest to generate and measured marginally fastest (120 ms vs 136 ms across six tables).

## The bug the unit tests could not have caught

Every fake in `test_export_query.py` gave each table the same columns. Running the generated SQL against the live server said otherwise:

```
Error during planning: UNION queries have different number of columns
```

Tables genuinely differ — a calibrated sensor writes `input_volts` and `calibration_id`, a simulated one writes neither — so arms selecting "whatever this table has" don't line up. A missing column now contributes `CAST(NULL AS ...)`, typed because an untyped `NULL` gives the planner nothing to reconcile against the arm holding the real column. The projection is the **union** of available columns, not the intersection, so one plain table doesn't hide another's provenance.

`UnevenClient` was added to cover this: a fake that answers with a different column set per table, as a real server does.

## Also here

A second commit rewrites `_latest_branch`'s docstring for a reader who does not write SQL: what `GROUP BY` and `last_value` actually do before why they were chosen, the three details that trip people up (the measurement selected as a constant, the placeholders whose values never enter the query text, the typed NULL keeping every arm the same width), and the generated query as a worked example.

## Test plan

- [x] `pytest` — 575 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean
- [x] generated SQL run against the live demo stack: 13 sensors, one row each, `--sensor-id` narrowing verified
- [x] uneven-column union covered by a test that fails without the NULL padding

