### PR TITLE
feat(config): add a per-user configuration file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,12 @@
 # Configuration reference
 
-Every setting labmon exposes, in one place. Behaviour is tuned in three
-places — the environment, a command line, and the calibration file — and
-which one a given knob lives in is not always guessable. This page is the
-index; the per-component docs explain what each setting is *for*.
+Every setting labmon exposes, in one place. Behaviour is tuned in four
+places — the environment, a command line, the calibration file, and a
+per-user configuration file — and which one a given knob lives in is not
+always guessable. This page is the index; the per-component docs explain
+what each setting is *for*.
 
-There is a fourth category, at the bottom: the constants that are
+There is a fifth category, at the bottom: the constants that are
 deliberately **not** configurable, and what breaks if you change them
 anyway.
 
@@ -147,6 +148,43 @@ They do decide how finely `value` is rounded — see
 [How many digits a reading keeps](#how-many-digits-a-reading-keeps) —
 and digits dropped on the way in do not come back. `input_volts` keeps
 all of its own, which is what makes the correction possible.
+
+## The user configuration file
+
+Everything above configures a *deployment* — a host, a database, a
+token — and reaches labmon through the environment, because that is how
+a container is configured. The settings in this section configure a
+*person*: how readings are shown to whoever is reading them. They live
+with that person's other dotfiles rather than with the stack.
+
+Read from `$XDG_CONFIG_HOME/labmon/labmon.toml`, or
+`~/.config/labmon/labmon.toml` when `XDG_CONFIG_HOME` is unset. **Not
+having one is the ordinary case**: every key has a default and a missing
+file is not an error.
+
+```toml
+timezone = "Europe/Paris"
+```
+
+| Key | Default | Purpose |
+|---|---|---|
+| `timezone` | `"UTC"` | Zone the `time` column is printed in. An IANA name, or `"local"` for the machine's own zone |
+
+`timezone` changes only what a terminal prints. Readings are stored in
+UTC and exported in UTC — a data file that carried somebody's desk clock
+would be unusable to the next person to open it. What it fixes is the
+question you actually ask standing next to an experiment: whether the
+cryostat was cold at 3 a.m. *your* time.
+
+`"local"` is resolved by asking the machine, so a laptop that travels
+follows it. A name that looks right but is rejected usually means the
+system timezone database is not installed — `tzdata` provides it.
+
+**An unrecognised key is an error, not a warning.** A config file that
+skips what it does not understand gives a misspelled setting the exact
+appearance of a working one, with nothing to notice. The cost is that a
+key added by a newer labmon fails on an older one, which is a message
+naming the key rather than a silent wrong answer.
 
 ## The calibration file
 

--- a/src/labmon/cli/commands/query.py
+++ b/src/labmon/cli/commands/query.py
@@ -50,9 +50,11 @@ def query(
         # and print two tables.
         return
 
+    from labmon.config import load
+
     configure(log_level)
     table, _window = selection.read(measurement, sensor_id, since, until)
-    print(render(table, limit=limit))
+    print(render(table, limit=limit, tz=load().timezone))
 
 
 LATEST_HELP = (

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -6,7 +6,7 @@ wants the few columns that carry meaning, aligned, in a width that fits.
 """
 
 from collections.abc import Container, Mapping, Sequence
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, cast
 
 from labmon.cli.age import Freshness, describe, freshness
@@ -56,7 +56,7 @@ def visible_columns(table: "pa.Table") -> list[str]:
     ]
 
 
-def _cell(name: str, value: object) -> str:
+def _cell(name: str, value: object, tz: tzinfo = UTC) -> str:
     if value is None:
         return ""
     if name == "time" and isinstance(value, datetime):
@@ -67,7 +67,16 @@ def _cell(name: str, value: object) -> str:
         # fixed width: `str` omits the fractional part when it is zero,
         # so the slice cut into the offset instead of the digits — and
         # a whole second is what a sensor on a 1 Hz grid reports.
-        return value.replace(tzinfo=None).isoformat(sep=" ", timespec="milliseconds")
+        #
+        # Moved into the reader's zone first. The stored instant does not
+        # change; where somebody standing next to the experiment reads it
+        # does, and "was the cryostat cold at 3 a.m." is a question about
+        # their clock, not about UTC.
+        return (
+            value.astimezone(tz)
+            .replace(tzinfo=None)
+            .isoformat(sep=" ", timespec="milliseconds")
+        )
     if name in _NUMERIC_COLUMNS and isinstance(value, float):
         # Plain where a decimal reads well, scientific where it does not,
         # and nothing rounded away in either — see `labmon.cli.quantity`.
@@ -75,12 +84,16 @@ def _cell(name: str, value: object) -> str:
     return str(value)
 
 
-def render(table: "pa.Table", limit: int = DEFAULT_LIMIT) -> str:
+def render(table: "pa.Table", limit: int = DEFAULT_LIMIT, tz: tzinfo = UTC) -> str:
     """Format `table` as an aligned table, most recent rows last.
 
     A limit of 0 means every row. When rows are dropped, the footer says
     so — a silently truncated table is one somebody draws a conclusion
     from.
+
+    `tz` is the zone timestamps are shown in, from the user's config.
+    It defaults to UTC so a caller with no configuration to hand — a
+    test, or a path that has not been given one — behaves as before.
     """
     total = table.num_rows
     if total == 0:
@@ -91,7 +104,7 @@ def render(table: "pa.Table", limit: int = DEFAULT_LIMIT) -> str:
     columns = {name: shown.column(name).to_pylist() for name in names}
 
     rows = [
-        [_cell(name, columns[name][index]) for name in names]
+        [_cell(name, columns[name][index], tz) for name in names]
         for index in range(shown.num_rows)
     ]
     widths = [

--- a/src/labmon/cli/runtime.py
+++ b/src/labmon/cli/runtime.py
@@ -62,6 +62,7 @@ def _report(action: Callable[[], None]) -> None:
     # reaches this function at all.
     from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
 
+    from labmon.config import ConfigError
     from labmon.export.query import QueryError
     from labmon.export.window import WindowError
     from labmon.export.writers import ExportError
@@ -69,7 +70,7 @@ def _report(action: Callable[[], None]) -> None:
 
     try:
         action()
-    except (ExportError, QueryError, WindowError) as error:
+    except (ConfigError, ExportError, QueryError, WindowError) as error:
         logger.error("command failed", extra={"reason": str(error)})
         raise SystemExit(REFUSED) from None
     except InfluxDB3ClientError as error:

--- a/src/labmon/config.py
+++ b/src/labmon/config.py
@@ -1,0 +1,142 @@
+"""The user's configuration file, and what it is allowed to say.
+
+Distinct from the settings in `docs/configuration.md`, which describe a
+deployment: a host, a database, a token. Those belong to the machine and
+arrive through the environment, because that is how a container is
+configured. This file belongs to the *person* — how they want readings
+shown to them — so it lives beside their other dotfiles and is read from
+`$XDG_CONFIG_HOME/labmon/labmon.toml`.
+
+TOML rather than YAML: `tomllib` is in the standard library, calibration
+files are already TOML, and a second format would mean a second parser
+to document and a runtime dependency for a file most people never write.
+
+Unknown keys are refused rather than ignored. A config file that quietly
+skips what it does not recognise is the worst kind — a mistyped setting
+looks applied, behaves as though it were absent, and gives nothing to
+notice. The cost is that a key from a newer labmon fails on an older
+one, which is a plain message rather than a silent wrong answer.
+
+Imports nothing heavy: every command reads this, including the ones that
+never touch a database.
+"""
+
+import logging
+import os
+import tomllib
+from dataclasses import dataclass
+from datetime import UTC, datetime, tzinfo
+from pathlib import Path
+from typing import cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+CONFIG_NAME = "labmon.toml"
+
+# `timezone = "local"` means whatever the machine is set to, resolved
+# once here rather than left for each caller to remember.
+LOCAL = "local"
+
+
+class ConfigError(Exception):
+    """The configuration file exists and cannot be used as written.
+
+    Carries the path, because the first question on reading one of these
+    is always which file is meant — a per-procedure layout passed on the
+    command line and the machine-wide file are both plausible.
+    """
+
+
+@dataclass(frozen=True)
+class Config:
+    """Everything the configuration file settles.
+
+    One field today. It is a dataclass rather than a bare timezone so
+    that adding the monitor's layout does not change every signature
+    that carries the configuration around.
+    """
+
+    timezone: tzinfo = UTC
+
+
+def config_path() -> Path:
+    """Where the configuration lives, honouring `XDG_CONFIG_HOME`.
+
+    Resolved the same way as the roster's cache path rather than through
+    a dependency: two short functions are cheaper than a package, and
+    they cannot disagree about what an unset variable means.
+    """
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path(os.path.expanduser("~")) / ".config"
+    return root / "labmon" / CONFIG_NAME
+
+
+def load(path: Path | None = None) -> Config:
+    """Read the configuration, treating a missing file as the defaults.
+
+    Not having written one is the overwhelmingly common case and has to
+    be ordinary. A file that *is* there and cannot be used is the
+    opposite: it was written on purpose, so failing to apply it silently
+    would defeat the reason it exists.
+    """
+    where = path if path is not None else config_path()
+    try:
+        raw = where.read_bytes()
+    except FileNotFoundError:
+        logger.debug("no configuration file", extra={"path": str(where)})
+        return Config()
+    except OSError as error:
+        raise ConfigError(f"{where}: cannot be read ({error.strerror})") from None
+
+    try:
+        document = cast(dict[str, object], tomllib.loads(raw.decode()))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ConfigError(f"{where}: not valid TOML ({error})") from None
+
+    return _from_document(document, where)
+
+
+def _from_document(document: dict[str, object], where: Path) -> Config:
+    """Build a `Config` from a parsed document, or say what is wrong."""
+    unknown = sorted(set(document) - {"timezone"})
+    if unknown:
+        raise ConfigError(
+            f"{where}: unknown setting{'s' if len(unknown) > 1 else ''}"
+            + f" {', '.join(repr(name) for name in unknown)}"
+        )
+
+    zone = document.get("timezone", "UTC")
+    if not isinstance(zone, str):
+        raise ConfigError(
+            f"{where}: timezone must be a string, not {type(zone).__name__}"
+        )
+    return Config(timezone=_resolve(zone, where))
+
+
+def _resolve(name: str, where: Path) -> tzinfo:
+    """A zone name as something `astimezone` accepts.
+
+    `local` is resolved by asking the machine what an aware timestamp
+    becomes, which is the same question `datetime.astimezone()` answers
+    and needs no separate source of truth for the system zone.
+    """
+    if name in {"UTC", "utc"}:
+        # Answered without `ZoneInfo`, which needs the system timezone
+        # database — absent from some slim images. UTC is the default,
+        # so the default must not depend on a package being installed.
+        return UTC
+    if name == LOCAL:
+        local = datetime.now(UTC).astimezone().tzinfo
+        if local is None:  # pragma: no cover - astimezone always sets one
+            return UTC
+        return local
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError) as error:
+        raise ConfigError(
+            f"{where}: {name!r} is not a known timezone."
+            + " Use an IANA name such as 'Europe/Paris', 'UTC', or 'local'."
+            + " A name that looks right but is not found means the system"
+            + " timezone database is missing; install 'tzdata'"
+        ) from error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,16 @@ def _isolated_cache(  # pyright: ignore[reportUnusedFunction]
     to remember.
     """
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Point the configuration file inside the test's own directory.
+
+    Every command reads it, so without this the suite's behaviour
+    depends on whether whoever runs it has set a timezone — and a
+    passing run on one machine says nothing about another.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -4,6 +4,7 @@ import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import override
+from zoneinfo import ZoneInfo
 
 import pyarrow as pa
 import pytest
@@ -11,6 +12,7 @@ import pytest
 from labmon.cli import selection
 from labmon.cli.main import build_app
 from labmon.cli.render import DEFAULT_LIMIT, render, render_latest, visible_columns
+from labmon.cli.runtime import REFUSED
 from labmon.export.table import combine, normalise
 from tests.cli_runner import Invocation, invoke
 
@@ -397,6 +399,49 @@ def test_the_timezone_suffix_is_never_half_printed() -> None:
     # Every row in a result carries the same offset, so it is dropped
     # rather than repeated — but dropped whole, not sliced through.
     assert "+00:" not in render(_at(1_000))
+
+
+def test_a_configured_timezone_moves_the_printed_time() -> None:
+    # Paris was CET, UTC+1, on this date. The stored instant does not
+    # move; where it is shown does.
+    assert "1970-01-01 01:00:01.000" in render(_at(1_000), tz=ZoneInfo("Europe/Paris"))
+
+
+def test_a_shifted_time_still_does_not_print_its_offset() -> None:
+    # Dropping the suffix is what makes the column narrow enough to
+    # read, and it stays dropped once the zone is no longer UTC.
+    assert "+01:" not in render(_at(1_000), tz=ZoneInfo("Europe/Paris"))
+
+
+def test_the_timezone_reaches_the_query_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "config" / "labmon" / "labmon.toml"
+    config.parent.mkdir(parents=True)
+    _ = config.write_text('timezone = "Europe/Paris"\n')
+    monkeypatch.setattr("labmon.influx.get_client", FakeClient)
+
+    result = _run("query", "--since", "1h")
+
+    assert result.exit_code == 0
+    # FakeClient stamps its one reading at the epoch, which in Paris is
+    # an hour later on the same day.
+    assert "1970-01-01 01:00:00.000" in result.output
+
+
+def test_a_broken_configuration_is_reported_without_a_traceback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "config" / "labmon" / "labmon.toml"
+    config.parent.mkdir(parents=True)
+    _ = config.write_text('timezone = "Mars/Olympus"\n')
+    monkeypatch.setattr("labmon.influx.get_client", FakeClient)
+
+    result = _run("query", "--since", "1h")
+
+    assert result.exit_code == REFUSED
+    assert "Traceback" not in result.output
+    assert "Mars/Olympus" in result.output
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,99 @@
+"""The user configuration file: where it lives, and what it accepts."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from labmon.config import ConfigError, config_path, load
+
+
+@pytest.fixture
+def config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    return tmp_path / "labmon" / "labmon.toml"
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(text)
+    return path
+
+
+def test_the_path_honours_xdg_config_home(config_home: Path) -> None:
+    assert config_path() == config_home
+
+
+def test_the_path_falls_back_to_dot_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", "/home/somebody")
+
+    assert config_path() == Path("/home/somebody/.config/labmon/labmon.toml")
+
+
+def test_a_missing_file_is_the_defaults_rather_than_an_error(
+    config_home: Path,
+) -> None:
+    # Every command reads the config, and the overwhelmingly common case
+    # is not having written one. That has to be ordinary, not a failure.
+    assert load(config_home).timezone is UTC
+
+
+def test_an_empty_file_is_the_defaults_too(config_home: Path) -> None:
+    assert load(_write(config_home, "")).timezone is UTC
+
+
+def test_a_named_timezone_is_resolved(config_home: Path) -> None:
+    config = load(_write(config_home, 'timezone = "Europe/Paris"\n'))
+
+    assert config.timezone == ZoneInfo("Europe/Paris")
+
+
+def test_local_means_this_machine(config_home: Path) -> None:
+    config = load(_write(config_home, 'timezone = "local"\n'))
+
+    # Asserted as an offset rather than as a name: the machine running
+    # this may be in any zone, including UTC, and what "local" promises
+    # is that a timestamp lands where the machine says it should.
+    moment = datetime(2026, 7, 1, 12, tzinfo=UTC)
+    assert moment.astimezone(config.timezone).utcoffset() == (
+        moment.astimezone().utcoffset()
+    )
+
+
+def test_an_unknown_timezone_says_which_one(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match="Mars/Olympus"):
+        _ = load(_write(config_home, 'timezone = "Mars/Olympus"\n'))
+
+
+def test_a_timezone_that_is_not_a_string_is_refused(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match="timezone"):
+        _ = load(_write(config_home, "timezone = 2\n"))
+
+
+def test_a_misspelled_key_is_refused_rather_than_ignored(config_home: Path) -> None:
+    # A config file that silently ignores what it does not recognise is
+    # the worst kind: the setting looks applied and is not.
+    with pytest.raises(ConfigError, match="timezon"):
+        _ = load(_write(config_home, 'timezon = "Europe/Paris"\n'))
+
+
+def test_the_error_names_the_file(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match=r"labmon\.toml"):
+        _ = load(_write(config_home, "timezone = 2\n"))
+
+
+def test_broken_toml_is_reported_as_a_config_error(config_home: Path) -> None:
+    # Not a traceback: somebody edited a file by hand and needs the line.
+    with pytest.raises(ConfigError, match=r"labmon\.toml"):
+        _ = load(_write(config_home, 'timezone = "unterminated\n'))
+
+
+def test_a_file_that_cannot_be_read_is_reported(config_home: Path) -> None:
+    # A directory where the file should be. Chosen over an unreadable
+    # file because a suite run as root can read one of those anyway.
+    config_home.mkdir(parents=True)
+
+    with pytest.raises(ConfigError, match=r"labmon\.toml"):
+        _ = load(config_home)


### PR DESCRIPTION
First of the #156 stack — the configuration file the terminal panel will read, landed on its own with one setting so the format is settled before anything depends on it.

1. **this PR** — the per-user configuration file
2. #171 — the window statistics, `labmon query latest --stats`
3. #172 — `labmon monitor`, the refreshing panel
4. #177 — the configured tiles, and the panel's finish

*Rebased onto `main` after #175 and #176 merged. One conflict, in `docs/configuration.md`, where #175 added a paragraph on `--vref`/`--resolution-bits` deciding stored digits immediately above the section this PR adds — both kept, in that order. No other content changed.*

## Why a file at all, and why this one

labmon already has settings, and they all describe a **deployment**: a host, a database, a token. They arrive through the environment because that is how a container is configured, and `docs/configuration.md` documents them that way.

`timezone` is not that. It describes a **person** — how a reading is shown to whoever is reading it — and it should follow them between machines rather than belong to one. So it lives with their dotfiles, at `$XDG_CONFIG_HOME/labmon/labmon.toml` (`~/.config/labmon/labmon.toml` when the variable is unset), resolved the same way `roster.cache_path()` resolves `XDG_CACHE_HOME` rather than by adding `platformdirs` for two lines.

```toml
timezone = "Europe/Paris"
```

```
=== default (UTC)                        === timezone = "Europe/Paris"
time                     sensor_id       time                     sensor_id
-----------------------  -----------     -----------------------  -----------
2026-08-26 14:58:15.081  beam-y          2026-08-26 16:58:15.081  beam-y
2026-08-26 14:58:16.227  wavemeter-1     2026-08-26 16:58:16.227  wavemeter-1
```

`"local"` resolves to whatever the machine is set to, so a laptop that travels follows it.

## TOML, not YAML

#156 left this open and sketched YAML. TOML won on three counts: `tomllib` is in the standard library where `pyyaml` would be a new **runtime** dependency (today it is dev-only, pulled in by pre-commit); the calibration files are already TOML, so this is one format to document rather than two; and `[[monitor.panels]]` covers the nesting the panel layout needs without the indentation-sensitivity that makes hand-edited YAML fail in interesting ways. The `--config bakeout.toml` layouts in stage 4 will use the same parser.

## Three decisions worth arguing with

**A missing file is the defaults, not an error.** Not having written one is the overwhelmingly common case and has to be ordinary. A file that *is* there and cannot be used is the opposite — it was written on purpose, so applying it silently as "nothing" would defeat the reason it exists.

**An unknown key is an error, not a warning.**

```
reason="…/labmon.toml: unknown setting 'timezon'"       exit 2
```

Skipping what it does not recognise gives a misspelled setting the exact appearance of a working one, with nothing at all to notice. The cost is real and accepted: a key written for a newer labmon fails on an older one. That is a message naming the key, which is recoverable; a silently ignored setting is not.

**`"UTC"` resolves without `ZoneInfo`.** The default must not depend on the system timezone database being installed — some slim images have none. A name that *is* rejected says so:

```
reason="…/labmon.toml: 'Mars/Olympus' is not a known timezone. Use an IANA
        name such as 'Europe/Paris', 'UTC', or 'local'. A name that looks
        right but is not found means the system timezone database is
        missing; install 'tzdata'"
```

`ConfigError` joins the exceptions `runtime._report` turns into one logged line and exit 2, so a hand-edited file never produces a traceback.

## Scope, deliberately

**Storage and exports stay in UTC.** All three writers stamp `datetime.now(UTC)` explicitly (`sensors/mock_sensor.py:132`, `sensors/polling.py:90`, `sensors/serial_sensor.py:188`) — an aware instant that never consults `TZ` or `/etc/localtime`, so hosts in different countries write the same instant for the same moment. That property is worth keeping, and a data file carrying somebody's desk clock is unusable to whoever opens it next.

The setting changes **only what a terminal prints**. Grafana's dashboards are already `"timezone": "browser"`, so this closes an inconsistency between the two views rather than opening one.

`query latest` and `sensors` print ages rather than absolute times, so nothing there changes.

## Test isolation

`tests/conftest.py` gains an autouse `_isolated_config` beside `_isolated_cache`. Without it the suite reads the config of whoever runs it, and a passing run on one machine says nothing about another.

## Test plan

- [x] `pytest` — 737 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean, zero warnings
- [x] exercised against the live demo stack: no config, `Europe/Paris`, `local`, a misspelled key, a non-string value, and an unknown zone — the last three exit 2 with one line each
- [x] confirm on a machine with no system tzdata that `"UTC"` and `"local"` still work and a named zone gives the install-`tzdata` message

Refs #156. The rest of the stack is now open on top of this: #171 (window statistics), #172 (`labmon monitor` itself) and #177 (configured tiles).


