### PR TITLE
feat(cli): add query --latest, with how long ago each sensor reported

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -276,6 +276,49 @@ screen.
 `query` never emits binary. To pipe a real format into another tool, use
 `labmon export -o -`.
 
+## What is everything reading right now
+
+`--latest` answers a different question from the rest of `query`: not
+what happened over a window, but where each sensor stands at this
+moment.
+
+```bash
+labmon query --latest
+labmon query --latest --measurement temperature
+labmon query --latest --sensor-id cryo-77k --sensor-id room-1
+```
+
+```
+sensor_id     measurement  value                   unit  age
+------------  -----------  ----------------------  ----  -------
+wavemeter-1   frequency    276561302600000.0       Hz    1s ago
+beam-y        position     22.652263736263734      µm    2s ago
+cryo-77k      temperature  74.828                  K     4s ago
+room-1        temperature  20.132                  °C    5s ago
+probe-158     temperature  21.0691                 K     57m ago
+
+13 sensors
+```
+
+One row per sensor, and **the `age` column is as much the point as the
+value is.** A sensor that stopped writing an hour ago still has a most
+recent reading, and it looks perfectly healthy until you can see when it
+arrived — `probe-158` above is the row worth noticing.
+
+Rows are ordered by age with the oldest last, so the sensor that has
+gone quiet is the line an eye lands on. In a terminal the age is
+coloured: unmarked under a minute, amber up to five, red beyond. Those
+thresholds are global for now; sensors here legitimately run from 1 Hz
+to once a minute, so a per-sensor expectation is the better answer and
+belongs in a configuration file.
+
+Colour is written only when the output is a terminal, so piping this
+into a file leaves escape codes out of it.
+
+The same four selection flags apply. `--since` still bounds how far back
+to look — a sensor silent for longer than the window has no row at all,
+which is the one case this view cannot show you.
+
 ## Tab completion
 
 ```bash

--- a/src/labmon/cli/age.py
+++ b/src/labmon/cli/age.py
@@ -1,0 +1,60 @@
+"""How long ago a reading arrived, said briefly and coloured by concern.
+
+Imports nothing beyond the standard library, so naming a threshold as a
+CLI option default costs no startup time.
+"""
+
+from datetime import timedelta
+from enum import Enum
+
+# A sensor here may legitimately sample once a minute — the demo stack
+# spans 1 Hz to that — so the fresh window has to clear a whole interval
+# before it starts warning, or every slow sensor reads as a problem.
+FRESH_UNTIL: timedelta = timedelta(minutes=1)
+
+# Past this, silence is worth explaining rather than shrugging at. Both
+# thresholds are deliberately global for now; a per-sensor expected
+# interval belongs in the configuration file, and is tracked separately.
+STALE_AFTER: timedelta = timedelta(minutes=5)
+
+_UNITS: tuple[tuple[int, str], ...] = (
+    (86_400, "d"),
+    (3_600, "h"),
+    (60, "m"),
+    (1, "s"),
+)
+
+
+class Freshness(Enum):
+    """How much concern an age deserves at a glance."""
+
+    FRESH = "fresh"
+    AGEING = "ageing"
+    STALE = "stale"
+
+
+def describe(delta: timedelta) -> str:
+    """`delta` as one number and one unit, e.g. `3m ago`.
+
+    One significant unit rather than `1h 3m 12s`: the question being
+    asked of this column is "is this current?", and a single magnitude
+    answers it where a breakdown has to be read.
+
+    A negative age is reported as zero. Clock skew between a sensor host
+    and this one is ordinary, and `-3s ago` reads as a bug in labmon
+    rather than as a clock worth checking.
+    """
+    seconds = max(0, int(delta.total_seconds()))
+    for size, suffix in _UNITS:
+        if seconds >= size:
+            return f"{seconds // size}{suffix} ago"
+    return "0s ago"
+
+
+def freshness(delta: timedelta) -> Freshness:
+    """Which band `delta` falls in, for colouring."""
+    if delta < FRESH_UNTIL:
+        return Freshness.FRESH
+    if delta < STALE_AFTER:
+        return Freshness.AGEING
+    return Freshness.STALE

--- a/src/labmon/cli/commands/query.py
+++ b/src/labmon/cli/commands/query.py
@@ -6,7 +6,7 @@ import typer
 
 from labmon.cli import selection
 from labmon.cli.options import LogLevelOption, Measurements, SensorIds, Since, Until
-from labmon.cli.render import DEFAULT_LIMIT, render
+from labmon.cli.render import DEFAULT_LIMIT, render, render_latest
 from labmon.cli.runtime import configure
 
 HELP = (
@@ -23,6 +23,15 @@ HELP = (
     + "    labmon query --since 1h --limit 0"
 )
 
+Latest = Annotated[
+    bool,
+    typer.Option(
+        "--latest",
+        help="One row per sensor: its most recent reading, and how long ago"
+        + " it arrived",
+    ),
+]
+
 Limit = Annotated[
     int,
     typer.Option(
@@ -38,10 +47,21 @@ def query(
     sensor_id: SensorIds = None,
     since: Since = "1h",
     until: Until = None,
+    latest: Latest = False,
     limit: Limit = DEFAULT_LIMIT,
     log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
 ) -> None:
     """Print recorded readings as a table."""
+    import sys
+    from datetime import UTC, datetime
+
     configure(log_level)
+    if latest:
+        table, _window = selection.read_latest(measurement, sensor_id, since, until)
+        # Colour only where something will interpret it. Piping this into
+        # a file should leave escape codes out of the file, and `isatty`
+        # is what answers that without guessing at the terminal.
+        print(render_latest(table, now=datetime.now(UTC), colour=sys.stdout.isatty()))
+        return
     table, _window = selection.read(measurement, sensor_id, since, until)
     print(render(table, limit=limit))

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -5,8 +5,10 @@ every column and full precision so nothing is lost, while a terminal
 wants the few columns that carry meaning, aligned, in a width that fits.
 """
 
-from datetime import datetime
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+from labmon.cli.age import Freshness, describe, freshness
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -107,3 +109,85 @@ def render(table: "pa.Table", limit: int = DEFAULT_LIMIT) -> str:
         lines.append("")
         lines.append(f"{total} reading{'s' if total != 1 else ''}")
     return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# The latest reading from each sensor
+# --------------------------------------------------------------------------
+
+LATEST_COLUMNS: tuple[str, ...] = ("sensor_id", "measurement", "value", "unit", "age")
+
+# SGR codes rather than a styling library: this is the only colour the
+# CLI emits, and reaching for one would pull an import into a path the
+# startup work deliberately keeps clear.
+_STYLES: dict[Freshness, str] = {
+    Freshness.FRESH: "",
+    Freshness.AGEING: "\x1b[33m",
+    Freshness.STALE: "\x1b[31m",
+}
+_RESET = "\x1b[0m"
+
+
+def render_latest(table: "pa.Table", now: datetime, *, colour: bool = False) -> str:
+    """One row per sensor, oldest last, with how long ago it reported.
+
+    Sorted by age rather than by name, ascending, so the sensor that has
+    stopped reporting is the last line — which is where an eye lands on
+    a short list, and it is the row this view exists to surface.
+
+    Colour is applied after padding, never before. An escape code counts
+    toward `len`, so a cell coloured first pads to fewer visible
+    characters than its neighbours and silently shortens its column.
+    """
+    total = table.num_rows
+    if total == 0:
+        return "no readings matched"
+
+    columns = {name: table.column(name).to_pylist() for name in table.column_names}
+    ages = [now - _as_datetime(stamp) for stamp in columns["time"]]
+    order = sorted(range(total), key=lambda index: ages[index])
+
+    present = [name for name in LATEST_COLUMNS if name == "age" or name in columns]
+    rows: list[list[str]] = []
+    styles: list[str] = []
+    for index in order:
+        cells = [
+            describe(ages[index])
+            if name == "age"
+            else _cell(name, columns[name][index])
+            for name in present
+        ]
+        rows.append(cells)
+        styles.append(_STYLES[freshness(ages[index])] if colour else "")
+
+    widths = [
+        max(len(name), *(len(row[position]) for row in rows))
+        for position, name in enumerate(present)
+    ]
+
+    lines = [
+        "  ".join(
+            name.ljust(width) for name, width in zip(present, widths, strict=True)
+        ),
+        "  ".join("-" * width for width in widths),
+    ]
+    for row, style in zip(rows, styles, strict=True):
+        padded = "  ".join(
+            cell.ljust(width) for cell, width in zip(row, widths, strict=True)
+        ).rstrip()
+        lines.append(f"{style}{padded}{_RESET}" if style else padded)
+
+    lines.append("")
+    lines.append(f"{total} sensor{'s' if total != 1 else ''}")
+    return "\n".join(lines)
+
+
+def _as_datetime(stamp: object) -> datetime:
+    """A timestamp column entry as an aware datetime.
+
+    pyarrow hands back a naive value for a column with no zone, and the
+    latest query stamps in UTC, so an absent zone means UTC rather than
+    local time.
+    """
+    moment = cast(datetime, stamp)
+    return moment if moment.tzinfo else moment.replace(tzinfo=UTC)

--- a/src/labmon/cli/selection.py
+++ b/src/labmon/cli/selection.py
@@ -59,3 +59,34 @@ def read(
         extra={"rows": table.num_rows, "measurements": len(resolved)},
     )
     return table, window
+
+
+def read_latest(
+    measurements: Sequence[str] | None,
+    sensor_ids: Sequence[str] | None,
+    since: str,
+    until: str | None,
+) -> "tuple[pa.Table, Window]":
+    """The most recent reading each sensor produced within the window.
+
+    Shares the client handling and the measurement allowlist with
+    `read`, and differs only in the query it runs — so a sensor visible
+    to one is visible to the other.
+    """
+    from labmon.export.query import fetch_latest, resolve_measurements
+    from labmon.export.window import Window
+    from labmon.influx import get_client
+
+    window = Window.parse(since, until)
+    client = get_client()
+    try:
+        resolved = resolve_measurements(client, list(measurements or ()))
+        table = fetch_latest(client, resolved, window, list(sensor_ids or ()))
+    finally:
+        client.close()
+
+    logger.debug(
+        "read latest",
+        extra={"sensors": table.num_rows, "measurements": len(resolved)},
+    )
+    return table, window

--- a/tests/test_cli_age.py
+++ b/tests/test_cli_age.py
@@ -1,0 +1,49 @@
+"""How long ago a reading arrived, said briefly and coloured by concern."""
+
+from datetime import timedelta
+
+import pytest
+
+from labmon.cli.age import FRESH_UNTIL, STALE_AFTER, Freshness, describe, freshness
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "0s ago"),
+        (1, "1s ago"),
+        (59, "59s ago"),
+        (60, "1m ago"),
+        (3599, "59m ago"),
+        (3600, "1h ago"),
+        (86_399, "23h ago"),
+        (86_400, "1d ago"),
+        (86_400 * 9, "9d ago"),
+    ],
+)
+def test_an_age_reads_as_one_number_and_one_unit(seconds: int, expected: str) -> None:
+    # A glance has to answer "is this current?", which one significant
+    # unit does and "1h 3m 12s" does not.
+    assert describe(timedelta(seconds=seconds)) == expected
+
+
+def test_a_reading_from_the_future_is_not_negative() -> None:
+    # Clock skew between a sensor host and this one is ordinary, and
+    # "-3s ago" reads as a bug in labmon rather than a clock to check.
+    assert describe(timedelta(seconds=-3)) == "0s ago"
+
+
+def test_a_recent_reading_is_fresh() -> None:
+    assert freshness(FRESH_UNTIL - timedelta(seconds=1)) is Freshness.FRESH
+
+
+def test_freshness_turns_at_the_documented_boundaries() -> None:
+    assert freshness(FRESH_UNTIL) is Freshness.AGEING
+    assert freshness(STALE_AFTER - timedelta(seconds=1)) is Freshness.AGEING
+    assert freshness(STALE_AFTER) is Freshness.STALE
+
+
+def test_the_boundaries_are_ordered() -> None:
+    # A sensor sampling once a minute is normal here, so the fresh
+    # window has to clear a whole interval before it starts warning.
+    assert timedelta(0) < FRESH_UNTIL < STALE_AFTER

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -1,5 +1,7 @@
 """`labmon query` and the terminal table it prints."""
 
+import re
+from datetime import UTC, datetime, timedelta
 from typing import override
 
 import pyarrow as pa
@@ -7,7 +9,7 @@ import pytest
 
 from labmon.cli import selection
 from labmon.cli.main import build_app
-from labmon.cli.render import DEFAULT_LIMIT, render, visible_columns
+from labmon.cli.render import DEFAULT_LIMIT, render, render_latest, visible_columns
 from labmon.export.table import combine, normalise
 from tests.cli_runner import Invocation, invoke
 
@@ -394,3 +396,174 @@ def test_the_timezone_suffix_is_never_half_printed() -> None:
     # Every row in a result carries the same offset, so it is dropped
     # rather than repeated — but dropped whole, not sliced through.
     assert "+00:" not in render(_at(1_000))
+
+
+# --------------------------------------------------------------------------
+# The latest reading from each sensor
+# --------------------------------------------------------------------------
+
+
+def _latest(rows: list[tuple[str, str, float, str, int]]) -> "pa.Table":
+    """One row per sensor, `seconds` old, in the shape fetch_latest returns."""
+    now = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    return pa.table(
+        {
+            "measurement": pa.array([r[1] for r in rows]),
+            "sensor_id": pa.array([r[0] for r in rows]),
+            "time": pa.array(
+                [now - timedelta(seconds=r[4]) for r in rows],
+                pa.timestamp("ms", tz="UTC"),
+            ),
+            "value": pa.array([r[2] for r in rows]),
+            "unit": pa.array([r[3] for r in rows]),
+        }
+    )
+
+
+_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+
+
+def test_the_latest_view_has_an_age_column() -> None:
+    rendered = render_latest(_latest([("a", "temperature", 1.0, "K", 3)]), now=_NOW)
+
+    assert "age" in rendered.splitlines()[0]
+    assert "3s ago" in rendered
+
+
+def test_a_sensor_is_listed_once() -> None:
+    table = _latest(
+        [("a", "temperature", 1.0, "K", 3), ("b", "temperature", 2.0, "K", 9)]
+    )
+
+    body = [
+        line for line in render_latest(table, now=_NOW).splitlines() if " ago" in line
+    ]
+
+    assert len(body) == 2
+
+
+def test_the_stalest_sensor_is_listed_last() -> None:
+    # The one that stopped reporting is the one worth finding, and a
+    # reader's eye lands on the end of a short list.
+    table = _latest(
+        [
+            ("fresh", "temperature", 1.0, "K", 2),
+            ("silent", "temperature", 2.0, "K", 9000),
+        ]
+    )
+
+    lines = [
+        line for line in render_latest(table, now=_NOW).splitlines() if " ago" in line
+    ]
+
+    assert lines[-1].startswith("silent")
+
+
+def test_columns_stay_aligned_when_an_age_is_coloured() -> None:
+    # Padding a string that carries escape codes counts them toward its
+    # width, so a coloured cell silently shortens its own column.
+    table = _latest(
+        [
+            ("a", "temperature", 1.0, "K", 2),
+            ("bbbbbbbbbb", "temperature", 2.0, "K", 9000),
+        ]
+    )
+
+    rendered = render_latest(table, now=_NOW, colour=True)
+    plain = [
+        re.sub(r"\x1b\[[0-9;]*m", "", line)
+        for line in rendered.splitlines()
+        if " ago" in line
+    ]
+
+    starts = {line.index("ago") for line in plain}
+    assert len(starts) == 1, f"age column is ragged: {starts}"
+
+
+def test_no_colour_means_no_escape_codes() -> None:
+    rendered = render_latest(_latest([("a", "temperature", 1.0, "K", 2)]), now=_NOW)
+
+    assert "\x1b[" not in rendered
+
+
+def test_an_empty_latest_result_says_so() -> None:
+    assert render_latest(_latest([]), now=_NOW) == "no readings matched"
+
+
+class LatestClient(FakeClient):
+    """Answers the latest query with one row per sensor, of differing ages."""
+
+    @override
+    def query(self, query: str, *args: object, **kwargs: object) -> pa.Table:
+        if query.startswith("SELECT '"):
+            now = datetime.now(UTC)
+            return pa.table(
+                {
+                    "measurement": pa.array(["temperature", "temperature"]),
+                    "sensor_id": pa.array(["cryo-77k", "abandoned"]),
+                    "time": pa.array(
+                        [now - timedelta(seconds=2), now - timedelta(hours=3)],
+                        pa.timestamp("ms", tz="UTC"),
+                    ),
+                    "value": pa.array([77.01, 4.2]),
+                    "unit": pa.array(["K", "K"]),
+                }
+            )
+        return super().query(query, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+
+
+def test_latest_prints_one_row_per_sensor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", LatestClient)
+
+    result = _run("query", "--latest")
+
+    assert result.exit_code == 0, result.output
+    assert "cryo-77k" in result.output
+    assert "2 sensors" in result.output
+
+
+def test_latest_reports_how_long_ago_each_sensor_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", LatestClient)
+
+    result = _run("query", "--latest")
+
+    assert "2s ago" in result.output
+    assert "3h ago" in result.output
+
+
+def test_latest_puts_the_quietest_sensor_last(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", LatestClient)
+
+    body = [
+        line for line in _run("query", "--latest").output.splitlines() if " ago" in line
+    ]
+
+    assert body[-1].startswith("abandoned")
+
+
+def test_latest_closes_the_client_when_the_query_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed: list[bool] = []
+
+    class Failing(FakeClient):
+        @override
+        def query(self, query: str, *args: object, **kwargs: object) -> pa.Table:
+            if query.startswith("SELECT '"):
+                raise RuntimeError("server said no")
+            return super().query(query, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+
+        @override
+        def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr("labmon.influx.get_client", Failing)
+
+    result = _run("query", "--latest")
+
+    assert result.exit_code != 0
+    assert closed == [True]


### PR DESCRIPTION
Second of three stacked PRs for #155. **Based on #163, not `main`** — review that one first.

1. #163 — `fetch_latest`, the SQL
2. **this PR** — the latest view and the age column
3. #165 — the remembered roster, and `labmon sensors`

> [!NOTE]
> This PR introduces the view as a flag, `labmon query --latest`. **#165 turns it into a subcommand, `labmon query latest`**, after review feedback that a subcommand carries its own help and completions and leaves room for `query stats`. The end state of the stack is the subcommand; read this PR for the view itself rather than for its spelling. The value formatting shown below also changes in #165 — the wavemeter reads `2.765612997e+14 Hz` by the end.

## What it does

One row per sensor, its most recent reading, and how long ago it arrived:

```
sensor_id     measurement  value                   unit  age
------------  -----------  ----------------------  ----  -------
wavemeter-1   frequency    276561302600000.0       Hz    1s ago
beam-y        position     22.652263736263734      µm    2s ago
cryo-77k      temperature  74.828                  K     4s ago
room-1        temperature  20.132                  °C    5s ago
probe-158     temperature  21.0691                 K     57m ago
```

**The `age` column is as much the point as the value.** A sensor that stopped writing an hour ago still has a most recent reading and looks perfectly healthy until you can see when it arrived — `probe-158` above is a real one, left behind by a process of mine that hung earlier.

Rows are sorted by age with the oldest **last**, so the sensor that has gone quiet is where an eye lands at the end of a short list.

## Details worth reviewing

**Colour is applied after padding, never before.** An escape code counts toward `len`, so a cell coloured first pads to fewer visible characters than its neighbours and quietly shortens its own column. A test asserts the age column starts at the same offset on every row, and fails if that order is reversed.

**Colour only when stdout is a terminal.** Verified both ways — under a pty the stale row is wrapped in `\x1b[31m`, and piped output contains zero escape codes.

**An age is one number and one unit.** The question is "is this current?", which a single magnitude answers and `1h 3m 12s` makes you parse. A negative age reports as `0s ago`: clock skew between a sensor host and this one is ordinary, and a leading minus reads as a bug in labmon rather than a clock worth checking.

**Thresholds are global for now** — unmarked under a minute, amber to five, red beyond. A minute clears a whole sampling interval, since sensors here run from 1 Hz down to once a minute and anything tighter paints every slow sensor as a problem. Per-sensor expectations belong in the config file from #156.

## Test plan

- [x] `pytest` — 598 passed at this commit, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean
- [x] run against the live demo stack: 13 sensors, correct ordering, `--measurement` and `--sensor-id` narrowing
- [x] colour verified present under a pty and absent when piped
