### PR TITLE
feat(cli): remember sensors that have gone quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ uv tool install --editable .   # puts `labmon` on your PATH
 labmon --install-completion
 ```
 
+`labmon query --latest` answers the other question — what every sensor
+reads right now, and how long ago each last spoke, so a silent one shows
+up instead of quietly disappearing.
+
 [`docs/export.md`](docs/export.md) covers the formats, the time window
 spellings, completion for bash and zsh, and why the unit is a column
 rather than only metadata.

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ uv tool install --editable .   # puts `labmon` on your PATH
 labmon --install-completion
 ```
 
-`labmon query --latest` answers the other question — what every sensor
+`labmon query latest` answers the other question — what every sensor
 reads right now, and how long ago each last spoke, so a silent one shows
 up instead of quietly disappearing.
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -315,9 +315,79 @@ belongs in a configuration file.
 Colour is written only when the output is a terminal, so piping this
 into a file leaves escape codes out of it.
 
-The same four selection flags apply. `--since` still bounds how far back
-to look — a sensor silent for longer than the window has no row at all,
-which is the one case this view cannot show you.
+The same four selection flags apply, and they narrow the remembered
+sensors as well as the query — asking for temperatures does not list a
+silent pressure gauge.
+
+## Sensors that have gone quiet
+
+`--since` bounds how far back the query looks, so a sensor silent for
+longer than the window returns no row. It has nothing to be stale: it
+simply disappears, which is the worst possible failure for a view whose
+job is spotting silence.
+
+labmon therefore remembers the sensors it has seen, and unions that list
+into the result:
+
+```
+sensor_id   measurement  value               unit  age
+----------  -----------  ------------------  ----  -------
+cryo-diode  temperature  17.097367521367556  K     1s ago
+room-1      temperature  20.518              °C    2s ago
+probe-158   temperature                      K     1h ago
+
+6 sensors
+1 of them reported nothing in this window — remembered from a previous run
+```
+
+`probe-158` reported nothing inside the window. Its **value is left
+blank rather than filled with the last reading it ever sent**: printed
+beside a fresh number from another sensor, an old one reads as current.
+
+The rule the cache follows is that **it may only add sensors, never
+replace or filter them.** Used as a union a stale cache is harmless, and
+the worst it can do is mention something that has since been removed.
+Used as a substitute it would grow its own silent failure, hiding a
+newly added sensor until somebody remembered to rebuild it.
+
+## `labmon sensors`
+
+The list is a cache, so it needs a window onto it — otherwise a
+decommissioned instrument shows red for ever with no recourse but
+deleting the file by hand.
+
+```bash
+labmon sensors                       # what labmon knows, and where from
+labmon sensors --refresh             # ask the database and remember
+labmon sensors --refresh --since 1w  # over a wider window
+labmon sensors --forget old-probe    # an instrument that is genuinely gone
+```
+
+```
+sensor_id     measurement  unit  age     source
+------------  -----------  ----  ------  ------
+wavemeter-1   frequency    Hz    1s ago  live
+cryo-77k      temperature  K     1s ago  live
+bias-monitor  voltage      V     2s ago  live
+old-probe     temperature  K     3h ago  cached
+
+14 sensors
+```
+
+The `source` column is what earns the command its place: it says
+outright whether a sensor is reporting now or is only remembered.
+
+A refresh is a union too — it never drops what the window did not cover,
+since that would delete exactly the silence worth keeping. `--forget` is
+the way to remove one, and it fails rather than pretending when the name
+is not there, so a mistyped id cannot leave somebody believing they
+removed a sensor that is still listed.
+
+The cache lives at `$XDG_CACHE_HOME/labmon/sensors.json` (usually
+`~/.cache/labmon/sensors.json`) — beside other caches rather than in the
+configuration directory, because it is derived data that can be deleted
+at any moment without losing a setting. It is indented JSON, so it can
+be read and edited by hand.
 
 ## Tab completion
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -278,27 +278,43 @@ screen.
 
 ## What is everything reading right now
 
-`--latest` answers a different question from the rest of `query`: not
-what happened over a window, but where each sensor stands at this
-moment.
+`labmon query latest` answers a different question from `query` itself:
+not what happened over a window, but where each sensor stands at this
+moment. A subcommand rather than a flag, so it carries its own help and
+completions and leaves room for the other questions worth asking of
+recorded readings.
 
 ```bash
-labmon query --latest
-labmon query --latest --measurement temperature
-labmon query --latest --sensor-id cryo-77k --sensor-id room-1
+labmon query latest
+labmon query latest --measurement temperature
+labmon query latest --sensor-id cryo-77k --sensor-id room-1
 ```
 
 ```
-sensor_id     measurement  value                   unit  age
-------------  -----------  ----------------------  ----  -------
-wavemeter-1   frequency    276561302600000.0       Hz    1s ago
-beam-y        position     22.652263736263734      µm    2s ago
-cryo-77k      temperature  74.828                  K     4s ago
-room-1        temperature  20.132                  °C    5s ago
-probe-158     temperature  21.0691                 K     57m ago
+sensor_id     measurement  value             unit  age
+------------  -----------  ----------------  ----  -------
+wavemeter-1   frequency    2.765612997e+14   Hz    2s ago
+chamber-1     pressure     1.9867e-07        mbar  4s ago
+cryo-77k      temperature  76.945            K     4s ago
+room-1        temperature  21.552            °C    4s ago
+old-probe     temperature  21.0691           K     57m ago
 
 13 sensors
 ```
+
+Readings are shown plainly where a decimal reads well, and in scientific
+notation where it does not — more than three digits ahead of the point,
+or zeros crowding in behind it, is where a column of numbers has to be
+counted rather than read. Nothing is rounded away in either form: the
+shortest text that reads back as the same number is used, because a
+sensor has already rounded to the resolution it claims.
+
+The unit is never rewritten. Rescaling `Hz` to `THz` is the prettiest
+answer for a wavemeter and the wrong one nearly everywhere else — `mbar`
+already carries a prefix, so choosing one afresh turns a vacuum reading
+into picobar, and `°C` is an offset unit that cannot be scaled at all. A
+per-sensor prefix, chosen rather than inferred, is the better answer
+where one is wanted, and belongs in a configuration file.
 
 One row per sensor, and **the `age` column is as much the point as the
 value is.** A sensor that stopped writing an hour ago still has a most

--- a/docs/export.md
+++ b/docs/export.md
@@ -370,12 +370,21 @@ wavemeter-1   frequency    Hz    1s ago  live
 cryo-77k      temperature  K     1s ago  live
 bias-monitor  voltage      V     2s ago  live
 old-probe     temperature  K     3h ago  cached
-
-14 sensors
 ```
 
-The `source` column is what earns the command its place: it says
-outright whether a sensor is reporting now or is only remembered.
+**The `source` column appears only with `--refresh`**, because only a
+refresh asks the database anything. A plain listing reads the remembered
+file and touches nothing, so the column could report nothing but
+"cached" — including beside a sensor reporting at that moment. It is
+left out rather than printed misleadingly.
+
+`--measurement` and `--sensor-id` describe a remembered entry, so they
+narrow a plain listing as well as a refresh. `--since` and `--until`
+bound the query a refresh runs, and are refused without it.
+
+An entry is a sensor **and** a measurement, not a sensor alone: one
+writing both a temperature and a pressure is listed once for each, which
+is how the readings themselves are stored.
 
 A refresh is a union too — it never drops what the window did not cover,
 since that would delete exactly the silence worth keeping. `--forget` is
@@ -386,8 +395,11 @@ removed a sensor that is still listed.
 The cache lives at `$XDG_CACHE_HOME/labmon/sensors.json` (usually
 `~/.cache/labmon/sensors.json`) — beside other caches rather than in the
 configuration directory, because it is derived data that can be deleted
-at any moment without losing a setting. It is indented JSON, so it can
-be read and edited by hand.
+at any moment without losing a setting. It is an indented JSON list, so
+it can be read and edited by hand, and it is written through a temporary
+file and moved into place: a half-written roster would read as empty,
+and what that heals to is the loss of every quiet sensor it exists to
+remember.
 
 ## Tab completion
 

--- a/src/labmon/cli/commands/query.py
+++ b/src/labmon/cli/commands/query.py
@@ -57,11 +57,20 @@ def query(
 
     configure(log_level)
     if latest:
-        table, _window = selection.read_latest(measurement, sensor_id, since, until)
+        table, silent = selection.read_latest_with_roster(
+            measurement, sensor_id, since, until
+        )
         # Colour only where something will interpret it. Piping this into
         # a file should leave escape codes out of the file, and `isatty`
         # is what answers that without guessing at the terminal.
-        print(render_latest(table, now=datetime.now(UTC), colour=sys.stdout.isatty()))
+        print(
+            render_latest(
+                table,
+                now=datetime.now(UTC),
+                colour=sys.stdout.isatty(),
+                silent=silent,
+            )
+        )
         return
     table, _window = selection.read(measurement, sensor_id, since, until)
     print(render(table, limit=limit))

--- a/src/labmon/cli/commands/query.py
+++ b/src/labmon/cli/commands/query.py
@@ -23,15 +23,6 @@ HELP = (
     + "    labmon query --since 1h --limit 0"
 )
 
-Latest = Annotated[
-    bool,
-    typer.Option(
-        "--latest",
-        help="One row per sensor: its most recent reading, and how long ago"
-        + " it arrived",
-    ),
-]
-
 Limit = Annotated[
     int,
     typer.Option(
@@ -43,34 +34,68 @@ Limit = Annotated[
 
 
 def query(
+    ctx: typer.Context,
     measurement: Measurements = None,
     sensor_id: SensorIds = None,
     since: Since = "1h",
     until: Until = None,
-    latest: Latest = False,
     limit: Limit = DEFAULT_LIMIT,
     log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
 ) -> None:
     """Print recorded readings as a table."""
+    if ctx.invoked_subcommand is not None:
+        # This runs as the group's callback so that a bare `labmon query`
+        # keeps working, which means it is also called on the way to a
+        # subcommand. Without this, `labmon query latest` would run both
+        # and print two tables.
+        return
+
+    configure(log_level)
+    table, _window = selection.read(measurement, sensor_id, since, until)
+    print(render(table, limit=limit))
+
+
+LATEST_HELP = (
+    "One row per sensor: its most recent reading, and how long ago it"
+    + " arrived."
+    + "\n\n"
+    + "The [bold]age[/bold] column is as much the point as the value. A"
+    + " sensor that stopped writing an hour ago still has a most recent"
+    + " reading, and it looks healthy until you can see when it arrived."
+    + " A sensor silent for longer than [bold]--since[/bold] has no row"
+    + " at all, so the ones labmon has seen before are remembered and"
+    + " shown with no value — see [bold]labmon sensors[/bold]."
+    + "\n\n"
+    + "[bold]Examples[/bold]\n\n"
+    + "    labmon query latest\n"
+    + "    labmon query latest --measurement temperature\n"
+    + "    labmon query latest --sensor-id cryo-77k --sensor-id room-1"
+)
+
+
+def latest(
+    measurement: Measurements = None,
+    sensor_id: SensorIds = None,
+    since: Since = "1h",
+    until: Until = None,
+    log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
+) -> None:
+    """One row per sensor: its most recent reading, and how long ago."""
     import sys
     from datetime import UTC, datetime
 
     configure(log_level)
-    if latest:
-        table, silent = selection.read_latest_with_roster(
-            measurement, sensor_id, since, until
+    table, silent = selection.read_latest_with_roster(
+        measurement, sensor_id, since, until
+    )
+    # Colour only where something will interpret it. Piping this into a
+    # file should leave escape codes out of the file, and `isatty` is
+    # what answers that without guessing at the terminal.
+    print(
+        render_latest(
+            table,
+            now=datetime.now(UTC),
+            colour=sys.stdout.isatty(),
+            silent=silent,
         )
-        # Colour only where something will interpret it. Piping this into
-        # a file should leave escape codes out of the file, and `isatty`
-        # is what answers that without guessing at the terminal.
-        print(
-            render_latest(
-                table,
-                now=datetime.now(UTC),
-                colour=sys.stdout.isatty(),
-                silent=silent,
-            )
-        )
-        return
-    table, _window = selection.read(measurement, sensor_id, since, until)
-    print(render(table, limit=limit))
+    )

--- a/src/labmon/cli/commands/sensors.py
+++ b/src/labmon/cli/commands/sensors.py
@@ -1,0 +1,106 @@
+"""`labmon sensors` — what labmon remembers, and how to correct it."""
+
+from typing import Annotated
+
+import typer
+
+from labmon.cli.options import LogLevelOption, Measurements, SensorIds, Since, Until
+from labmon.cli.runtime import configure
+
+HELP = (
+    "List the sensors labmon knows about."
+    + "\n\n"
+    + "The list is a cache, because a sensor that has gone quiet is the"
+    + " one worth finding and a query alone cannot show it: silent for"
+    + " longer than the window asked about, it has no row to be stale and"
+    + " simply vanishes. The [bold]source[/bold] column says whether a"
+    + " sensor is reporting now or is only remembered."
+    + "\n\n"
+    + "[bold]Examples[/bold]\n\n"
+    + "    labmon sensors\n"
+    + "    labmon sensors --refresh\n"
+    + "    labmon sensors --refresh --since 1w\n"
+    + "    labmon sensors --forget old-probe"
+)
+
+Refresh = Annotated[
+    bool,
+    typer.Option(
+        "--refresh",
+        help="Ask the database which sensors have reported, and remember them",
+    ),
+]
+
+Forget = Annotated[
+    str | None,
+    typer.Option(
+        "--forget",
+        help="Drop one sensor from the list, for an instrument that is gone",
+        metavar="SENSOR_ID",
+        show_default=False,
+    ),
+]
+
+
+def sensors(
+    refresh: Refresh = False,
+    forget: Forget = None,
+    measurement: Measurements = None,
+    sensor_id: SensorIds = None,
+    since: Since = "24h",
+    until: Until = None,
+    log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
+) -> None:
+    """List the sensors labmon knows about."""
+    import sys
+    from datetime import UTC, datetime
+
+    from labmon.cli import selection
+    from labmon.cli.render import render_roster
+    from labmon.cli.roster import cache_path, load, save
+    from labmon.cli.roster import forget as drop
+
+    configure(log_level)
+    path = cache_path()
+
+    if forget is not None and refresh:
+        # A refresh would re-add whatever was just forgotten if it still
+        # reports, so the two together have no coherent meaning.
+        raise typer.BadParameter("--forget cannot be combined with --refresh")
+
+    if forget is not None:
+        known = load(path)
+        try:
+            remaining = drop(known, forget)
+        except KeyError:
+            raise typer.BadParameter(
+                f"no sensor named {forget!r} is remembered", param_hint="--forget"
+            ) from None
+        save(path, remaining)
+        print(f"forgot {forget}")
+        return
+
+    live: set[str] = set()
+    if refresh:
+        table, _silent = selection.read_latest_with_roster(
+            measurement, sensor_id, since, until
+        )
+        live = {str(name) for name in table.column("sensor_id").to_pylist()}
+        # read_latest_with_roster has already merged and saved; reloading
+        # rather than rebuilding keeps one writer for the file.
+        known = load(path)
+    else:
+        known = load(path)
+
+    if not known:
+        print(
+            "nothing remembered yet — run `labmon sensors --refresh`"
+            + " to ask the database"
+        )
+        return
+
+    print(
+        render_roster(
+            known, live=live, now=datetime.now(UTC), colour=sys.stdout.isatty()
+        )
+    )

--- a/src/labmon/cli/commands/sensors.py
+++ b/src/labmon/cli/commands/sensors.py
@@ -1,11 +1,18 @@
 """`labmon sensors` — what labmon remembers, and how to correct it."""
 
+import logging
 from typing import Annotated
 
 import typer
 
 from labmon.cli.options import LogLevelOption, Measurements, SensorIds, Since, Until
 from labmon.cli.runtime import configure
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# The window a refresh covers, and the one a forgotten sensor is
+# checked against, so the two agree on what "recently" means.
+DEFAULT_WINDOW = "24h"
 
 HELP = (
     "List the sensors labmon knows about."
@@ -78,6 +85,7 @@ def sensors(
             ) from None
         save(path, remaining)
         print(f"forgot {forget}")
+        _say_if_still_reporting(forget)
         return
 
     if not refresh and (since is not None or until is not None):
@@ -92,7 +100,7 @@ def sensors(
     live: set[tuple[str, str]] | None = None
     if refresh:
         table, _silent = selection.read_latest_with_roster(
-            measurement, sensor_id, since or "24h", until
+            measurement, sensor_id, since or DEFAULT_WINDOW, until
         )
         live = set(
             zip(
@@ -128,4 +136,42 @@ def sensors(
         render_roster(
             known, live=live, now=datetime.now(UTC), colour=sys.stdout.isatty()
         )
+    )
+
+
+def _say_if_still_reporting(sensor_id: str) -> None:
+    """Say so when the database still holds readings for a forgotten sensor.
+
+    Forgetting edits the cache, and the cache may only ever add — so a
+    sensor that is still writing will be found by the next query and
+    remembered again. `forgot X` on its own reads as "it is gone", which
+    for a sensor still reporting it is not.
+
+    Best-effort, and deliberately silent when it cannot run: the roster
+    has already been written, and a database that is unreachable is no
+    reason to fail a command that has finished its work. The condition
+    it reports on cannot exist if there is no database to report it.
+    """
+    from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
+
+    from labmon.cli import selection
+    from labmon.export.query import QueryError
+
+    try:
+        still = selection.reporting_measurements(sensor_id, DEFAULT_WINDOW)
+    except (InfluxDB3ClientError, QueryError, OSError, KeyError) as error:
+        # The same failures `labmon.cli.runtime` turns into exit codes —
+        # a server that is down or refusing the token, a query it will
+        # not answer, `INFLUXDB3_AUTH_TOKEN` unset — none of which say
+        # anything about a sensor.
+        logger.debug(
+            "could not check for recent readings", extra={"reason": str(error)}
+        )
+        return
+    if not still:
+        return
+    print(
+        f"it still has readings in {', '.join(still)} from the last"
+        + f" {DEFAULT_WINDOW}, so a query over that window will find it"
+        + " and remember it again until they age out"
     )

--- a/src/labmon/cli/commands/sensors.py
+++ b/src/labmon/cli/commands/sensors.py
@@ -47,7 +47,7 @@ def sensors(
     forget: Forget = None,
     measurement: Measurements = None,
     sensor_id: SensorIds = None,
-    since: Since = "24h",
+    since: Since | None = None,
     until: Until = None,
     log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
 ) -> None:
@@ -80,17 +80,42 @@ def sensors(
         print(f"forgot {forget}")
         return
 
-    live: set[str] = set()
+    if not refresh and (since is not None or until is not None):
+        # A window only bounds the query a refresh runs. Accepting it for
+        # a plain listing would let somebody believe it had narrowed
+        # something.
+        raise typer.BadParameter(
+            "--since and --until apply to --refresh; a plain listing reads"
+            + " only the remembered list"
+        )
+
+    live: set[tuple[str, str]] | None = None
     if refresh:
         table, _silent = selection.read_latest_with_roster(
-            measurement, sensor_id, since, until
+            measurement, sensor_id, since or "24h", until
         )
-        live = {str(name) for name in table.column("sensor_id").to_pylist()}
-        # read_latest_with_roster has already merged and saved; reloading
-        # rather than rebuilding keeps one writer for the file.
-        known = load(path)
-    else:
-        known = load(path)
+        live = set(
+            zip(
+                (str(name) for name in table.column("sensor_id").to_pylist()),
+                (str(name) for name in table.column("measurement").to_pylist()),
+                strict=True,
+            )
+        )
+    # read_latest_with_roster has already merged and saved; reloading
+    # rather than rebuilding keeps one writer for the file.
+    known = load(path)
+
+    # `--measurement` and `--sensor-id` describe a roster entry, so they
+    # narrow a plain listing too rather than being quietly ignored.
+    wanted_sensors = set(sensor_id or ())
+    wanted_measurements = set(measurement or ())
+    if wanted_sensors or wanted_measurements:
+        known = {
+            key: entry
+            for key, entry in known.items()
+            if (not wanted_sensors or entry.sensor_id in wanted_sensors)
+            and (not wanted_measurements or entry.measurement in wanted_measurements)
+        }
 
     if not known:
         print(

--- a/src/labmon/cli/main.py
+++ b/src/labmon/cli/main.py
@@ -48,7 +48,20 @@ def build_app() -> typer.Typer:
         # rather than start a sensor with every default.
         context_settings={"help_option_names": ["-h", "--help"]},
     )
-    _ = app.command("query", help=query_command.HELP)(reporting(query_command.query))
+    # `query` keeps its own behaviour when invoked bare — the log-style
+    # table is what it has always meant — and gains subcommands for the
+    # other questions worth asking of recorded readings.
+    query_app = typer.Typer(
+        help=query_command.HELP,
+        rich_markup_mode="rich",
+        invoke_without_command=True,
+        context_settings={"help_option_names": ["-h", "--help"]},
+    )
+    _ = query_app.callback(invoke_without_command=True)(reporting(query_command.query))
+    _ = query_app.command("latest", help=query_command.LATEST_HELP)(
+        reporting(query_command.latest)
+    )
+    app.add_typer(query_app, name="query")
     _ = app.command("sensors", help=sensors_command.HELP)(
         reporting(sensors_command.sensors)
     )

--- a/src/labmon/cli/main.py
+++ b/src/labmon/cli/main.py
@@ -15,6 +15,7 @@ import typer
 from labmon.cli.commands import export as export_command
 from labmon.cli.commands import mock_sensor as mock_sensor_command
 from labmon.cli.commands import query as query_command
+from labmon.cli.commands import sensors as sensors_command
 from labmon.cli.commands import serial_sensor as serial_sensor_command
 from labmon.cli.runtime import reporting
 
@@ -48,6 +49,9 @@ def build_app() -> typer.Typer:
         context_settings={"help_option_names": ["-h", "--help"]},
     )
     _ = app.command("query", help=query_command.HELP)(reporting(query_command.query))
+    _ = app.command("sensors", help=sensors_command.HELP)(
+        reporting(sensors_command.sensors)
+    )
     _ = app.command("export", help=export_command.HELP)(
         reporting(export_command.export)
     )

--- a/src/labmon/cli/quantity.py
+++ b/src/labmon/cli/quantity.py
@@ -1,0 +1,75 @@
+"""Showing a reading at a magnitude a person can read.
+
+A column of readings stops being readable at two places: when there are
+more than three digits ahead of the decimal point, and when zeros crowd
+in behind it. `276561300200000.0` and `0.00000068` both have to be
+counted rather than read, and counting is exactly what a glance cannot
+do.
+
+Scientific notation rather than an SI prefix, deliberately. Rescaling
+`Hz` to `THz` is the prettiest answer for a wavemeter and the wrong one
+almost everywhere else in a lab: `mbar` already carries a prefix, so
+"choose the right prefix" turns a vacuum reading into picobar, which is
+correct and unreadable to anybody who works with vacuum. `°C` is an
+offset unit and cannot be scaled at all — `pint` raises rather than
+guess. Scientific notation touches neither the unit nor the physics, so
+it works for every quantity a sensor writes.
+
+A per-sensor prefix, chosen rather than inferred, is the better answer
+for the cases where a prefix is wanted. That is a display preference,
+and it belongs in the configuration file rather than in a rule applied
+to every reading alike.
+
+Imports nothing, so naming a boundary as a CLI option default costs no
+startup time.
+"""
+
+import math
+
+# Below this, zeros crowd in after the point: 0.00023 has to be counted.
+PLAIN_FROM = 1e-3
+
+# From this up, more than three digits sit ahead of the point, which is
+# the same problem at the other end: 1234.0 has to be counted too.
+PLAIN_BELOW = 1e3
+
+# A float needs at most 17 significant digits to survive a round trip.
+_MAX_DIGITS = 17
+
+
+def show(value: float) -> str:
+    """`value` as text, plain where that reads well and scientific where
+    it does not.
+
+    Nothing is rounded away in either form. Sensors already round to the
+    resolution they claim, so a display that dropped digits would be
+    hiding what was actually recorded — the shortest form that still
+    reads back as the same float is used instead.
+    """
+    if not math.isfinite(value):
+        # nan and inf have no magnitude to judge, and both print fine.
+        return repr(value)
+
+    magnitude = abs(value)
+    if magnitude == 0.0 or PLAIN_FROM <= magnitude < PLAIN_BELOW:
+        return repr(value)
+    return _scientific(value)
+
+
+def _scientific(value: float) -> str:
+    """The shortest scientific form that reads back as `value`.
+
+    `f"{value:e}"` fixes six digits, which both truncates a long reading
+    and pads a short one — `1.5e-7` would print as `1.500000e-07`.
+    Growing the precision until the text parses back to the same float
+    gives the shortest honest answer instead.
+    """
+    text = ""
+    for digits in range(_MAX_DIGITS):
+        text = f"{value:.{digits}e}"
+        if float(text) == value:
+            break
+    # The loop always leaves `text` set, and its last attempt carries 17
+    # significant digits — which round-trips any float there is, so the
+    # break is reached for every real value rather than fallen past.
+    return text

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -5,13 +5,16 @@ every column and full precision so nothing is lost, while a terminal
 wants the few columns that carry meaning, aligned, in a width that fits.
 """
 
-from datetime import UTC, datetime
+from collections.abc import Container, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, cast
 
 from labmon.cli.age import Freshness, describe, freshness
 
 if TYPE_CHECKING:
     import pyarrow as pa
+
+    from labmon.cli.roster import Known
 
 # Columns worth a terminal's width, in reading order. `calibration_id` and
 # `input_volts` are deliberately absent: they are provenance, they are in
@@ -128,7 +131,13 @@ _STYLES: dict[Freshness, str] = {
 _RESET = "\x1b[0m"
 
 
-def render_latest(table: "pa.Table", now: datetime, *, colour: bool = False) -> str:
+def render_latest(
+    table: "pa.Table",
+    now: datetime,
+    *,
+    colour: bool = False,
+    silent: "Sequence[Known]" = (),
+) -> str:
     """One row per sensor, oldest last, with how long ago it reported.
 
     Sorted by age rather than by name, ascending, so the sensor that has
@@ -139,26 +148,41 @@ def render_latest(table: "pa.Table", now: datetime, *, colour: bool = False) -> 
     toward `len`, so a cell coloured first pads to fewer visible
     characters than its neighbours and silently shortens its column.
     """
-    total = table.num_rows
+    total = table.num_rows + len(silent)
     if total == 0:
         return "no readings matched"
 
     columns = {name: table.column(name).to_pylist() for name in table.column_names}
     ages = [now - _as_datetime(stamp) for stamp in columns["time"]]
-    order = sorted(range(total), key=lambda index: ages[index])
+    # Over the live rows only: `total` counts the silent sensors too, and
+    # those carry their age from the roster rather than from this table.
+    order = sorted(range(table.num_rows), key=lambda index: ages[index])
 
     present = [name for name in LATEST_COLUMNS if name == "age" or name in columns]
-    rows: list[list[str]] = []
-    styles: list[str] = []
+    entries: list[tuple[timedelta, list[str]]] = []
     for index in order:
-        cells = [
-            describe(ages[index])
-            if name == "age"
-            else _cell(name, columns[name][index])
-            for name in present
-        ]
-        rows.append(cells)
-        styles.append(_STYLES[freshness(ages[index])] if colour else "")
+        entries.append(
+            (
+                ages[index],
+                [
+                    describe(ages[index])
+                    if name == "age"
+                    else _cell(name, columns[name][index])
+                    for name in present
+                ],
+            )
+        )
+    # Sensors the query returned nothing for, carried in from the roster.
+    # Their value column is left blank rather than filled with the last
+    # reading they ever sent: printed beside a fresh number from another
+    # sensor, an old one reads as current.
+    for entry in silent:
+        age = now - entry.last_seen
+        entries.append((age, [_silent_cell(name, entry, age) for name in present]))
+
+    entries.sort(key=lambda item: item[0])
+    rows = [cells for _, cells in entries]
+    styles = [_STYLES[freshness(age)] if colour else "" for age, _ in entries]
 
     widths = [
         max(len(name), *(len(row[position]) for row in rows))
@@ -179,7 +203,27 @@ def render_latest(table: "pa.Table", now: datetime, *, colour: bool = False) -> 
 
     lines.append("")
     lines.append(f"{total} sensor{'s' if total != 1 else ''}")
+    if silent:
+        quiet = len(silent)
+        lines.append(
+            f"{quiet} of them reported nothing in this window"
+            + " — remembered from a previous run"
+        )
     return "\n".join(lines)
+
+
+def _silent_cell(name: str, entry: "Known", age: timedelta) -> str:
+    """One cell for a sensor the query returned no reading for."""
+    if name == "age":
+        return describe(age)
+    if name == "sensor_id":
+        return entry.sensor_id
+    if name == "measurement":
+        return entry.measurement
+    if name == "unit":
+        return entry.unit
+    # `value` and anything else: nothing was read, so nothing is shown.
+    return ""
 
 
 def _as_datetime(stamp: object) -> datetime:
@@ -191,3 +235,59 @@ def _as_datetime(stamp: object) -> datetime:
     """
     moment = cast(datetime, stamp)
     return moment if moment.tzinfo else moment.replace(tzinfo=UTC)
+
+
+ROSTER_COLUMNS: tuple[str, ...] = ("sensor_id", "measurement", "unit", "age", "source")
+
+
+def render_roster(
+    known: "Mapping[str, Known]",
+    *,
+    live: "Container[str]",
+    now: datetime,
+    colour: bool = False,
+) -> str:
+    """The remembered sensors, oldest last, saying which are reporting.
+
+    The `source` column is what earns this view its place: it states
+    whether a sensor is reporting now or is only remembered, which makes
+    the union rule visible instead of magic.
+    """
+    if not known:
+        return "nothing remembered yet"
+
+    entries = sorted(known.values(), key=lambda entry: now - entry.last_seen)
+    rows = [
+        [
+            entry.sensor_id,
+            entry.measurement,
+            entry.unit,
+            describe(now - entry.last_seen),
+            "live" if entry.sensor_id in live else "cached",
+        ]
+        for entry in entries
+    ]
+    styles = [
+        _STYLES[freshness(now - entry.last_seen)] if colour else "" for entry in entries
+    ]
+
+    widths = [
+        max(len(name), *(len(row[position]) for row in rows))
+        for position, name in enumerate(ROSTER_COLUMNS)
+    ]
+    lines = [
+        "  ".join(
+            name.ljust(width)
+            for name, width in zip(ROSTER_COLUMNS, widths, strict=True)
+        ),
+        "  ".join("-" * width for width in widths),
+    ]
+    for row, style in zip(rows, styles, strict=True):
+        padded = "  ".join(
+            cell.ljust(width) for cell, width in zip(row, widths, strict=True)
+        ).rstrip()
+        lines.append(f"{style}{padded}{_RESET}" if style else padded)
+
+    lines.append("")
+    lines.append(f"{len(entries)} sensor{'s' if len(entries) != 1 else ''}")
+    return "\n".join(lines)

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -241,9 +241,9 @@ ROSTER_COLUMNS: tuple[str, ...] = ("sensor_id", "measurement", "unit", "age", "s
 
 
 def render_roster(
-    known: "Mapping[str, Known]",
+    known: "Mapping[tuple[str, str], Known]",
     *,
-    live: "Container[str]",
+    live: "Container[tuple[str, str]] | None",
     now: datetime,
     colour: bool = False,
 ) -> str:
@@ -252,18 +252,24 @@ def render_roster(
     The `source` column is what earns this view its place: it states
     whether a sensor is reporting now or is only remembered, which makes
     the union rule visible instead of magic.
+
+    It appears only when `live` is known — that is, when the database was
+    actually asked. A plain listing touches nothing, so the column could
+    only ever read "cached", including beside a sensor reporting at that
+    moment. Omitting it beats printing one that misleads.
     """
     if not known:
         return "nothing remembered yet"
 
     entries = sorted(known.values(), key=lambda entry: now - entry.last_seen)
+    names = ROSTER_COLUMNS if live is not None else ROSTER_COLUMNS[:-1]
     rows = [
         [
             entry.sensor_id,
             entry.measurement,
             entry.unit,
             describe(now - entry.last_seen),
-            "live" if entry.sensor_id in live else "cached",
+            *(["live" if entry.key in live else "cached"] if live is not None else []),
         ]
         for entry in entries
     ]
@@ -273,13 +279,10 @@ def render_roster(
 
     widths = [
         max(len(name), *(len(row[position]) for row in rows))
-        for position, name in enumerate(ROSTER_COLUMNS)
+        for position, name in enumerate(names)
     ]
     lines = [
-        "  ".join(
-            name.ljust(width)
-            for name, width in zip(ROSTER_COLUMNS, widths, strict=True)
-        ),
+        "  ".join(name.ljust(width) for name, width in zip(names, widths, strict=True)),
         "  ".join("-" * width for width in widths),
     ]
     for row, style in zip(rows, styles, strict=True):

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, cast
 
 from labmon.cli.age import Freshness, describe, freshness
+from labmon.cli.quantity import show
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -30,6 +31,11 @@ PREFERRED_COLUMNS: tuple[str, ...] = (
 # Rows shown when --limit is not given. Enough to see a trend, few enough
 # that a stray `labmon query` over a week does not fill the scrollback.
 DEFAULT_LIMIT = 20
+
+# Columns holding a measured quantity, shown at a readable magnitude.
+# `input_volts` is here for the export-shaped tables that carry it, even
+# though the terminal views leave it out.
+_NUMERIC_COLUMNS: frozenset[str] = frozenset({"value", "input_volts"})
 
 
 def _is_all_null(column: "pa.ChunkedArray") -> bool:
@@ -62,11 +68,10 @@ def _cell(name: str, value: object) -> str:
         # so the slice cut into the offset instead of the digits — and
         # a whole second is what a sensor on a 1 Hz grid reports.
         return value.replace(tzinfo=None).isoformat(sep=" ", timespec="milliseconds")
-    if name == "value" and isinstance(value, float):
-        # `repr` rather than a fixed precision: sensors already round to
-        # the resolution they claim, so this shows exactly what was
-        # stored rather than inventing or hiding digits.
-        return repr(value)
+    if name in _NUMERIC_COLUMNS and isinstance(value, float):
+        # Plain where a decimal reads well, scientific where it does not,
+        # and nothing rounded away in either — see `labmon.cli.quantity`.
+        return show(value)
     return str(value)
 
 

--- a/src/labmon/cli/roster.py
+++ b/src/labmon/cli/roster.py
@@ -35,12 +35,24 @@ CACHE_NAME = "sensors.json"
 
 @dataclass(frozen=True)
 class Known:
-    """One sensor the roster remembers, and when it was last heard from."""
+    """One sensor the roster remembers, and when it was last heard from.
+
+    Identified by sensor *and* measurement, because a sensor may write
+    to more than one table and `fetch_latest` returns a row for each
+    pair. Keying on the sensor alone kept whichever arrived last, and
+    the row order of a UNION is not defined — so which survived was
+    arbitrary.
+    """
 
     sensor_id: str
     measurement: str
     unit: str
     last_seen: datetime
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """What identifies this entry in the roster."""
+        return (self.sensor_id, self.measurement)
 
 
 def cache_path() -> Path:
@@ -50,7 +62,7 @@ def cache_path() -> Path:
     return root / "labmon" / CACHE_NAME
 
 
-def load(path: Path) -> dict[str, Known]:
+def load(path: Path) -> dict[tuple[str, str], Known]:
     """Read the roster, treating anything unreadable as empty.
 
     A cache is rebuildable by definition, so a truncated or hand-edited
@@ -62,16 +74,16 @@ def load(path: Path) -> dict[str, Known]:
     except (OSError, ValueError):
         logger.debug("no usable roster cache", extra={"path": str(path)})
         return {}
-    if not isinstance(parsed, dict):
+    if not isinstance(parsed, list):
         return {}
 
-    known: dict[str, Known] = {}
-    for sensor, entry in cast(dict[str, object], parsed).items():
+    known: dict[tuple[str, str], Known] = {}
+    for entry in cast(list[object], parsed):
         if not isinstance(entry, dict):
             continue
         fields = cast(dict[str, object], entry)
         try:
-            known[str(sensor)] = Known(
+            found = Known(
                 sensor_id=str(fields["sensor_id"]),
                 measurement=str(fields["measurement"]),
                 unit=str(fields["unit"]),
@@ -79,30 +91,48 @@ def load(path: Path) -> dict[str, Known]:
             )
         except (KeyError, ValueError):
             continue
+        known[found.key] = found
     return known
 
 
-def save(path: Path, known: Mapping[str, Known]) -> None:
+def save(path: Path, known: Mapping[tuple[str, str], Known]) -> None:
     """Write the roster, creating its directory if need be.
 
-    Indented rather than compact: somebody should be able to open it,
-    see what is remembered and delete a line.
+    A list rather than an object, since an entry is identified by two
+    fields and a composite key would only be readable by splitting it.
+    Indented rather than compact: somebody should be able to open this,
+    see what is remembered, and delete an entry.
+
+    Written to a neighbouring temporary file and moved into place. A
+    crash midway through a direct write leaves a truncated file, which
+    `load` correctly treats as empty — self-healing, except that what it
+    heals to is an empty roster, discarding exactly the memory of quiet
+    sensors this exists to keep. `os.replace` is atomic within a
+    filesystem, so a reader sees either the old roster or the new one.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        sensor: {
+    payload = [
+        {
             "sensor_id": entry.sensor_id,
             "measurement": entry.measurement,
             "unit": entry.unit,
             "last_seen": entry.last_seen.astimezone(UTC).isoformat(),
         }
-        for sensor, entry in known.items()
-    }
-    _ = path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        for entry in sorted(known.values(), key=lambda item: item.key)
+    ]
+    scratch = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        _ = scratch.write_text(json.dumps(payload, indent=2) + "\n")
+        os.replace(scratch, path)
+    except OSError:
+        scratch.unlink(missing_ok=True)
+        raise
     logger.debug("wrote roster cache", extra={"sensors": len(payload)})
 
 
-def merge(cached: Mapping[str, Known], live: Iterable[Known]) -> dict[str, Known]:
+def merge(
+    cached: Mapping[tuple[str, str], Known], live: Iterable[Known]
+) -> dict[tuple[str, str], Known]:
     """Everything the cache knows, updated by everything just seen.
 
     A union, never a replacement — see the module docstring. A live
@@ -112,17 +142,25 @@ def merge(cached: Mapping[str, Known], live: Iterable[Known]) -> dict[str, Known
     """
     merged = dict(cached)
     for entry in live:
-        merged[entry.sensor_id] = entry
+        merged[entry.key] = entry
     return merged
 
 
-def forget(cached: Mapping[str, Known], sensor_id: str) -> dict[str, Known]:
-    """The roster without `sensor_id`, for one that is genuinely gone.
+def forget(
+    cached: Mapping[tuple[str, str], Known], sensor_id: str
+) -> dict[tuple[str, str], Known]:
+    """The roster without `sensor_id`, for an instrument that is gone.
+
+    Every measurement it wrote to goes with it: the thing being removed
+    is a sensor, not one of the tables it happened to appear in.
 
     Raises `KeyError` when it was never there: silently succeeding would
     leave somebody believing they had removed a sensor that is still
     listed under a name they mistyped.
     """
-    if sensor_id not in cached:
+    remaining = {
+        key: entry for key, entry in cached.items() if entry.sensor_id != sensor_id
+    }
+    if len(remaining) == len(cached):
         raise KeyError(sensor_id)
-    return {name: entry for name, entry in cached.items() if name != sensor_id}
+    return remaining

--- a/src/labmon/cli/roster.py
+++ b/src/labmon/cli/roster.py
@@ -1,0 +1,128 @@
+"""The remembered list of sensors labmon has seen.
+
+Derived data, kept beside other caches rather than in the config
+directory: it can be deleted at any moment without losing a setting, and
+rebuilding it costs one query.
+
+It exists for one reason. A sensor silent for longer than the window
+being asked about has no row in the result, so it has nothing to be
+stale — it simply vanishes, which is the worst possible failure for a
+view whose job is spotting silence. The cache is what remembers it.
+
+That gives the rule the rest of the CLI has to honour: **the cache may
+only add sensors, never replace or filter them.** Used as a union, a
+stale cache is harmless. Used as a substitute, it acquires its own
+silent failure, hiding a newly added sensor until somebody remembers to
+rebuild.
+
+Imports nothing heavy, so reaching for the roster does not pull the
+database client into a path that has no use for it.
+"""
+
+import json
+import logging
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+CACHE_NAME = "sensors.json"
+
+
+@dataclass(frozen=True)
+class Known:
+    """One sensor the roster remembers, and when it was last heard from."""
+
+    sensor_id: str
+    measurement: str
+    unit: str
+    last_seen: datetime
+
+
+def cache_path() -> Path:
+    """Where the roster lives, honouring `XDG_CACHE_HOME`."""
+    base = os.environ.get("XDG_CACHE_HOME")
+    root = Path(base) if base else Path(os.path.expanduser("~")) / ".cache"
+    return root / "labmon" / CACHE_NAME
+
+
+def load(path: Path) -> dict[str, Known]:
+    """Read the roster, treating anything unreadable as empty.
+
+    A cache is rebuildable by definition, so a truncated or hand-edited
+    file is a reason to start again rather than a reason to refuse to
+    run.
+    """
+    try:
+        parsed = cast(object, json.loads(path.read_text()))
+    except (OSError, ValueError):
+        logger.debug("no usable roster cache", extra={"path": str(path)})
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+
+    known: dict[str, Known] = {}
+    for sensor, entry in cast(dict[str, object], parsed).items():
+        if not isinstance(entry, dict):
+            continue
+        fields = cast(dict[str, object], entry)
+        try:
+            known[str(sensor)] = Known(
+                sensor_id=str(fields["sensor_id"]),
+                measurement=str(fields["measurement"]),
+                unit=str(fields["unit"]),
+                last_seen=datetime.fromisoformat(str(fields["last_seen"])),
+            )
+        except (KeyError, ValueError):
+            continue
+    return known
+
+
+def save(path: Path, known: Mapping[str, Known]) -> None:
+    """Write the roster, creating its directory if need be.
+
+    Indented rather than compact: somebody should be able to open it,
+    see what is remembered and delete a line.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        sensor: {
+            "sensor_id": entry.sensor_id,
+            "measurement": entry.measurement,
+            "unit": entry.unit,
+            "last_seen": entry.last_seen.astimezone(UTC).isoformat(),
+        }
+        for sensor, entry in known.items()
+    }
+    _ = path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    logger.debug("wrote roster cache", extra={"sensors": len(payload)})
+
+
+def merge(cached: Mapping[str, Known], live: Iterable[Known]) -> dict[str, Known]:
+    """Everything the cache knows, updated by everything just seen.
+
+    A union, never a replacement — see the module docstring. A live
+    sensor wins over its cached entry because its reading is newer; a
+    cached sensor the query did not return is kept, because that silence
+    is the thing worth showing.
+    """
+    merged = dict(cached)
+    for entry in live:
+        merged[entry.sensor_id] = entry
+    return merged
+
+
+def forget(cached: Mapping[str, Known], sensor_id: str) -> dict[str, Known]:
+    """The roster without `sensor_id`, for one that is genuinely gone.
+
+    Raises `KeyError` when it was never there: silently succeeding would
+    leave somebody believing they had removed a sensor that is still
+    listed under a name they mistyped.
+    """
+    if sensor_id not in cached:
+        raise KeyError(sensor_id)
+    return {name: entry for name, entry in cached.items() if name != sensor_id}

--- a/src/labmon/cli/selection.py
+++ b/src/labmon/cli/selection.py
@@ -163,12 +163,15 @@ def read_latest_with_roster(
     # question nobody asked.
     wanted_sensors = set(sensor_ids or ())
     wanted_measurements = set(measurements or ())
-    seen = {entry.sensor_id for entry in live}
+    # Compared on the same key the roster is stored under — a sensor and
+    # a measurement — so a sensor that reports to two tables can be
+    # current in one and silent in the other.
+    seen = {entry.key for entry in live}
     silent = [
         entry
-        for name, entry in sorted(remembered.items())
-        if name not in seen
-        and (not wanted_sensors or name in wanted_sensors)
+        for key, entry in sorted(remembered.items())
+        if key not in seen
+        and (not wanted_sensors or entry.sensor_id in wanted_sensors)
         and (not wanted_measurements or entry.measurement in wanted_measurements)
     ]
     return table, silent

--- a/src/labmon/cli/selection.py
+++ b/src/labmon/cli/selection.py
@@ -94,6 +94,32 @@ def read_latest(
     return table, window
 
 
+def reporting_measurements(
+    sensor_id: str, since: str, until: str | None = None
+) -> list[str]:
+    """The measurements `sensor_id` still has readings in, in the window.
+
+    Asked after a sensor is dropped from the roster, to say whether the
+    database agrees that it is gone. Runs the same latest-query as
+    everything else, narrowed to the one sensor, so what it reports is
+    exactly what `labmon query latest` would find.
+
+    The rows are checked against the sensor asked for rather than
+    trusted. Naming a sensor that is not the one enquired about would
+    turn this into misinformation, and it is one comparison to be sure.
+    """
+    table, _window = read_latest(None, [sensor_id], since, until)
+    sensors = table.column("sensor_id").to_pylist()
+    measurements = table.column("measurement").to_pylist()
+    return sorted(
+        {
+            str(name)
+            for sensor, name in zip(sensors, measurements, strict=True)
+            if name and str(sensor) == sensor_id
+        }
+    )
+
+
 def known_from(table: "pa.Table") -> "list[Known]":
     """The roster entries a latest-query result describes."""
     from labmon.cli.roster import Known

--- a/src/labmon/cli/selection.py
+++ b/src/labmon/cli/selection.py
@@ -7,11 +7,13 @@ database in subtly different ways.
 
 import logging
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     import pyarrow as pa
 
+    from labmon.cli.roster import Known
     from labmon.export.window import Window
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -90,3 +92,83 @@ def read_latest(
         extra={"sensors": table.num_rows, "measurements": len(resolved)},
     )
     return table, window
+
+
+def known_from(table: "pa.Table") -> "list[Known]":
+    """The roster entries a latest-query result describes."""
+    from labmon.cli.roster import Known
+
+    columns = {name: table.column(name).to_pylist() for name in table.column_names}
+    entries: list[Known] = []
+    for index in range(table.num_rows):
+        sensor = columns["sensor_id"][index]
+        raw = columns["time"][index]
+        if sensor is None or raw is None:
+            continue
+        # `to_pylist` is typed as returning objects; the column is a
+        # timestamp, and a column with no zone is UTC because that is
+        # what the latest query stamps in.
+        stamp = cast(datetime, raw)
+        entries.append(
+            Known(
+                sensor_id=str(sensor),
+                measurement=str(_at(columns, "measurement", index)),
+                unit=str(_at(columns, "unit", index)),
+                last_seen=stamp if stamp.tzinfo else stamp.replace(tzinfo=UTC),
+            )
+        )
+    return entries
+
+
+def _at(columns: "dict[str, list[object]]", name: str, index: int) -> object:
+    """One optional column's value, or an empty string when absent."""
+    values = columns.get(name)
+    if values is None or values[index] is None:
+        return ""
+    return values[index]
+
+
+def read_latest_with_roster(
+    measurements: Sequence[str] | None,
+    sensor_ids: Sequence[str] | None,
+    since: str,
+    until: str | None,
+) -> "tuple[pa.Table, list[Known]]":
+    """The latest readings, plus every sensor the roster remembers.
+
+    The roster is unioned in, never substituted: a cached sensor the
+    query did not return is carried through so it can be shown as
+    silent, and a live sensor the cache had not seen is added to it. A
+    stale cache can therefore only ever add a row, never hide one.
+
+    Narrowing by `--sensor-id` narrows the roster too, so asking about
+    one sensor does not print the rest of the lab.
+    """
+    from labmon.cli.roster import cache_path, load, merge, save
+
+    table, _window = read_latest(measurements, sensor_ids, since, until)
+    live = known_from(table)
+
+    path = cache_path()
+    remembered = merge(load(path), live)
+    try:
+        save(path, remembered)
+    except OSError as error:
+        # A cache that cannot be written is a degraded experience, not a
+        # failed command: everything the query returned is still correct.
+        logger.warning("could not write the roster cache", extra={"reason": str(error)})
+
+    # The roster is narrowed by the same flags as the query. Asking for
+    # temperatures and being shown a silent pressure gauge answers a
+    # question nobody asked.
+    wanted_sensors = set(sensor_ids or ())
+    wanted_measurements = set(measurements or ())
+    seen = {entry.sensor_id for entry in live}
+    silent = [
+        entry
+        for name, entry in sorted(remembered.items())
+        if name not in seen
+        and (not wanted_sensors or name in wanted_sensors)
+        and (not wanted_measurements or entry.measurement in wanted_measurements)
+    ]
+    return table, silent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Fixtures every test in the suite gets.
+
+Kept to isolation rather than convenience: a test that reaches outside
+the repository is a test that changes the machine it runs on.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+# An autouse fixture is called by pytest, never by name, so a checker
+# reasonably reports it as unused.
+@pytest.fixture(autouse=True)
+def _isolated_cache(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Point the roster cache inside the test's own directory.
+
+    `labmon query --latest` remembers the sensors it saw, and without
+    this the suite writes that file into the home directory of whoever
+    runs it — inventing sensors from fixtures, and carrying them between
+    runs. Applied to every test rather than only the ones known to need
+    it, because the next command to reach for the cache should not have
+    to remember.
+    """
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))

--- a/tests/test_cli_quantity.py
+++ b/tests/test_cli_quantity.py
@@ -1,0 +1,63 @@
+"""Showing a reading at a magnitude a person can read."""
+
+import pytest
+
+from labmon.cli.quantity import PLAIN_BELOW, PLAIN_FROM, show
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0.0, "0.0"),
+        (4.2, "4.2"),
+        (20.575, "20.575"),
+        (999.9, "999.9"),
+        (107.39021978021978, "107.39021978021978"),
+        (-3.107, "-3.107"),
+        (0.001, "0.001"),
+    ],
+)
+def test_an_ordinary_magnitude_is_left_alone(value: float, expected: str) -> None:
+    # Between a millilitre and a thousand, a plain decimal reads fine and
+    # rewriting it would only add noise.
+    assert show(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (276561300200000.0, "2.765613002e+14"),
+        (1234.0, "1.234e+03"),
+        (0.000023, "2.3e-05"),
+        (6.84648e-07, "6.84648e-07"),
+        (-1.5e-7, "-1.5e-07"),
+    ],
+)
+def test_an_awkward_magnitude_becomes_scientific(value: float, expected: str) -> None:
+    # More than three digits before the point, or zeros crowding after
+    # it, is where a column of numbers stops being readable.
+    assert show(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [276561300200000.0, 0.000023, 6.84648e-07, 107.39021978021978, 1.5e-7, 4.2],
+)
+def test_nothing_is_rounded_away(value: float) -> None:
+    # Sensors already round to the resolution they claim, so this shows
+    # what was stored rather than inventing or hiding digits.
+    assert float(show(value)) == value
+
+
+def test_the_shortest_form_that_survives_is_the_one_shown() -> None:
+    # 17 significant digits always round-trips and always looks awful.
+    assert show(1.5e-7) == "1.5e-07"
+
+
+def test_a_value_that_is_not_a_number_is_still_printable() -> None:
+    assert show(float("nan")) == "nan"
+    assert show(float("inf")) == "inf"
+
+
+def test_the_boundaries_are_ordered() -> None:
+    assert 0 < PLAIN_FROM < PLAIN_BELOW

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -516,7 +516,7 @@ class LatestClient(FakeClient):
 def test_latest_prints_one_row_per_sensor(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("labmon.influx.get_client", LatestClient)
 
-    result = _run("query", "--latest")
+    result = _run("query", "latest")
 
     assert result.exit_code == 0, result.output
     assert "cryo-77k" in result.output
@@ -528,7 +528,7 @@ def test_latest_reports_how_long_ago_each_sensor_reported(
 ) -> None:
     monkeypatch.setattr("labmon.influx.get_client", LatestClient)
 
-    result = _run("query", "--latest")
+    result = _run("query", "latest")
 
     assert "2s ago" in result.output
     assert "3h ago" in result.output
@@ -540,7 +540,7 @@ def test_latest_puts_the_quietest_sensor_last(
     monkeypatch.setattr("labmon.influx.get_client", LatestClient)
 
     body = [
-        line for line in _run("query", "--latest").output.splitlines() if " ago" in line
+        line for line in _run("query", "latest").output.splitlines() if " ago" in line
     ]
 
     assert body[-1].startswith("abandoned")
@@ -564,7 +564,7 @@ def test_latest_closes_the_client_when_the_query_fails(
 
     monkeypatch.setattr("labmon.influx.get_client", Failing)
 
-    result = _run("query", "--latest")
+    result = _run("query", "latest")
 
     assert result.exit_code != 0
     assert closed == [True]
@@ -621,7 +621,7 @@ def test_a_sensor_silent_beyond_the_window_is_still_listed(
     )
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 
-    result = _run("query", "--latest")
+    result = _run("query", "latest")
 
     assert "abandoned" in result.output
     assert "2d ago" in result.output
@@ -652,7 +652,7 @@ def test_a_silent_sensor_shows_no_value_rather_than_a_stale_one(
 
     line = next(
         line
-        for line in _run("query", "--latest").output.splitlines()
+        for line in _run("query", "latest").output.splitlines()
         if line.startswith("abandoned")
     )
 
@@ -666,7 +666,7 @@ def test_a_live_sensor_is_remembered_for_next_time(
 
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 
-    _ = _run("query", "--latest")
+    _ = _run("query", "latest")
 
     assert ("cryo-77k", "temperature") in load(roster)
 
@@ -713,7 +713,7 @@ def test_an_unwritable_cache_does_not_fail_the_command(
 
     monkeypatch.setattr("labmon.cli.roster.save", refuse)
 
-    result = _run("query", "--latest")
+    result = _run("query", "latest")
 
     assert result.exit_code == 0
     assert "cryo-77k" in result.output
@@ -749,7 +749,39 @@ def test_narrowing_by_measurement_narrows_the_roster_too(
     )
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 
-    output = _run("query", "--latest", "--measurement", "temperature").output
+    output = _run("query", "latest", "--measurement", "temperature").output
 
     assert "old-thermo" in output
     assert "old-gauge" not in output
+
+
+def test_query_still_prints_readings_with_no_subcommand(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `latest` is an addition, not a replacement: the log-style view is
+    # what `labmon query` has always meant and is documented as.
+    monkeypatch.setattr("labmon.influx.get_client", FakeClient)
+
+    result = _run("query", "--since", "1h")
+
+    assert result.exit_code == 0, result.output
+    assert "cryo-77k" in result.output
+
+
+def test_latest_is_a_subcommand_rather_than_a_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A subcommand gets its own help and its own completions, and leaves
+    # room for the other questions worth asking of recorded readings.
+    monkeypatch.setattr("labmon.influx.get_client", LatestClient)
+
+    result = _run("query", "--latest")
+
+    assert result.exit_code != 0
+
+
+def test_query_help_names_its_subcommand() -> None:
+    result = _run("query", "--help")
+
+    assert result.exit_code == 0
+    assert "latest" in result.output

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import override
 
 import pyarrow as pa
@@ -567,3 +568,179 @@ def test_latest_closes_the_client_when_the_query_fails(
 
     assert result.exit_code != 0
     assert closed == [True]
+
+
+class QuietClient(FakeClient):
+    """Returns one live sensor, so a cached one has nothing to match."""
+
+    @override
+    def query(self, query: str, *args: object, **kwargs: object) -> pa.Table:
+        if query.startswith("SELECT '"):
+            return pa.table(
+                {
+                    "measurement": pa.array(["temperature"]),
+                    "sensor_id": pa.array(["cryo-77k"]),
+                    "time": pa.array(
+                        [datetime.now(UTC) - timedelta(seconds=2)],
+                        pa.timestamp("ms", tz="UTC"),
+                    ),
+                    "value": pa.array([77.01]),
+                    "unit": pa.array(["K"]),
+                }
+            )
+        return super().query(query, *args, **kwargs)  # pyright: ignore[reportArgumentType]
+
+
+@pytest.fixture
+def roster(tmp_path: "Path", monkeypatch: pytest.MonkeyPatch) -> "Path":
+    """Point the roster cache somewhere disposable."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path / "labmon" / "sensors.json"
+
+
+def test_a_sensor_silent_beyond_the_window_is_still_listed(
+    monkeypatch: pytest.MonkeyPatch, roster: "Path"
+) -> None:
+    # The whole point of the cache: without it this sensor has no row to
+    # be stale, so it vanishes instead of turning red.
+    from labmon.cli.roster import Known, save
+
+    save(
+        roster,
+        {
+            "abandoned": Known(
+                sensor_id="abandoned",
+                measurement="temperature",
+                unit="K",
+                last_seen=datetime.now(UTC) - timedelta(days=2),
+            )
+        },
+    )
+    monkeypatch.setattr("labmon.influx.get_client", QuietClient)
+
+    result = _run("query", "--latest")
+
+    assert "abandoned" in result.output
+    assert "2d ago" in result.output
+
+
+def test_a_silent_sensor_shows_no_value_rather_than_a_stale_one(
+    monkeypatch: pytest.MonkeyPatch, roster: "Path"
+) -> None:
+    # Printing the last value it ever sent, next to a fresh reading from
+    # another sensor, would read as current.
+    from labmon.cli.roster import Known, save
+
+    save(
+        roster,
+        {
+            "abandoned": Known(
+                sensor_id="abandoned",
+                measurement="temperature",
+                unit="K",
+                last_seen=datetime.now(UTC) - timedelta(days=2),
+            )
+        },
+    )
+    monkeypatch.setattr("labmon.influx.get_client", QuietClient)
+
+    line = next(
+        line
+        for line in _run("query", "--latest").output.splitlines()
+        if line.startswith("abandoned")
+    )
+
+    assert "77.01" not in line
+
+
+def test_a_live_sensor_is_remembered_for_next_time(
+    monkeypatch: pytest.MonkeyPatch, roster: "Path"
+) -> None:
+    from labmon.cli.roster import load
+
+    monkeypatch.setattr("labmon.influx.get_client", QuietClient)
+
+    _ = _run("query", "--latest")
+
+    assert "cryo-77k" in load(roster)
+
+
+def test_a_row_without_a_sensor_is_left_out_of_the_roster() -> None:
+    # A measurement written by something else may carry no sensor id, and
+    # remembering an entry with no name would be remembering nothing.
+    table = pa.table(
+        {
+            "measurement": pa.array(["temperature", "temperature"]),
+            "sensor_id": pa.array(["a", None]),
+            "time": pa.array([datetime.now(UTC), None], pa.timestamp("ms", tz="UTC")),
+            "value": pa.array([1.0, 2.0]),
+            "unit": pa.array(["K", "K"]),
+        }
+    )
+
+    assert [entry.sensor_id for entry in selection.known_from(table)] == ["a"]
+
+
+def test_a_missing_unit_column_is_remembered_as_blank() -> None:
+    table = pa.table(
+        {
+            "sensor_id": pa.array(["a"]),
+            "time": pa.array([datetime.now(UTC)], pa.timestamp("ms", tz="UTC")),
+            "value": pa.array([1.0]),
+        }
+    )
+
+    assert selection.known_from(table)[0].unit == ""
+
+
+def test_an_unwritable_cache_does_not_fail_the_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Everything the query returned is still correct; refusing to print
+    # it because a derived file could not be written would be the wrong
+    # trade.
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr("labmon.influx.get_client", QuietClient)
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("labmon.cli.roster.save", refuse)
+
+    result = _run("query", "--latest")
+
+    assert result.exit_code == 0
+    assert "cryo-77k" in result.output
+
+
+def test_narrowing_by_measurement_narrows_the_roster_too(
+    monkeypatch: pytest.MonkeyPatch, roster: Path
+) -> None:
+    # Asking for temperatures and being shown a silent pressure gauge is
+    # answering a question that was not asked.
+    from labmon.cli.roster import Known, save
+
+    stale = datetime.now(UTC) - timedelta(days=1)
+    save(
+        roster,
+        {
+            "old-thermo": Known(
+                sensor_id="old-thermo",
+                measurement="temperature",
+                unit="K",
+                last_seen=stale,
+            ),
+            "old-gauge": Known(
+                sensor_id="old-gauge",
+                measurement="pressure",
+                unit="mbar",
+                last_seen=stale,
+            ),
+        },
+    )
+    monkeypatch.setattr("labmon.influx.get_client", QuietClient)
+
+    output = _run("query", "--latest", "--measurement", "temperature").output
+
+    assert "old-thermo" in output
+    assert "old-gauge" not in output

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -603,18 +603,21 @@ def test_a_sensor_silent_beyond_the_window_is_still_listed(
 ) -> None:
     # The whole point of the cache: without it this sensor has no row to
     # be stale, so it vanishes instead of turning red.
-    from labmon.cli.roster import Known, save
+    from labmon.cli.roster import Known, merge, save
 
     save(
         roster,
-        {
-            "abandoned": Known(
-                sensor_id="abandoned",
-                measurement="temperature",
-                unit="K",
-                last_seen=datetime.now(UTC) - timedelta(days=2),
-            )
-        },
+        merge(
+            {},
+            [
+                Known(
+                    sensor_id="abandoned",
+                    measurement="temperature",
+                    unit="K",
+                    last_seen=datetime.now(UTC) - timedelta(days=2),
+                )
+            ],
+        ),
     )
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 
@@ -629,18 +632,21 @@ def test_a_silent_sensor_shows_no_value_rather_than_a_stale_one(
 ) -> None:
     # Printing the last value it ever sent, next to a fresh reading from
     # another sensor, would read as current.
-    from labmon.cli.roster import Known, save
+    from labmon.cli.roster import Known, merge, save
 
     save(
         roster,
-        {
-            "abandoned": Known(
-                sensor_id="abandoned",
-                measurement="temperature",
-                unit="K",
-                last_seen=datetime.now(UTC) - timedelta(days=2),
-            )
-        },
+        merge(
+            {},
+            [
+                Known(
+                    sensor_id="abandoned",
+                    measurement="temperature",
+                    unit="K",
+                    last_seen=datetime.now(UTC) - timedelta(days=2),
+                )
+            ],
+        ),
     )
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 
@@ -662,7 +668,7 @@ def test_a_live_sensor_is_remembered_for_next_time(
 
     _ = _run("query", "--latest")
 
-    assert "cryo-77k" in load(roster)
+    assert ("cryo-77k", "temperature") in load(roster)
 
 
 def test_a_row_without_a_sensor_is_left_out_of_the_roster() -> None:
@@ -718,25 +724,28 @@ def test_narrowing_by_measurement_narrows_the_roster_too(
 ) -> None:
     # Asking for temperatures and being shown a silent pressure gauge is
     # answering a question that was not asked.
-    from labmon.cli.roster import Known, save
+    from labmon.cli.roster import Known, merge, save
 
     stale = datetime.now(UTC) - timedelta(days=1)
     save(
         roster,
-        {
-            "old-thermo": Known(
-                sensor_id="old-thermo",
-                measurement="temperature",
-                unit="K",
-                last_seen=stale,
-            ),
-            "old-gauge": Known(
-                sensor_id="old-gauge",
-                measurement="pressure",
-                unit="mbar",
-                last_seen=stale,
-            ),
-        },
+        merge(
+            {},
+            [
+                Known(
+                    sensor_id="old-thermo",
+                    measurement="temperature",
+                    unit="K",
+                    last_seen=stale,
+                ),
+                Known(
+                    sensor_id="old-gauge",
+                    measurement="pressure",
+                    unit="mbar",
+                    last_seen=stale,
+                ),
+            ],
+        ),
     )
     monkeypatch.setattr("labmon.influx.get_client", QuietClient)
 

--- a/tests/test_cli_roster.py
+++ b/tests/test_cli_roster.py
@@ -57,18 +57,18 @@ def test_a_corrupt_cache_reads_as_empty_rather_than_failing(tmp_path: Path) -> N
 
 def test_what_is_saved_comes_back(tmp_path: Path) -> None:
     target = tmp_path / "sensors.json"
-    save(target, {"cryo-77k": _known("cryo-77k")})
+    save(target, merge({}, [_known("cryo-77k")]))
 
     restored = load(target)
 
-    assert restored["cryo-77k"].unit == "K"
-    assert restored["cryo-77k"].last_seen == _NOW
+    assert restored[("cryo-77k", "temperature")].unit == "K"
+    assert restored[("cryo-77k", "temperature")].last_seen == _NOW
 
 
 def test_saving_creates_the_directory(tmp_path: Path) -> None:
     target = tmp_path / "deep" / "down" / "sensors.json"
 
-    save(target, {"a": _known("a")})
+    save(target, merge({}, [_known("a")]))
 
     assert target.is_file()
 
@@ -76,28 +76,28 @@ def test_saving_creates_the_directory(tmp_path: Path) -> None:
 def test_the_cache_is_readable_json(tmp_path: Path) -> None:
     # Somebody should be able to look at it and delete a line.
     target = tmp_path / "sensors.json"
-    save(target, {"a": _known("a")})
+    save(target, merge({}, [_known("a")]))
 
-    assert "sensor_id" in json.loads(target.read_text())["a"]
+    assert "sensor_id" in json.loads(target.read_text())[0]
 
 
 def test_merging_keeps_a_sensor_the_live_query_did_not_return() -> None:
     # The whole reason the cache exists: a sensor silent for longer than
     # the window has no row to be stale, so it vanishes rather than
     # turning red.
-    cached = {"gone": _known("gone", seconds_ago=90_000)}
+    cached = merge({}, [_known("gone", seconds_ago=90_000)])
 
     merged = merge(cached, [_known("here")])
 
-    assert set(merged) == {"gone", "here"}
+    assert {entry.sensor_id for entry in merged.values()} == {"gone", "here"}
 
 
 def test_merging_prefers_the_live_reading() -> None:
-    cached = {"a": _known("a", seconds_ago=90_000)}
+    cached = merge({}, [_known("a", seconds_ago=90_000)])
 
     merged = merge(cached, [_known("a", seconds_ago=1)])
 
-    assert merged["a"].last_seen == _NOW - timedelta(seconds=1)
+    assert merged[("a", "temperature")].last_seen == _NOW - timedelta(seconds=1)
 
 
 def test_merging_adds_a_sensor_the_cache_had_never_seen() -> None:
@@ -105,38 +105,38 @@ def test_merging_adds_a_sensor_the_cache_had_never_seen() -> None:
     # added sensor until somebody remembered to rebuild it.
     merged = merge({}, [_known("brand-new")])
 
-    assert "brand-new" in merged
+    assert ("brand-new", "temperature") in merged
 
 
 def test_forgetting_removes_one_sensor() -> None:
-    cached = {"a": _known("a"), "b": _known("b")}
+    cached = merge({}, [_known("a"), _known("b")])
 
-    assert set(forget(cached, "a")) == {"b"}
+    assert {e.sensor_id for e in forget(cached, "a").values()} == {"b"}
 
 
 def test_forgetting_an_unknown_sensor_says_so() -> None:
     with pytest.raises(KeyError):
-        _ = forget({"a": _known("a")}, "nope")
+        _ = forget(merge({}, [_known("a")]), "nope")
 
 
 def test_forgetting_does_not_mutate_what_it_was_given() -> None:
-    cached = {"a": _known("a"), "b": _known("b")}
+    cached = merge({}, [_known("a"), _known("b")])
 
     _ = forget(cached, "a")
 
-    assert set(cached) == {"a", "b"}
+    assert {e.sensor_id for e in cached.values()} == {"a", "b"}
 
 
 def test_a_cache_that_is_not_an_object_reads_as_empty(tmp_path: Path) -> None:
     target = tmp_path / "sensors.json"
-    _ = target.write_text("[1, 2, 3]")
+    _ = target.write_text('{"a": 1}')
 
     assert load(target) == {}
 
 
 def test_an_entry_that_is_not_an_object_is_skipped(tmp_path: Path) -> None:
     target = tmp_path / "sensors.json"
-    _ = target.write_text(json.dumps({"a": "not an object"}))
+    _ = target.write_text(json.dumps(["not an object"]))
 
     assert load(target) == {}
 
@@ -147,33 +147,33 @@ def test_an_entry_missing_a_field_is_skipped(tmp_path: Path) -> None:
     target = tmp_path / "sensors.json"
     _ = target.write_text(
         json.dumps(
-            {
-                "broken": {"sensor_id": "broken"},
-                "intact": {
+            [
+                {"sensor_id": "broken"},
+                {
                     "sensor_id": "intact",
                     "measurement": "temperature",
                     "unit": "K",
                     "last_seen": _NOW.isoformat(),
                 },
-            }
+            ]
         )
     )
 
-    assert set(load(target)) == {"intact"}
+    assert {e.sensor_id for e in load(target).values()} == {"intact"}
 
 
 def test_an_entry_with_an_unreadable_timestamp_is_skipped(tmp_path: Path) -> None:
     target = tmp_path / "sensors.json"
     _ = target.write_text(
         json.dumps(
-            {
-                "broken": {
+            [
+                {
                     "sensor_id": "broken",
                     "measurement": "temperature",
                     "unit": "K",
                     "last_seen": "the day before yesterday",
                 }
-            }
+            ]
         )
     )
 
@@ -186,3 +186,100 @@ def test_an_empty_roster_renders_as_a_sentence() -> None:
     empty: set[str] = set()
 
     assert render_roster({}, live=empty, now=_NOW) == "nothing remembered yet"
+
+
+def _at(sensor: str, measurement: str, unit: str) -> Known:
+    return Known(sensor_id=sensor, measurement=measurement, unit=unit, last_seen=_NOW)
+
+
+def test_a_sensor_reporting_two_measurements_keeps_both() -> None:
+    # Keying by sensor alone kept whichever row iterated last, and the
+    # union's row order is not defined — so which one survived was
+    # arbitrary. `fetch_latest` returns a row per sensor and measurement,
+    # and the roster has to hold the same shape.
+    merged = merge(
+        {}, [_at("multi", "temperature", "K"), _at("multi", "pressure", "mbar")]
+    )
+
+    assert {entry.measurement for entry in merged.values()} == {
+        "temperature",
+        "pressure",
+    }
+
+
+def test_the_same_sensor_and_measurement_is_updated_not_duplicated() -> None:
+    first = _at("a", "temperature", "K")
+    later = Known(
+        sensor_id="a",
+        measurement="temperature",
+        unit="K",
+        last_seen=_NOW + timedelta(seconds=10),
+    )
+
+    merged = merge(merge({}, [first]), [later])
+
+    assert len(merged) == 1
+    assert next(iter(merged.values())).last_seen == later.last_seen
+
+
+def test_both_measurements_survive_a_round_trip(tmp_path: Path) -> None:
+    target = tmp_path / "sensors.json"
+    save(
+        target,
+        merge({}, [_at("multi", "temperature", "K"), _at("multi", "pressure", "mbar")]),
+    )
+
+    assert len(load(target)) == 2
+
+
+def test_forgetting_a_sensor_forgets_all_of_its_measurements() -> None:
+    known = merge(
+        {},
+        [
+            _at("multi", "temperature", "K"),
+            _at("multi", "pressure", "mbar"),
+            _at("other", "temperature", "K"),
+        ],
+    )
+
+    remaining = forget(known, "multi")
+
+    assert {entry.sensor_id for entry in remaining.values()} == {"other"}
+
+
+def test_a_failed_write_leaves_the_previous_roster_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The point of writing through a temporary file: a half-written
+    # roster reads as empty, and what that heals to is the loss of every
+    # quiet sensor this exists to remember.
+    target = tmp_path / "sensors.json"
+    save(target, merge({}, [_known("keep-me")]))
+
+    def refuse(_self: Path, *_args: object, **_kwargs: object) -> int:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(Path, "write_text", refuse)
+
+    with pytest.raises(OSError, match="no space"):
+        save(target, merge({}, [_known("new")]))
+
+    monkeypatch.undo()
+    assert {entry.sensor_id for entry in load(target).values()} == {"keep-me"}
+
+
+def test_a_failed_write_does_not_leave_a_temporary_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "sensors.json"
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("os.replace", refuse)
+
+    with pytest.raises(OSError):
+        save(target, merge({}, [_known("a")]))
+
+    monkeypatch.undo()
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/test_cli_roster.py
+++ b/tests/test_cli_roster.py
@@ -1,0 +1,188 @@
+"""The remembered list of sensors, and where it lives on disk."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from labmon.cli.roster import Known, cache_path, forget, load, merge, save
+
+_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+
+
+def _known(sensor: str, seconds_ago: int = 0) -> Known:
+    return Known(
+        sensor_id=sensor,
+        measurement="temperature",
+        unit="K",
+        last_seen=_NOW - timedelta(seconds=seconds_ago),
+    )
+
+
+def test_the_cache_honours_xdg_cache_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/somewhere")
+
+    assert cache_path() == Path("/tmp/somewhere/labmon/sensors.json")
+
+
+def test_the_cache_falls_back_to_dot_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/home/someone")
+
+    assert cache_path() == Path("/home/someone/.cache/labmon/sensors.json")
+
+
+def test_it_is_a_cache_not_a_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Derived data that can be deleted at any time without losing a
+    # setting, so it belongs beside other caches rather than in config.
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/home/someone")
+
+    assert ".config" not in str(cache_path())
+
+
+def test_a_missing_cache_reads_as_empty(tmp_path: Path) -> None:
+    assert load(tmp_path / "absent.json") == {}
+
+
+def test_a_corrupt_cache_reads_as_empty_rather_than_failing(tmp_path: Path) -> None:
+    # A cache is rebuildable by definition. Refusing to run because a
+    # derived file was truncated would be the wrong trade.
+    target = tmp_path / "sensors.json"
+    _ = target.write_text("{not json at all")
+
+    assert load(target) == {}
+
+
+def test_what_is_saved_comes_back(tmp_path: Path) -> None:
+    target = tmp_path / "sensors.json"
+    save(target, {"cryo-77k": _known("cryo-77k")})
+
+    restored = load(target)
+
+    assert restored["cryo-77k"].unit == "K"
+    assert restored["cryo-77k"].last_seen == _NOW
+
+
+def test_saving_creates_the_directory(tmp_path: Path) -> None:
+    target = tmp_path / "deep" / "down" / "sensors.json"
+
+    save(target, {"a": _known("a")})
+
+    assert target.is_file()
+
+
+def test_the_cache_is_readable_json(tmp_path: Path) -> None:
+    # Somebody should be able to look at it and delete a line.
+    target = tmp_path / "sensors.json"
+    save(target, {"a": _known("a")})
+
+    assert "sensor_id" in json.loads(target.read_text())["a"]
+
+
+def test_merging_keeps_a_sensor_the_live_query_did_not_return() -> None:
+    # The whole reason the cache exists: a sensor silent for longer than
+    # the window has no row to be stale, so it vanishes rather than
+    # turning red.
+    cached = {"gone": _known("gone", seconds_ago=90_000)}
+
+    merged = merge(cached, [_known("here")])
+
+    assert set(merged) == {"gone", "here"}
+
+
+def test_merging_prefers_the_live_reading() -> None:
+    cached = {"a": _known("a", seconds_ago=90_000)}
+
+    merged = merge(cached, [_known("a", seconds_ago=1)])
+
+    assert merged["a"].last_seen == _NOW - timedelta(seconds=1)
+
+
+def test_merging_adds_a_sensor_the_cache_had_never_seen() -> None:
+    # A cache used as a substitute rather than a union would hide a newly
+    # added sensor until somebody remembered to rebuild it.
+    merged = merge({}, [_known("brand-new")])
+
+    assert "brand-new" in merged
+
+
+def test_forgetting_removes_one_sensor() -> None:
+    cached = {"a": _known("a"), "b": _known("b")}
+
+    assert set(forget(cached, "a")) == {"b"}
+
+
+def test_forgetting_an_unknown_sensor_says_so() -> None:
+    with pytest.raises(KeyError):
+        _ = forget({"a": _known("a")}, "nope")
+
+
+def test_forgetting_does_not_mutate_what_it_was_given() -> None:
+    cached = {"a": _known("a"), "b": _known("b")}
+
+    _ = forget(cached, "a")
+
+    assert set(cached) == {"a", "b"}
+
+
+def test_a_cache_that_is_not_an_object_reads_as_empty(tmp_path: Path) -> None:
+    target = tmp_path / "sensors.json"
+    _ = target.write_text("[1, 2, 3]")
+
+    assert load(target) == {}
+
+
+def test_an_entry_that_is_not_an_object_is_skipped(tmp_path: Path) -> None:
+    target = tmp_path / "sensors.json"
+    _ = target.write_text(json.dumps({"a": "not an object"}))
+
+    assert load(target) == {}
+
+
+def test_an_entry_missing_a_field_is_skipped(tmp_path: Path) -> None:
+    # Hand-editing this file is expected, so half an entry should cost
+    # that entry rather than the whole roster.
+    target = tmp_path / "sensors.json"
+    _ = target.write_text(
+        json.dumps(
+            {
+                "broken": {"sensor_id": "broken"},
+                "intact": {
+                    "sensor_id": "intact",
+                    "measurement": "temperature",
+                    "unit": "K",
+                    "last_seen": _NOW.isoformat(),
+                },
+            }
+        )
+    )
+
+    assert set(load(target)) == {"intact"}
+
+
+def test_an_entry_with_an_unreadable_timestamp_is_skipped(tmp_path: Path) -> None:
+    target = tmp_path / "sensors.json"
+    _ = target.write_text(
+        json.dumps(
+            {
+                "broken": {
+                    "sensor_id": "broken",
+                    "measurement": "temperature",
+                    "unit": "K",
+                    "last_seen": "the day before yesterday",
+                }
+            }
+        )
+    )
+
+    assert load(target) == {}
+
+
+def test_an_empty_roster_renders_as_a_sentence() -> None:
+    from labmon.cli.render import render_roster
+
+    empty: set[str] = set()
+
+    assert render_roster({}, live=empty, now=_NOW) == "nothing remembered yet"

--- a/tests/test_cli_sensors_roster.py
+++ b/tests/test_cli_sensors_roster.py
@@ -214,3 +214,52 @@ def test_a_window_without_a_refresh_is_refused(roster: Path) -> None:
     result = _run("sensors", "--since", "1w")
 
     assert result.exit_code != 0
+
+
+def test_forgetting_a_sensor_that_is_still_writing_says_so(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The cache may only ever add, so a sensor still reporting will be
+    # remembered again by the next query. `forgot X` alone would read as
+    # "it is gone" for a sensor that is not.
+    _remember(roster, "cryo-77k")
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    result = _run("sensors", "--forget", "cryo-77k")
+
+    assert result.exit_code == 0
+    assert ("cryo-77k", "temperature") not in load(roster)
+    assert "still has readings in temperature" in result.output
+
+
+def test_forgetting_a_silent_sensor_adds_nothing(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # RosterClient only ever reports cryo-77k, so the database agrees
+    # that old-probe is gone and there is nothing to warn about.
+    _remember(roster, "old-probe")
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    result = _run("sensors", "--forget", "old-probe")
+
+    assert result.exit_code == 0
+    assert "still has readings" not in result.output
+
+
+def test_forgetting_works_with_the_database_unreachable(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The roster is already written by the time the check runs, so a
+    # database that is not there cannot turn a finished command into a
+    # failed one.
+    _remember(roster, "old-probe")
+
+    def refuse() -> object:
+        raise OSError("no route to host")
+
+    monkeypatch.setattr("labmon.influx.get_client", refuse)
+
+    result = _run("sensors", "--forget", "old-probe")
+
+    assert result.exit_code == 0
+    assert ("old-probe", "temperature") not in load(roster)

--- a/tests/test_cli_sensors_roster.py
+++ b/tests/test_cli_sensors_roster.py
@@ -1,0 +1,166 @@
+"""`labmon sensors` — what labmon remembers, and how to correct it."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from labmon.cli.main import build_app
+from labmon.cli.roster import Known, load, save
+from tests.cli_runner import Invocation, invoke
+
+
+def _run(*args: str) -> Invocation:
+    return invoke(build_app(), list(args))
+
+
+class RosterClient:
+    """One live sensor, so a cached one has nothing to match."""
+
+    def query(
+        self,
+        query: str,
+        language: str = "sql",
+        mode: str = "all",
+        database: str | None = None,
+        **kwargs: object,
+    ) -> pa.Table:
+        _ = (language, mode, database, kwargs)
+        if "SHOW TABLES" in query:
+            return pa.table(
+                {
+                    "table_schema": pa.array(["iox"]),
+                    "table_name": pa.array(["temperature"]),
+                }
+            )
+        if "information_schema.columns" in query:
+            return pa.table(
+                {"column_name": pa.array(["time", "value", "sensor_id", "unit"])}
+            )
+        return pa.table(
+            {
+                "measurement": pa.array(["temperature"]),
+                "sensor_id": pa.array(["cryo-77k"]),
+                "time": pa.array(
+                    [datetime.now(UTC) - timedelta(seconds=3)],
+                    pa.timestamp("ms", tz="UTC"),
+                ),
+                "value": pa.array([77.01]),
+                "unit": pa.array(["K"]),
+            }
+        )
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture
+def roster(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    return tmp_path / "labmon" / "sensors.json"
+
+
+def _remember(path: Path, sensor: str, days: int = 2) -> None:
+    known = load(path)
+    known[sensor] = Known(
+        sensor_id=sensor,
+        measurement="temperature",
+        unit="K",
+        last_seen=datetime.now(UTC) - timedelta(days=days),
+    )
+    save(path, known)
+
+
+@pytest.mark.usefixtures("roster")
+def test_an_empty_roster_says_so_rather_than_printing_a_bare_header() -> None:
+    result = _run("sensors")
+
+    assert result.exit_code == 0
+    assert "nothing" in result.output.lower()
+
+
+def test_sensors_lists_what_is_remembered(roster: Path) -> None:
+    _remember(roster, "old-probe")
+
+    result = _run("sensors")
+
+    assert result.exit_code == 0
+    assert "old-probe" in result.output
+
+
+def test_a_remembered_sensor_is_marked_as_cached(roster: Path) -> None:
+    # The source column is the point: it says outright whether a sensor
+    # is reporting now or is only remembered.
+    _remember(roster, "old-probe")
+
+    result = _run("sensors")
+
+    assert "cached" in result.output
+
+
+def test_refresh_rebuilds_from_the_database(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    result = _run("sensors", "--refresh")
+
+    assert result.exit_code == 0
+    assert "cryo-77k" in load(roster)
+
+
+@pytest.mark.usefixtures("roster")
+def test_a_refreshed_sensor_is_marked_as_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    result = _run("sensors", "--refresh")
+
+    assert "live" in result.output
+
+
+def test_refresh_keeps_a_sensor_the_database_no_longer_has(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A refresh is a union too. Dropping what the window did not cover
+    # would delete exactly the silence worth keeping.
+    _remember(roster, "old-probe")
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    _ = _run("sensors", "--refresh")
+
+    assert "old-probe" in load(roster)
+
+
+def test_forget_removes_a_decommissioned_sensor(roster: Path) -> None:
+    _remember(roster, "old-probe")
+
+    result = _run("sensors", "--forget", "old-probe")
+
+    assert result.exit_code == 0
+    assert "old-probe" not in load(roster)
+
+
+def test_forgetting_an_unknown_sensor_fails_rather_than_pretending(
+    roster: Path,
+) -> None:
+    # Succeeding silently leaves somebody believing they removed a sensor
+    # that is still listed under a name they mistyped.
+    _remember(roster, "old-probe")
+
+    result = _run("sensors", "--forget", "typo")
+
+    assert result.exit_code != 0
+    assert "old-probe" in load(roster)
+
+
+def test_forget_and_refresh_together_are_refused(roster: Path) -> None:
+    # Refreshing would re-add whatever was just forgotten if it still
+    # reports, so the two together have no coherent meaning.
+    _remember(roster, "old-probe")
+
+    result = _run("sensors", "--refresh", "--forget", "old-probe")
+
+    assert result.exit_code != 0

--- a/tests/test_cli_sensors_roster.py
+++ b/tests/test_cli_sensors_roster.py
@@ -7,7 +7,7 @@ import pyarrow as pa
 import pytest
 
 from labmon.cli.main import build_app
-from labmon.cli.roster import Known, load, save
+from labmon.cli.roster import Known, load, merge, save
 from tests.cli_runner import Invocation, invoke
 
 
@@ -62,14 +62,13 @@ def roster(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _remember(path: Path, sensor: str, days: int = 2) -> None:
-    known = load(path)
-    known[sensor] = Known(
+    entry = Known(
         sensor_id=sensor,
         measurement="temperature",
         unit="K",
         last_seen=datetime.now(UTC) - timedelta(days=days),
     )
-    save(path, known)
+    save(path, merge(load(path), [entry]))
 
 
 @pytest.mark.usefixtures("roster")
@@ -89,16 +88,6 @@ def test_sensors_lists_what_is_remembered(roster: Path) -> None:
     assert "old-probe" in result.output
 
 
-def test_a_remembered_sensor_is_marked_as_cached(roster: Path) -> None:
-    # The source column is the point: it says outright whether a sensor
-    # is reporting now or is only remembered.
-    _remember(roster, "old-probe")
-
-    result = _run("sensors")
-
-    assert "cached" in result.output
-
-
 def test_refresh_rebuilds_from_the_database(
     roster: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -107,7 +96,7 @@ def test_refresh_rebuilds_from_the_database(
     result = _run("sensors", "--refresh")
 
     assert result.exit_code == 0
-    assert "cryo-77k" in load(roster)
+    assert ("cryo-77k", "temperature") in load(roster)
 
 
 @pytest.mark.usefixtures("roster")
@@ -131,7 +120,7 @@ def test_refresh_keeps_a_sensor_the_database_no_longer_has(
 
     _ = _run("sensors", "--refresh")
 
-    assert "old-probe" in load(roster)
+    assert ("old-probe", "temperature") in load(roster)
 
 
 def test_forget_removes_a_decommissioned_sensor(roster: Path) -> None:
@@ -140,7 +129,7 @@ def test_forget_removes_a_decommissioned_sensor(roster: Path) -> None:
     result = _run("sensors", "--forget", "old-probe")
 
     assert result.exit_code == 0
-    assert "old-probe" not in load(roster)
+    assert ("old-probe", "temperature") not in load(roster)
 
 
 def test_forgetting_an_unknown_sensor_fails_rather_than_pretending(
@@ -153,7 +142,7 @@ def test_forgetting_an_unknown_sensor_fails_rather_than_pretending(
     result = _run("sensors", "--forget", "typo")
 
     assert result.exit_code != 0
-    assert "old-probe" in load(roster)
+    assert ("old-probe", "temperature") in load(roster)
 
 
 def test_forget_and_refresh_together_are_refused(roster: Path) -> None:
@@ -162,5 +151,66 @@ def test_forget_and_refresh_together_are_refused(roster: Path) -> None:
     _remember(roster, "old-probe")
 
     result = _run("sensors", "--refresh", "--forget", "old-probe")
+
+    assert result.exit_code != 0
+
+
+def test_a_plain_listing_does_not_claim_to_know_what_is_live(roster: Path) -> None:
+    # Without --refresh nothing is asked of the database, so a `source`
+    # column could only ever say "cached" — including for sensors
+    # reporting right now. Better to omit a column than to print one
+    # that is misleading.
+    _remember(roster, "old-probe")
+
+    result = _run("sensors")
+
+    assert "source" not in result.output
+
+
+def test_a_refresh_does_report_what_is_live(
+    roster: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _remember(roster, "old-probe")
+    monkeypatch.setattr("labmon.influx.get_client", RosterClient)
+
+    result = _run("sensors", "--refresh")
+
+    assert "source" in result.output
+    assert "live" in result.output
+
+
+def test_a_listing_can_be_narrowed_to_one_sensor(roster: Path) -> None:
+    _remember(roster, "old-probe")
+    _remember(roster, "other-probe")
+
+    result = _run("sensors", "--sensor-id", "old-probe")
+
+    assert "old-probe" in result.output
+    assert "other-probe" not in result.output
+
+
+def test_a_listing_can_be_narrowed_to_one_measurement(roster: Path) -> None:
+    known = load(roster)
+    known[("gauge", "pressure")] = Known(
+        sensor_id="gauge",
+        measurement="pressure",
+        unit="mbar",
+        last_seen=datetime.now(UTC),
+    )
+    save(roster, known)
+    _remember(roster, "thermo")
+
+    result = _run("sensors", "--measurement", "temperature")
+
+    assert "thermo" in result.output
+    assert "gauge" not in result.output
+
+
+def test_a_window_without_a_refresh_is_refused(roster: Path) -> None:
+    # --since only bounds the query a refresh runs; accepting it for a
+    # plain listing would let somebody believe it had narrowed something.
+    _remember(roster, "old-probe")
+
+    result = _run("sensors", "--since", "1w")
 
     assert result.exit_code != 0


### PR DESCRIPTION
Closes #155. Third and last of the stack. **Based on #164** — review #163 and #164 first.

1. #163 — `fetch_latest`, the SQL
2. #164 — the latest view and the age column
3. **this PR** — the remembered roster, `labmon sensors`, and two rounds of feedback

Five commits, in order: the roster; the review findings; `latest` becoming a subcommand; readable value formatting; the `--forget` note below.

## 1. The hole this fills

`--since` bounds how far back the query looks, so a sensor silent for longer than the window returns **no row**. It has nothing to be stale — it disappears. That is the worst possible failure for a view whose whole job is spotting silence.

labmon now remembers the sensors it has seen and unions that list into the result:

```
sensor_id   measurement  value             unit  age
----------  -----------  ----------------  ----  -------
cryo-diode  temperature  43.40249084249082 K     2s ago
room-1      temperature  21.552            °C    4s ago
old-probe   temperature                    K     1h ago

6 sensors
1 of them reported nothing in this window — remembered from a previous run
```

`old-probe`'s **value is blank rather than the last reading it ever sent** — printed beside a fresh number from another sensor, an old one reads as current.

**The cache may only add sensors, never replace or filter them.** Used as a union a stale cache is harmless; the worst it can do is mention an instrument since removed. Used as a *substitute* it would grow its own silent failure, hiding a newly added sensor until somebody rebuilt it.

It is **not** for speed: the query discovers sensors by itself as a by-product of asking for values (60 ms roster-only against 84 ms for roster-and-values). It exists to remember what the window no longer covers.

## 2. `labmon sensors`

```bash
labmon sensors                       # what labmon knows
labmon sensors --refresh             # ask the database and remember
labmon sensors --refresh --since 1w  # over a wider window
labmon sensors --forget old-probe    # an instrument that is genuinely gone
```

`--forget` also says when the database disagrees:

```
❯ labmon sensors --forget wavemeter-1
forgot wavemeter-1
it still has readings in frequency from the last 24h, so a query over that window will find it and remember it again until they age out
```

The cache may only add, so forgetting a sensor that is still writing is undone by the next `labmon query latest` — and `forgot X` on its own reads as "it is gone", which for such a sensor it is not. The check runs after the roster is saved and stays silent on the failures the runtime otherwise maps to exit codes: an unreachable database says nothing about a sensor, and the removal has already succeeded.

A cache nobody can see is a liability — a decommissioned instrument would show red for ever with no recourse but deleting the file by hand. A refresh is a union too: dropping what the window did not cover would delete exactly the silence worth keeping. `--forget` fails rather than pretending when the name is unknown.

Cache at `$XDG_CACHE_HOME/labmon/sensors.json`, an indented JSON list so it can be read and edited by hand, written through a temporary file and moved into place.

## 3. Review findings, addressed

**An entry is a sensor *and* a measurement.** Keying on the sensor alone meant one writing to two tables kept whichever row arrived last — and the row order of a `UNION` is undefined, so which survived was arbitrary. Worse, if such a sensor went quiet and you asked about the measurement that had been dropped, the silent-row filter removed it: the exact vanishing act the cache exists to prevent. Verified against real data by running a `dual-probe` into two tables; both entries now survive. Rekeying also exposed a second bug the review did not catch — `selection.py` compared roster keys against a set of sensor-id *strings*, so every remembered entry counted as silent.

**`labmon sensors` no longer accepts flags it ignores.** `--measurement` and `--sensor-id` describe a roster entry, so they narrow a plain listing; `--since` and `--until` bound a refresh's query and are refused without it.

**The `source` column appears only with `--refresh`.** A plain listing touches no database, so the column could report nothing but "cached" — including beside a sensor reporting that second. The docs claimed it said outright whether a sensor was reporting; true only of an unnarrowed refresh.

**The roster is written atomically.** A crash midway through a direct write leaves a truncated file, which `load` correctly treats as empty — self-healing, except that what it heals to is the loss of every quiet sensor it exists to remember.

Left as a follow-up: **#167**, `--latest` making one round trip per measurement for column discovery before the single union query.

## 4. `labmon query latest`, a subcommand

A subcommand carries its own help and completions, which a boolean flag cannot, and leaves room for the other questions worth asking — `query stats <sensor_id>` being the obvious next. A bare `labmon query` keeps meaning what it always has.

One trap: a Typer callback declared `invoke_without_command=True` runs on the way to a subcommand *as well as* instead of one, so `query latest` initially ran both and printed two tables. The test counting how often the database client is closed caught it.

## 5. Readable values

```
wavemeter-1   frequency    2.765612997e+14   Hz     (was 276561300200000.0)
chamber-1     pressure     1.9867e-07        mbar
room-1        temperature  21.552            °C
```

Plain decimal between 1e-3 and 1e3, scientific outside — more than three digits ahead of the point, or zeros crowding behind it, is where a column has to be counted rather than read.

**Scientific notation rather than SI prefixes, and the units in this project are the reason.** Tested with `pint` against the demo stack's own units before choosing:

```
276561300200000.0 Hz   -> 276.5613002 THz          ✓
          6.8e-07 mbar -> 680.0 pbar               ✗ correct, unreadable for vacuum
             20.9 degC -> OffsetUnitCalculusError  ✗ would crash both room sensors
```

`mbar` already carries a prefix and `°C` is an offset unit. A per-sensor prefix, chosen rather than inferred, is the better answer where one is wanted, and belongs in #156's config file.

Nothing is rounded away in either form: the shortest text that reads back as the same float is used, keeping the existing renderer's promise that a sensor has already rounded to the resolution it claims.

## Test plan

- [x] `pytest` — 670 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean, zero warnings
- [x] every path exercised against the live demo stack: `query latest`, bare `query`, list, `--refresh`, `--forget` of a sensor still reporting and of one genuinely gone, `--forget` of an unknown id, `--refresh --forget` together, narrowing by sensor and by measurement, and a sensor reporting two measurements
- [x] verified the suite no longer writes outside its own tmp directory

