### PR TITLE
feat(cli): add labmon monitor, a refreshing terminal panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ together visually.*
 - [Connecting a real instrument](#connecting-a-real-instrument)
 - [Logs, next to the measurements](#logs-next-to-the-measurements)
 - [Getting the data out](#getting-the-data-out) — CSV, Parquet, Feather, netCDF
+- [Watching it in the terminal](#watching-it-in-the-terminal) — a panel over SSH
 - [Running it across the lab](#running-it-across-the-lab)
 - [Configuration](docs/configuration.md) — every setting, and where it lives
 - [How it works](#how-it-works)
@@ -324,6 +325,35 @@ rather than only metadata.
 [`docs/loading-exports.md`](docs/loading-exports.md) takes it from the
 other end — loading each file into pandas, polars and xarray, and what
 the shape of the data means once it is there.
+
+## Watching it in the terminal
+
+Grafana is the right tool for a wall display. It is the wrong one for
+the terminal already open next to the experiment, and it is unavailable
+over a bare SSH session — which is exactly when *is the cryostat still
+cold?* is worth asking.
+
+```bash
+pip install 'labmon[tui]'
+labmon monitor
+```
+
+```
+sensor_id      measurement  value                  unit  age     mean             sd       n
+-------------  -----------  ---------------------  ----  ------  ---------------  -------  -----
+wavemeter-1    frequency    2.765613014e+14        Hz    0s ago  2.765612999e+14  2.0e+06  11153
+cryo-77k       temperature  76.704                 K     2s ago  77.0             1.5      4462
+room-1         temperature  21.125                 °C    2s ago  20.93            0.78     4462
+probe-158      temperature  21.0691                K     7h ago  21.069           0.056    3
+
+16 sensors
+18:12:09 · window 24h · refreshing every 2s
+```
+
+Redraws in place, colours a sensor amber then red as it goes quiet, and
+keeps the last good table on screen when the database is briefly
+unreachable rather than tearing down the terminal.
+[`docs/monitor.md`](docs/monitor.md) has the rest.
 
 ## Running it across the lab
 

--- a/README.md
+++ b/README.md
@@ -339,15 +339,28 @@ labmon monitor
 ```
 
 ```
-sensor_id      measurement  value                  unit  age     mean             sd       n
--------------  -----------  ---------------------  ----  ------  ---------------  -------  -----
-wavemeter-1    frequency    2.765613014e+14        Hz    0s ago  2.765612999e+14  2.0e+06  11153
-cryo-77k       temperature  76.704                 K     2s ago  77.0             1.5      4462
-room-1         temperature  21.125                 °C    2s ago  20.93            0.78     4462
-probe-158      temperature  21.0691                K     7h ago  21.069           0.056    3
-
-16 sensors
-18:12:09 · window 24h · refreshing every 2s
+                                               labmon                                               
+╭─────────────┬───────────────┬─────────────────┬──────┬────────┬─────────────────┬─────────┬──────╮
+│ measurement │ sensor        │           value │ unit │ age    │            mean │      sd │    n │
+├─────────────┼───────────────┼─────────────────┼──────┼────────┼─────────────────┼─────────┼──────┤
+│ frequency   │ wavemeter-1   │ 2.765612976e+14 │ Hz   │ 2s ago │ 2.765613000e+14 │ 1.9e+06 │  899 │
+│ frequency   │ wavemeter-thz │                 │ THz  │ 4h ago │                 │         │      │
+│ position    │ beam-x        │               4 │ µm   │ 2s ago │               0 │      19 │ 1797 │
+│ position    │ beam-y        │              22 │ µm   │ 2s ago │               0 │      16 │ 1797 │
+│ power       │ laser-1       │            90.8 │ mW   │ 2s ago │            95.0 │     8.9 │ 1797 │
+│ pressure    │ chamber-1     │        1.40e-07 │ mbar │ 3s ago │        1.34e-07 │ 2.1e-08 │  360 │
+│ pressure    │ dual-probe    │                 │ mbar │ 6h ago │                 │         │      │
+│ pressure    │ pirani-1      │           9e-09 │ mbar │ 2s ago │         2.9e-08 │ 3.4e-08 │ 1797 │
+│ temperature │ cryo-4k       │            4.06 │ K    │ 3s ago │            4.26 │    0.24 │  360 │
+│ temperature │ cryo-77k      │            78.6 │ K    │ 3s ago │            76.8 │     1.7 │  360 │
+│ temperature │ cryo-diode    │              41 │ K    │ 2s ago │              28 │      11 │ 1797 │
+│ temperature │ dual-probe    │                 │ K    │ 6h ago │                 │         │      │
+│ temperature │ probe-158     │                 │ K    │ 8h ago │                 │         │      │
+│ temperature │ room-1        │           20.69 │ °C   │ 3s ago │           21.18 │    0.60 │  360 │
+│ temperature │ room-2        │           22.68 │ °C   │ 3s ago │           22.41 │    0.70 │  360 │
+│ voltage     │ bias-monitor  │            -3.1 │ V    │ 2s ago │               0 │     2.2 │ 1797 │
+╰─────────────┴───────────────┴─────────────────┴──────┴────────┴─────────────────┴─────────┴──────╯
+                       16 sensors, 4 quiet · window 30m · every 2s · 19:17:06
 ```
 
 Redraws in place, colours a sensor amber then red as it goes quiet, and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,24 @@ timezone = "Europe/Paris"
 | Key | Default | Purpose |
 |---|---|---|
 | `timezone` | `"UTC"` | Zone the `time` column is printed in. An IANA name, or `"local"` for the machine's own zone |
+| `monitor.refresh` | `"2s"` | How often `labmon monitor` redraws |
+| `monitor.window` | `"15m"` | How much history the panel's statistics cover |
+
+```toml
+timezone = "Europe/Paris"
+
+[monitor]
+refresh = "2s"
+window  = "15m"
+```
+
+Durations are spelled the way `--since` spells them — `2s`, `90m`,
+`24h`, `7d`, `1w` — because one parser serves both. A bare number is
+refused: `2` could be seconds or minutes, and a panel that guesses wrong
+refreshes sixty times too often. Both `[monitor]` values are validated
+when the file is read rather than when they are first used, since a
+mistake that surfaced on the first tick would already have taken over
+the terminal. See [`docs/monitor.md`](monitor.md).
 
 `timezone` changes only what a terminal prints. Readings are stored in
 UTC and exported in UTC — a data file that carried somebody's desk clock

--- a/docs/export.md
+++ b/docs/export.md
@@ -321,9 +321,20 @@ value is.** A sensor that stopped writing an hour ago still has a most
 recent reading, and it looks perfectly healthy until you can see when it
 arrived — `probe-158` above is the row worth noticing.
 
-Rows are ordered by age with the oldest last, so the sensor that has
-gone quiet is the line an eye lands on. In a terminal the age is
-coloured: unmarked under a minute, amber up to five, red beyond. Those
+Rows are ordered by **measurement, then sensor**, alphabetically and by
+nothing else. Age was the obvious key while this view printed once and
+exited — it put the sensor that had stopped on the last line, where an
+eye lands. It is unusable on anything that redraws: every row moves on
+every tick, so no row can be followed and reading one value means
+finding it again first. `labmon monitor` shares this renderer, and the
+same order is used by `labmon sensors`, so a sensor sits in the same
+place in all three.
+
+The measurement leads because it is what the rows are sorted by. A table
+ordered by a column it does not show first looks arbitrary.
+
+Staleness is carried by colour instead, which does not depend on
+position: unmarked under a minute, amber up to five, red beyond. Those
 thresholds are global for now; sensors here legitimately run from 1 Hz
 to once a minute, so a per-sensor expectation is the better answer and
 belongs in a configuration file.
@@ -342,17 +353,17 @@ swinging. `--stats` adds the mean, the standard deviation and the number
 of readings over the same window:
 
 ```bash
-labmon query latest --stats --since 15m
+labmon query latest --stats --since 24h
 ```
 
 ```
-sensor_id      measurement  value                  unit  age     mean             sd       n
--------------  -----------  ---------------------  ----  ------  ---------------  -------  -----
-wavemeter-1    frequency    2.765612984e+14        Hz    2h ago  2.765612999e+14  2.0e+06  11136
-laser-1        power        101.77054945054947     mW    2h ago  95.0             8.8      22262
-cryo-77k       temperature  80.735                 K     2h ago  77.0             1.5      4455
-room-1         temperature  19.737                 °C    2h ago  20.93            0.78     4455
-wavemeter-thz  frequency    276.5613007            THz   3h ago  276.56130115     3.1e-07  8
+measurement  sensor_id      value                  unit  age     mean             sd       n    
+-----------  -------------  ---------------------  ----  ------  ---------------  -------  -----
+frequency    wavemeter-1    2.765612976e+14        Hz    2s ago  2.765612998e+14  2.0e+06  13101
+frequency    wavemeter-thz  276.5613007            THz   4h ago  276.56130115     3.1e-07  8
+position     beam-x         6.462197802197792      µm    2s ago  0                19       26189
+position     beam-y         21.799340659340643     µm    2s ago  0                16       26189
+power        laser-1        90.24996336996337      mW    2s ago  95.0             8.8      26189
 ```
 
 These come from the **same grouping as the value**, in the same query —

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -1,0 +1,117 @@
+# Watching values in the terminal
+
+`labmon monitor` opens a panel that redraws itself, showing where every
+sensor stands and how its window has behaved.
+
+```bash
+labmon monitor
+labmon monitor --since 1h --refresh 5s
+labmon monitor --measurement temperature
+```
+
+```
+sensor_id      measurement  value                  unit  age     mean             sd       n
+-------------  -----------  ---------------------  ----  ------  ---------------  -------  -----
+wavemeter-1    frequency    2.765613014e+14        Hz    0s ago  2.765612999e+14  2.0e+06  11153
+cryo-77k       temperature  76.704                 K     2s ago  77.0             1.5      4462
+cryo-4k        temperature  4.103                  K     2s ago  4.11             0.25     4462
+room-1         temperature  21.125                 °C    2s ago  20.93            0.78     4462
+wavemeter-thz  frequency    276.5613007            THz   3h ago  276.56130115     3.1e-07  8
+probe-158      temperature  21.0691                K     7h ago  21.069           0.056    3
+
+16 sensors
+18:12:09 · window 24h · refreshing every 2s
+```
+
+`q` quits. `r` redraws immediately, for when waiting out the cadence is
+one second too many.
+
+Needs the `tui` extra, which brings in Textual:
+
+```bash
+pip install 'labmon[tui]'
+```
+
+Running it without that gives the install command rather than an import
+traceback.
+
+## Why not just leave Grafana open
+
+Grafana is the right tool for a wall display and for digging through
+history. It is the wrong one for the terminal that is already open next
+to the experiment, and it is unavailable over a bare SSH session — which
+is exactly the moment "is the cryostat still cold?" is worth asking.
+
+## What it shows, and what it shares
+
+The panel shows exactly what `labmon query latest --stats` shows: the
+same selection layer, the same renderer, the same notion of staleness.
+Two implementations of "the latest value and how old it is" would drift,
+and the one that drifted would be the one nobody was watching.
+
+That means everything from
+[`docs/export.md`](export.md#what-is-everything-reading-right-now)
+applies here — the age colouring, the sensors remembered from the roster
+when they have gone quiet, the mean rounded against its own deviation.
+
+`n` deserves a second look on a live panel. Sensors here legitimately
+run from 1 Hz down to once a minute, so a tile that has not changed in
+thirty seconds might be perfectly healthy or might be dead. The reading
+count over the window is what separates the two.
+
+## How a refresh works
+
+Each tick re-queries the whole window and replaces the result. It does
+not append to what it already has.
+
+That is what Grafana does with a SQL datasource, and the measurements
+say why it is right here too. Pulling every reading from every sensor,
+against the demo stack:
+
+| window | rows | time |
+|---|---|---|
+| 5 minutes | 2 298 | 11 ms |
+| 15 minutes | 6 918 | 14 ms |
+| 1 hour | 27 694 | 19 ms |
+
+Fourteen milliseconds against a two-second cadence is not worth
+optimising. An incremental design would have to carry per-sensor
+watermarks, handle late-arriving points and reconcile after a dropped
+connection — real state, and real bugs, to save single-digit
+milliseconds.
+
+Re-querying is also **self-healing**. After a network blip the next tick
+is simply correct, with no gap to detect and no backfill to run.
+
+The query runs on a worker thread. It blocks for tens of milliseconds,
+which is long enough to make a keypress feel sticky, and there is no
+reason for `q` to wait for a database.
+
+## When a refresh fails
+
+The panel does not exit. The last good table stays on screen and the
+status line says what happened:
+
+```
+cannot reach the database — showing the last good reading · window 15m · refreshing every 2s
+```
+
+A panel that tore down the terminal on one unreachable moment would be
+worse than useless next to a running experiment. The window is
+re-queried every tick anyway, so recovery needs no action.
+
+## Settings
+
+`--since` and `--refresh` override the configuration file for one run.
+The file is where a decision worth keeping goes — see
+[`docs/configuration.md`](configuration.md#the-user-configuration-file):
+
+```toml
+[monitor]
+refresh = "2s"
+window  = "15m"
+```
+
+Both are checked when the file is read, not when they are first used. A
+mistake that surfaced on the first tick would already have taken over
+the terminal.

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -10,21 +10,35 @@ labmon monitor --measurement temperature
 ```
 
 ```
-sensor_id      measurement  value                  unit  age     mean             sd       n
--------------  -----------  ---------------------  ----  ------  ---------------  -------  -----
-wavemeter-1    frequency    2.765613014e+14        Hz    0s ago  2.765612999e+14  2.0e+06  11153
-cryo-77k       temperature  76.704                 K     2s ago  77.0             1.5      4462
-cryo-4k        temperature  4.103                  K     2s ago  4.11             0.25     4462
-room-1         temperature  21.125                 °C    2s ago  20.93            0.78     4462
-wavemeter-thz  frequency    276.5613007            THz   3h ago  276.56130115     3.1e-07  8
-probe-158      temperature  21.0691                K     7h ago  21.069           0.056    3
-
-16 sensors
-18:12:09 · window 24h · refreshing every 2s
+                                               labmon                                               
+╭─────────────┬───────────────┬─────────────────┬──────┬────────┬─────────────────┬─────────┬──────╮
+│ measurement │ sensor        │           value │ unit │ age    │            mean │      sd │    n │
+├─────────────┼───────────────┼─────────────────┼──────┼────────┼─────────────────┼─────────┼──────┤
+│ frequency   │ wavemeter-1   │ 2.765612976e+14 │ Hz   │ 2s ago │ 2.765613000e+14 │ 1.9e+06 │  899 │
+│ frequency   │ wavemeter-thz │                 │ THz  │ 4h ago │                 │         │      │
+│ position    │ beam-x        │               4 │ µm   │ 2s ago │               0 │      19 │ 1797 │
+│ position    │ beam-y        │              22 │ µm   │ 2s ago │               0 │      16 │ 1797 │
+│ power       │ laser-1       │            90.8 │ mW   │ 2s ago │            95.0 │     8.9 │ 1797 │
+│ pressure    │ chamber-1     │        1.40e-07 │ mbar │ 3s ago │        1.34e-07 │ 2.1e-08 │  360 │
+│ pressure    │ dual-probe    │                 │ mbar │ 6h ago │                 │         │      │
+│ pressure    │ pirani-1      │           9e-09 │ mbar │ 2s ago │         2.9e-08 │ 3.4e-08 │ 1797 │
+│ temperature │ cryo-4k       │            4.06 │ K    │ 3s ago │            4.26 │    0.24 │  360 │
+│ temperature │ cryo-77k      │            78.6 │ K    │ 3s ago │            76.8 │     1.7 │  360 │
+│ temperature │ cryo-diode    │              41 │ K    │ 2s ago │              28 │      11 │ 1797 │
+│ temperature │ dual-probe    │                 │ K    │ 6h ago │                 │         │      │
+│ temperature │ probe-158     │                 │ K    │ 8h ago │                 │         │      │
+│ temperature │ room-1        │           20.69 │ °C   │ 3s ago │           21.18 │    0.60 │  360 │
+│ temperature │ room-2        │           22.68 │ °C   │ 3s ago │           22.41 │    0.70 │  360 │
+│ voltage     │ bias-monitor  │            -3.1 │ V    │ 2s ago │               0 │     2.2 │ 1797 │
+╰─────────────┴───────────────┴─────────────────┴──────┴────────┴─────────────────┴─────────┴──────╯
+                       16 sensors, 4 quiet · window 30m · every 2s · 19:17:06
 ```
 
 `q` quits. `r` redraws immediately, for when waiting out the cadence is
-one second too many.
+one second too many. `p` opens the command palette, where the colour
+theme can be changed — the default is `nord`, chosen for being calm at a
+glance and legible on a projector, which is where a panel beside an
+experiment tends to end up.
 
 Needs the `tui` extra, which brings in Textual:
 
@@ -41,6 +55,31 @@ Grafana is the right tool for a wall display and for digging through
 history. It is the wrong one for the terminal that is already open next
 to the experiment, and it is unavailable over a bare SSH session — which
 is exactly the moment "is the cryostat still cold?" is worth asking.
+
+## Rows stay where you left them
+
+Ordered by measurement, then by sensor, alphabetically. Nothing about a
+reading moves a row.
+
+This matters more here than anywhere else: a panel sorted by age
+reorders itself on every tick, so following one number means finding it
+again first. Staleness is carried by colour, which does not need a
+position to say anything.
+
+## Readings are rounded to their own noise
+
+The panel shows each value at the precision its standard deviation over
+the window justifies — `76.9 K` rather than `76.92300000000001`, `-7 µm`
+for a beam whose spread is 16 µm.
+
+It is a glance view, read from across a room, and nineteen digits of a
+beam position crowd out the rest of the row while two of them carry
+information. `labmon query latest` is the view that promises the reading
+exactly as stored, and it still does.
+
+A reading with no statistics to round against — one sample in the window
+— is shown in full, because nothing says where its digits stop meaning
+anything.
 
 ## What it shows, and what it shares
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "ruff>=0.16.3",
     "scipy>=1.18.0",
     "scipy-stubs>=1.18.0.1",
+    "textual>=8.2.8",
     "typos>=1.49.0",
     "xarray>=2026.7.0",
 ]
@@ -53,6 +54,9 @@ netcdf = [
     "h5netcdf>=1.3.0",
     "h5py>=3.11.0",
     "xarray>=2024.7.0",
+]
+tui = [
+    "textual>=8.2.8",
 ]
 
 [build-system]

--- a/src/labmon/cli/commands/monitor.py
+++ b/src/labmon/cli/commands/monitor.py
@@ -90,11 +90,21 @@ def monitor(
     try:
         from labmon.cli.tui import Panel
     except ImportError as error:
-        # An ImportError traceback names a module. What somebody needs is
-        # the command that fixes it.
+        # Only when Textual is genuinely absent. Reporting every
+        # ImportError raised while loading that module as "the extra is
+        # missing" would misdiagnose a renamed Textual symbol after an
+        # upgrade, and send somebody to reinstall a package they have.
+        import importlib.util
+        import sys
+
+        if importlib.util.find_spec("textual") is not None:
+            raise
         raise typer.BadParameter(
-            "labmon monitor needs Textual, which is not installed."
-            + " Install it with: pip install 'labmon[tui]'"
+            "labmon monitor needs Textual, which is not installed in"
+            + f" {sys.executable}."
+            + " Install it with: pip install 'labmon[tui]' — or, for an"
+            + " editable checkout installed as a tool,"
+            + " uv tool install --editable '.[tui]' --force"
         ) from error
 
     Panel(

--- a/src/labmon/cli/commands/monitor.py
+++ b/src/labmon/cli/commands/monitor.py
@@ -63,7 +63,8 @@ def monitor(
     from labmon.export.window import WindowError, parse_duration, parse_instant
 
     configure(log_level)
-    settings = load().monitor
+    config = load()
+    settings = config.monitor
 
     cadence = settings.refresh
     if refresh is not None:
@@ -112,4 +113,5 @@ def monitor(
         sensor_ids=sensor_id,
         window=window,
         refresh=cadence,
+        tz=config.timezone,
     ).run()

--- a/src/labmon/cli/commands/monitor.py
+++ b/src/labmon/cli/commands/monitor.py
@@ -1,0 +1,105 @@
+"""`labmon monitor` — a panel to leave open beside the experiment."""
+
+from typing import Annotated
+
+import typer
+
+from labmon.cli.options import LogLevelOption, Measurements, SensorIds
+from labmon.cli.runtime import configure
+
+HELP = (
+    "Watch current sensor values in the terminal, refreshing in place."
+    + "\n\n"
+    + "Grafana is the right tool for a wall display or for digging"
+    + " through history. It is the wrong one for the terminal already"
+    + " open next to the experiment, and it is unavailable over a bare"
+    + " SSH session — which is exactly when [italic]is the cryostat"
+    + " still cold?[/italic] matters most."
+    + "\n\n"
+    + "Shows what [bold]labmon query latest --stats[/bold] shows, drawn"
+    + " again every couple of seconds. [bold]q[/bold] quits,"
+    + " [bold]r[/bold] refreshes without waiting."
+    + "\n\n"
+    + "Needs the [bold]tui[/bold] extra: pip install 'labmon[tui]'"
+    + "\n\n"
+    + "[bold]Examples[/bold]\n\n"
+    + "    labmon monitor\n"
+    + "    labmon monitor --since 1h --refresh 5s\n"
+    + "    labmon monitor --measurement temperature"
+)
+
+Refresh = Annotated[
+    str | None,
+    typer.Option(
+        "--refresh",
+        help="How often to redraw, as a duration (2s, 500ms is not a unit;"
+        + " use 1s). Default: the configuration file, else 2s",
+        metavar="EVERY",
+        show_default=False,
+    ),
+]
+
+Window = Annotated[
+    str | None,
+    typer.Option(
+        "--since",
+        help="How much history the statistics cover, same spellings as"
+        + " elsewhere. Default: the configuration file, else 15m",
+        metavar="WHEN",
+        show_default=False,
+    ),
+]
+
+
+def monitor(
+    measurement: Measurements = None,
+    sensor_id: SensorIds = None,
+    since: Window = None,
+    refresh: Refresh = None,
+    log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
+) -> None:
+    """Watch current sensor values in the terminal, refreshing in place."""
+    from labmon.config import load
+    from labmon.export.window import WindowError, parse_duration, parse_instant
+
+    configure(log_level)
+    settings = load().monitor
+
+    cadence = settings.refresh
+    if refresh is not None:
+        try:
+            cadence = parse_duration(refresh)
+        except WindowError as error:
+            raise typer.BadParameter(str(error), param_hint="--refresh") from None
+        if cadence <= 0:
+            raise typer.BadParameter(
+                "every zero seconds is a busy loop, not a fast panel",
+                param_hint="--refresh",
+            )
+
+    window = settings.window
+    if since is not None:
+        try:
+            # Checked before the screen is cleared: a mistake that
+            # surfaces on the first tick has already taken the terminal.
+            _ = parse_instant(since)
+        except WindowError as error:
+            raise typer.BadParameter(str(error), param_hint="--since") from None
+        window = since
+
+    try:
+        from labmon.cli.tui import Panel
+    except ImportError as error:
+        # An ImportError traceback names a module. What somebody needs is
+        # the command that fixes it.
+        raise typer.BadParameter(
+            "labmon monitor needs Textual, which is not installed."
+            + " Install it with: pip install 'labmon[tui]'"
+        ) from error
+
+    Panel(
+        measurements=measurement,
+        sensor_ids=sensor_id,
+        window=window,
+        refresh=cadence,
+    ).run()

--- a/src/labmon/cli/main.py
+++ b/src/labmon/cli/main.py
@@ -14,6 +14,7 @@ import typer
 
 from labmon.cli.commands import export as export_command
 from labmon.cli.commands import mock_sensor as mock_sensor_command
+from labmon.cli.commands import monitor as monitor_command
 from labmon.cli.commands import query as query_command
 from labmon.cli.commands import sensors as sensors_command
 from labmon.cli.commands import serial_sensor as serial_sensor_command
@@ -64,6 +65,9 @@ def build_app() -> typer.Typer:
     app.add_typer(query_app, name="query")
     _ = app.command("sensors", help=sensors_command.HELP)(
         reporting(sensors_command.sensors)
+    )
+    _ = app.command("monitor", help=monitor_command.HELP)(
+        reporting(monitor_command.monitor)
     )
     _ = app.command("export", help=export_command.HELP)(
         reporting(export_command.export)

--- a/src/labmon/cli/monitor.py
+++ b/src/labmon/cli/monitor.py
@@ -19,7 +19,11 @@ next tick is simply correct, with no gap to detect or backfill.
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime, tzinfo
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from labmon.cli.render import LatestRow
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -28,14 +32,27 @@ logger: logging.Logger = logging.getLogger(__name__)
 class Snapshot:
     """What one refresh produced, successful or not.
 
+    Carries rows rather than rendered text. The plain table
+    `labmon query latest` prints and the panel `labmon monitor` draws
+    are two presentations of the same `LatestRow` values, which is what
+    keeps them from disagreeing about a reading or its staleness while
+    still letting one of them have a border and a colour scheme.
+
     A failure is carried rather than raised. A panel that dies on one
     unreachable moment is useless next to an experiment, and the window
     is re-queried every tick anyway, so the recovery is automatic.
     """
 
-    body: str
     taken: datetime
+    columns: tuple[str, ...] = ()
+    rows: tuple["LatestRow", ...] = ()
+    quiet: int = 0
     error: str | None = None
+
+    @property
+    def sensors(self) -> int:
+        """How many sensors the table describes."""
+        return len(self.rows)
 
 
 def take(
@@ -44,18 +61,15 @@ def take(
     window: str,
     *,
     now: datetime | None = None,
-    tz: tzinfo = UTC,
-    colour: bool = True,
 ) -> Snapshot:
-    """Query the window and render it, or say why that failed."""
+    """Query the window and lay it out in rows, or say why that failed."""
     from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
 
     from labmon.cli import selection
-    from labmon.cli.render import render_latest
+    from labmon.cli.render import latest_rows
     from labmon.export.query import QueryError
     from labmon.export.window import WindowError
 
-    _ = tz  # the latest view reports ages, not absolute times
     moment = now or datetime.now(UTC)
     try:
         table, silent = selection.read_latest_with_roster(
@@ -74,12 +88,10 @@ def take(
         # unreachable moment is no reason to tear down a terminal an
         # experiment is being watched on.
         logger.debug("refresh failed", extra={"reason": str(error)})
-        return Snapshot(body="", taken=moment, error=str(error))
+        return Snapshot(taken=moment, error=str(error))
 
-    return Snapshot(
-        body=render_latest(table, now=moment, colour=colour, silent=silent),
-        taken=moment,
-    )
+    columns, rows = latest_rows(table, moment, silent=silent, round_values=True)
+    return Snapshot(taken=moment, columns=columns, rows=tuple(rows), quiet=len(silent))
 
 
 def status(snapshot: Snapshot, *, window: str, refresh: float) -> str:
@@ -89,10 +101,14 @@ def status(snapshot: Snapshot, *, window: str, refresh: float) -> str:
     changes what the numbers above it mean — they are now stale, and
     nothing else on screen says so.
     """
-    cadence = f"window {window} · refreshing every {_seconds(refresh)}"
+    cadence = f"window {window} · every {_seconds(refresh)}"
     if snapshot.error is not None:
         return f"{snapshot.error} — showing the last good reading · {cadence}"
-    return f"{snapshot.taken.strftime('%H:%M:%S')} · {cadence}"
+
+    counted = f"{snapshot.sensors} sensor{'s' if snapshot.sensors != 1 else ''}"
+    if snapshot.quiet:
+        counted += f", {snapshot.quiet} quiet"
+    return f"{counted} · {cadence} · {snapshot.taken.strftime('%H:%M:%S')}"
 
 
 def _seconds(value: float) -> str:

--- a/src/labmon/cli/monitor.py
+++ b/src/labmon/cli/monitor.py
@@ -19,7 +19,7 @@ next tick is simply correct, with no gap to detect or backfill.
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, tzinfo
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -94,12 +94,17 @@ def take(
     return Snapshot(taken=moment, columns=columns, rows=tuple(rows), quiet=len(silent))
 
 
-def status(snapshot: Snapshot, *, window: str, refresh: float) -> str:
+def status(snapshot: Snapshot, *, window: str, refresh: float, tz: tzinfo = UTC) -> str:
     """The line under the table: what is being shown, and how often.
 
     A failure leads, because it is the one thing on the line that
     changes what the numbers above it mean — they are now stale, and
     nothing else on screen says so.
+
+    The refresh time is moved into the reader's zone for the same reason
+    a `time` column is. Textual's own header clock is already showing
+    local time three lines above this one, so a UTC wall clock here puts
+    two clocks on one screen disagreeing by whole hours.
     """
     cadence = f"window {window} · every {_seconds(refresh)}"
     if snapshot.error is not None:
@@ -108,7 +113,8 @@ def status(snapshot: Snapshot, *, window: str, refresh: float) -> str:
     counted = f"{snapshot.sensors} sensor{'s' if snapshot.sensors != 1 else ''}"
     if snapshot.quiet:
         counted += f", {snapshot.quiet} quiet"
-    return f"{counted} · {cadence} · {snapshot.taken.strftime('%H:%M:%S')}"
+    clock = snapshot.taken.astimezone(tz).strftime("%H:%M:%S")
+    return f"{counted} · {cadence} · {clock}"
 
 
 def _seconds(value: float) -> str:

--- a/src/labmon/cli/monitor.py
+++ b/src/labmon/cli/monitor.py
@@ -1,0 +1,100 @@
+"""One tick of the terminal panel: the text, and what went wrong.
+
+Separated from the Textual application so that almost all of the panel
+can be tested without an event loop, and so that the panel and
+`labmon query latest` cannot disagree about what "latest" means — the
+same selection layer and the same renderer produce both.
+
+Refreshing re-queries the whole window rather than appending to what it
+already has. That is what Grafana does with a SQL datasource, and the
+numbers say why: the readings a fifteen-minute window holds cost about
+14 ms to pull. Against a two-second cadence that is not worth
+optimising, and an incremental design would have to carry per-sensor
+watermarks, handle late-arriving points and reconcile after a dropped
+connection — real state and real bugs, to save single-digit
+milliseconds. Re-querying is also self-healing: after a network blip the
+next tick is simply correct, with no gap to detect or backfill.
+"""
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, tzinfo
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """What one refresh produced, successful or not.
+
+    A failure is carried rather than raised. A panel that dies on one
+    unreachable moment is useless next to an experiment, and the window
+    is re-queried every tick anyway, so the recovery is automatic.
+    """
+
+    body: str
+    taken: datetime
+    error: str | None = None
+
+
+def take(
+    measurements: Sequence[str] | None,
+    sensor_ids: Sequence[str] | None,
+    window: str,
+    *,
+    now: datetime | None = None,
+    tz: tzinfo = UTC,
+    colour: bool = True,
+) -> Snapshot:
+    """Query the window and render it, or say why that failed."""
+    from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
+
+    from labmon.cli import selection
+    from labmon.cli.render import render_latest
+    from labmon.export.query import QueryError
+    from labmon.export.window import WindowError
+
+    _ = tz  # the latest view reports ages, not absolute times
+    moment = now or datetime.now(UTC)
+    try:
+        table, silent = selection.read_latest_with_roster(
+            measurements, sensor_ids, window, None, stats=True
+        )
+    except (
+        InfluxDB3ClientError,
+        QueryError,
+        WindowError,
+        OSError,
+        KeyError,
+    ) as error:
+        # The same failures `labmon.cli.runtime` turns into exit codes.
+        # Here they mean "no answer this tick" instead: the panel says so
+        # on its status line and tries again in two seconds, because one
+        # unreachable moment is no reason to tear down a terminal an
+        # experiment is being watched on.
+        logger.debug("refresh failed", extra={"reason": str(error)})
+        return Snapshot(body="", taken=moment, error=str(error))
+
+    return Snapshot(
+        body=render_latest(table, now=moment, colour=colour, silent=silent),
+        taken=moment,
+    )
+
+
+def status(snapshot: Snapshot, *, window: str, refresh: float) -> str:
+    """The line under the table: what is being shown, and how often.
+
+    A failure leads, because it is the one thing on the line that
+    changes what the numbers above it mean — they are now stale, and
+    nothing else on screen says so.
+    """
+    cadence = f"window {window} · refreshing every {_seconds(refresh)}"
+    if snapshot.error is not None:
+        return f"{snapshot.error} — showing the last good reading · {cadence}"
+    return f"{snapshot.taken.strftime('%H:%M:%S')} · {cadence}"
+
+
+def _seconds(value: float) -> str:
+    """A refresh interval, without a trailing `.0` on a whole number."""
+    return f"{value:g}s"

--- a/src/labmon/cli/quantity.py
+++ b/src/labmon/cli/quantity.py
@@ -156,6 +156,23 @@ def _for_mean(mean: float, place: int) -> int:
     return min(place, math.floor(math.log10(abs(mean))) - (MEAN_FIGURES - 1))
 
 
+def at_the_precision_of(value: float, sd: float | None) -> str | None:
+    """`value` rounded to where `sd` says its digits stop meaning anything.
+
+    For a panel read at a glance rather than a table read carefully.
+    `-7.441802197802218 µm` on a beam whose spread over the window is
+    16 µm is nineteen characters of which two carry information, and it
+    crowds out the rest of the row.
+
+    Returns `None` when there is nothing to round against, so the caller
+    can fall back to showing the reading in full.
+    """
+    if sd is None or not math.isfinite(sd) or sd == 0.0 or not math.isfinite(value):
+        return None
+    place = math.floor(math.log10(abs(sd))) - (DEVIATION_FIGURES - 1)
+    return _at_place(value, place)
+
+
 def _at_place(value: float, place: int) -> str:
     """`value` rounded to `10 ** place`, plain or scientific to match `show`.
 

--- a/src/labmon/cli/render.py
+++ b/src/labmon/cli/render.py
@@ -6,11 +6,12 @@ wants the few columns that carry meaning, aligned, in a width that fits.
 """
 
 from collections.abc import Container, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, cast
 
 from labmon.cli.age import Freshness, describe, freshness
-from labmon.cli.quantity import quote, show
+from labmon.cli.quantity import at_the_precision_of, quote, show
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -136,13 +137,18 @@ def render(table: "pa.Table", limit: int = DEFAULT_LIMIT, tz: tzinfo = UTC) -> s
 # The latest reading from each sensor
 # --------------------------------------------------------------------------
 
+# `measurement` leads because the rows are sorted by it. A table
+# ordered by a column that is not the first one it shows looks
+# arbitrary, which is the readability problem the ordering was meant to
+# solve.
+#
 # `mean`, `sd` and `n` are last because they are only sometimes there:
 # `render_latest` shows a column when the table carries it, so asking
 # the query for statistics is the only switch, and the view cannot
 # disagree with what was fetched.
 LATEST_COLUMNS: tuple[str, ...] = (
-    "sensor_id",
     "measurement",
+    "sensor_id",
     "value",
     "unit",
     "age",
@@ -162,6 +168,105 @@ _STYLES: dict[Freshness, str] = {
 _RESET = "\x1b[0m"
 
 
+@dataclass(frozen=True)
+class LatestRow:
+    """One sensor's line, independent of how it is finally drawn.
+
+    Built once and shared: the plain table `labmon query latest` prints
+    and the panel `labmon monitor` draws are two presentations of these,
+    so they cannot disagree about what a sensor's latest reading is or
+    about how stale it has become.
+    """
+
+    cells: tuple[str, ...]
+    age: timedelta
+    state: Freshness
+
+
+def latest_rows(
+    table: "pa.Table",
+    now: datetime,
+    *,
+    silent: "Sequence[Known]" = (),
+    round_values: bool = False,
+) -> tuple[tuple[str, ...], list[LatestRow]]:
+    """The columns worth showing, and one row per sensor, in order.
+
+    **Ordered by measurement, then by sensor.** Alphabetically, and by
+    nothing else. Age was the obvious key on a view that prints once and
+    exits — it put the sensor that had stopped on the last line, where
+    an eye lands. It is unusable on a panel that redraws every two
+    seconds: every row moves on every tick, so no row can be followed
+    and reading one value means finding it again first. Staleness is
+    carried by colour, which does not depend on position.
+
+    A sensor the roster remembers but the query did not return sorts
+    among the others rather than at the end. It is remembered, not
+    exiled, and its blank value already says what it is.
+
+    `round_values` shows each reading at the precision its own deviation
+    over the window justifies. It is off for `labmon query latest`,
+    which promises the reading exactly as stored, and on for the panel,
+    which is read at a glance from across a room and where nineteen
+    digits of a beam position crowd out the rest of the row. Nothing is
+    lost: the exact value is one `labmon query latest` away.
+    """
+    columns = {name: table.column(name).to_pylist() for name in table.column_names}
+    present = tuple(name for name in LATEST_COLUMNS if name == "age" or name in columns)
+
+    rows: list[tuple[tuple[str, str], LatestRow]] = []
+    for index in range(table.num_rows):
+        age = now - _as_datetime(columns["time"][index])
+        # `mean` and `sd` are rounded against each other, so neither can
+        # be formatted alone — see `labmon.cli.quantity.quote`.
+        summary = _summary(columns, index, round_values=round_values)
+        cells = tuple(
+            describe(age)
+            if name == "age"
+            else summary[name]
+            if name in summary
+            else _cell(name, columns[name][index])
+            for name in present
+        )
+        rows.append(
+            (
+                (
+                    str(_at(columns, "measurement", index)),
+                    str(columns["sensor_id"][index]),
+                ),
+                LatestRow(cells=cells, age=age, state=freshness(age)),
+            )
+        )
+
+    # Sensors the query returned nothing for, carried in from the roster.
+    # Their value column is left blank rather than filled with the last
+    # reading they ever sent: printed beside a fresh number from another
+    # sensor, an old one reads as current.
+    for entry in silent:
+        age = now - entry.last_seen
+        rows.append(
+            (
+                (entry.measurement, entry.sensor_id),
+                LatestRow(
+                    cells=tuple(_silent_cell(name, entry, age) for name in present),
+                    age=age,
+                    state=freshness(age),
+                ),
+            )
+        )
+
+    rows.sort(key=lambda item: item[0])
+    return present, [row for _key, row in rows]
+
+
+def _at(columns: "dict[str, list[object]]", name: str, index: int) -> object:
+    """One column's value at `index`, or an empty string when absent."""
+    values = columns.get(name)
+    if values is None or values[index] is None:
+        return ""
+    return values[index]
+
+
 def render_latest(
     table: "pa.Table",
     now: datetime,
@@ -169,11 +274,7 @@ def render_latest(
     colour: bool = False,
     silent: "Sequence[Known]" = (),
 ) -> str:
-    """One row per sensor, oldest last, with how long ago it reported.
-
-    Sorted by age rather than by name, ascending, so the sensor that has
-    stopped reporting is the last line — which is where an eye lands on
-    a short list, and it is the row this view exists to surface.
+    """One row per sensor, by measurement then sensor, with its age.
 
     Colour is applied after padding, never before. An escape code counts
     toward `len`, so a cell coloured first pads to fewer visible
@@ -187,42 +288,8 @@ def render_latest(
     if total == 0:
         return "no readings matched"
 
-    columns = {name: table.column(name).to_pylist() for name in table.column_names}
-    ages = [now - _as_datetime(stamp) for stamp in columns["time"]]
-    # Over the live rows only: `total` counts the silent sensors too, and
-    # those carry their age from the roster rather than from this table.
-    order = sorted(range(table.num_rows), key=lambda index: ages[index])
-
-    present = [name for name in LATEST_COLUMNS if name == "age" or name in columns]
-    entries: list[tuple[timedelta, list[str]]] = []
-    for index in order:
-        # `mean` and `sd` are rounded against each other, so neither can
-        # be formatted alone — see `labmon.cli.quantity.quote`.
-        summary = _summary(columns, index)
-        entries.append(
-            (
-                ages[index],
-                [
-                    describe(ages[index])
-                    if name == "age"
-                    else summary.get(name, "")
-                    if name in summary
-                    else _cell(name, columns[name][index])
-                    for name in present
-                ],
-            )
-        )
-    # Sensors the query returned nothing for, carried in from the roster.
-    # Their value column is left blank rather than filled with the last
-    # reading they ever sent: printed beside a fresh number from another
-    # sensor, an old one reads as current.
-    for entry in silent:
-        age = now - entry.last_seen
-        entries.append((age, [_silent_cell(name, entry, age) for name in present]))
-
-    entries.sort(key=lambda item: item[0])
-    rows = [cells for _, cells in entries]
-    styles = [_STYLES[freshness(age)] if colour else "" for age, _ in entries]
+    present, entries = latest_rows(table, now, silent=silent)
+    rows = [row.cells for row in entries]
 
     widths = [
         max(len(name), *(len(row[position]) for row in rows))
@@ -235,10 +302,11 @@ def render_latest(
         ),
         "  ".join("-" * width for width in widths),
     ]
-    for row, style in zip(rows, styles, strict=True):
+    for row, entry in zip(rows, entries, strict=True):
         padded = "  ".join(
             cell.ljust(width) for cell, width in zip(row, widths, strict=True)
         ).rstrip()
+        style = _STYLES[entry.state] if colour else ""
         lines.append(f"{style}{padded}{_RESET}" if style else padded)
 
     lines.append("")
@@ -252,8 +320,10 @@ def render_latest(
     return "\n".join(lines)
 
 
-def _summary(columns: "dict[str, list[object]]", index: int) -> dict[str, str]:
-    """The `mean` and `sd` cells for one row, rounded against each other.
+def _summary(
+    columns: "dict[str, list[object]]", index: int, *, round_values: bool = False
+) -> dict[str, str]:
+    """The cells one row's statistics decide, rounded against each other.
 
     Empty when the table carries no statistics, which is how a result
     fetched without them ends up showing none.
@@ -266,8 +336,17 @@ def _summary(columns: "dict[str, list[object]]", index: int) -> dict[str, str]:
         # No readings to average — the row came from somewhere the
         # aggregate could not be computed.
         return {"mean": "", "sd": ""}
-    shown, spread = quote(mean, sd if isinstance(sd, float) else None)
-    return {"mean": shown, "sd": spread}
+    spread = sd if isinstance(sd, float) else None
+    shown, deviation = quote(mean, spread)
+    cells = {"mean": shown, "sd": deviation}
+
+    if round_values:
+        reading = columns["value"][index]
+        if isinstance(reading, float):
+            matched = at_the_precision_of(reading, spread)
+            if matched is not None:
+                cells["value"] = matched
+    return cells
 
 
 def _silent_cell(name: str, entry: "Known", age: timedelta) -> str:
@@ -305,7 +384,12 @@ def render_roster(
     now: datetime,
     colour: bool = False,
 ) -> str:
-    """The remembered sensors, oldest last, saying which are reporting.
+    """The remembered sensors, in order, saying which are reporting.
+
+    Ordered by measurement then sensor, the same as `render_latest`.
+    Three views of the same kind of table sorting three different ways
+    would make a sensor hard to find in whichever one you were not
+    looking at.
 
     The `source` column is what earns this view its place: it states
     whether a sensor is reporting now or is only remembered, which makes
@@ -319,7 +403,9 @@ def render_roster(
     if not known:
         return "nothing remembered yet"
 
-    entries = sorted(known.values(), key=lambda entry: now - entry.last_seen)
+    entries = sorted(
+        known.values(), key=lambda entry: (entry.measurement, entry.sensor_id)
+    )
     names = ROSTER_COLUMNS if live is not None else ROSTER_COLUMNS[:-1]
     rows = [
         [

--- a/src/labmon/cli/tui.py
+++ b/src/labmon/cli/tui.py
@@ -1,0 +1,100 @@
+"""The Textual application `labmon monitor` runs.
+
+Thin on purpose. Everything that decides *what* to show lives in
+`labmon.cli.monitor`, which needs no event loop and is tested without
+one; this module places it on a screen and arranges for it to happen
+again in two seconds.
+
+Imported only from inside `labmon.cli.commands.monitor`, because Textual
+lives behind the `tui` extra and pulls Rich and a tree of its own
+dependencies. Nothing that merely writes readings should pay for that.
+"""
+
+from datetime import UTC, datetime
+from typing import ClassVar, final, override
+
+from rich.text import Text
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import BindingType
+from textual.widgets import Footer, Header, Static
+
+from labmon.cli.monitor import Snapshot, status, take
+
+
+@final
+class Panel(App[None]):
+    """A table of current values, redrawn on a fixed cadence.
+
+    The query runs in a worker thread. It blocks for tens of
+    milliseconds, which is long enough to make a keypress feel sticky if
+    it ran on the event loop, and there is no reason for `q` to wait for
+    a database.
+    """
+
+    CSS = """
+    Static { padding: 1 2; }
+    #status { color: $text-muted; }
+    """
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        ("q", "quit", "Quit"),
+        ("r", "refresh_now", "Refresh"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        measurements: list[str] | None,
+        sensor_ids: list[str] | None,
+        window: str,
+        refresh: float,
+    ) -> None:
+        super().__init__()
+        self._measurements: list[str] | None = measurements
+        self._sensor_ids: list[str] | None = sensor_ids
+        self._window: str = window
+        self._refresh: float = refresh
+        # The last snapshot, kept so a failed tick can leave the previous
+        # table on screen rather than blanking it. Public because it is
+        # what the tests assert against.
+        self.latest: Snapshot = Snapshot(body="", taken=datetime.now(UTC))
+
+    @override
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static(id="table")
+        yield Static(id="status")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.title = "labmon"
+        self.sub_title = self._window
+        _ = self.set_interval(self._refresh, self.refresh_now)
+        self.refresh_now()
+
+    def action_refresh_now(self) -> None:
+        """`r`, for somebody who does not want to wait for the cadence."""
+        self.refresh_now()
+
+    def refresh_now(self) -> None:
+        _ = self._query()
+
+    @work(thread=True, exclusive=True)
+    def _query(self) -> None:
+        snapshot = take(self._measurements, self._sensor_ids, self._window)
+        self.call_from_thread(self._show, snapshot)
+
+    def _show(self, snapshot: Snapshot) -> None:
+        # A failed tick keeps the previous table: a blank panel says
+        # less than a stale one labelled as stale.
+        if snapshot.error is None or not self.latest.body:
+            self.latest = snapshot
+        else:
+            self.latest = Snapshot(
+                body=self.latest.body, taken=snapshot.taken, error=snapshot.error
+            )
+        self.query_one("#table", Static).update(Text.from_ansi(self.latest.body))
+        self.query_one("#status", Static).update(
+            status(self.latest, window=self._window, refresh=self._refresh)
+        )

--- a/src/labmon/cli/tui.py
+++ b/src/labmon/cli/tui.py
@@ -10,7 +10,7 @@ lives behind the `tui` extra and pulls Rich and a tree of its own
 dependencies. Nothing that merely writes readings should pay for that.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, tzinfo
 from typing import ClassVar, final, override
 
 from rich import box
@@ -60,7 +60,9 @@ _STATE_STYLE: dict[Freshness, str] = {
 }
 
 
-def panel(snapshot: Snapshot, *, window: str, refresh: float) -> RenderableType:
+def panel(
+    snapshot: Snapshot, *, window: str, refresh: float, tz: tzinfo = UTC
+) -> RenderableType:
     """One tick, as something Rich can draw.
 
     Separate from the widget so it can be rendered to text and asserted
@@ -81,7 +83,9 @@ def panel(snapshot: Snapshot, *, window: str, refresh: float) -> RenderableType:
         border_style="dim",
         header_style="bold",
         title=Text("labmon", style="bold"),
-        caption=Text(status(snapshot, window=window, refresh=refresh), style="dim"),
+        caption=Text(
+            status(snapshot, window=window, refresh=refresh, tz=tz), style="dim"
+        ),
         expand=False,
     )
     for name in snapshot.columns:
@@ -140,12 +144,14 @@ class Panel(App[None]):
         sensor_ids: list[str] | None,
         window: str,
         refresh: float,
+        tz: tzinfo = UTC,
     ) -> None:
         super().__init__()
         self._measurements: list[str] | None = measurements
         self._sensor_ids: list[str] | None = sensor_ids
         self._window: str = window
         self._refresh: float = refresh
+        self._tz: tzinfo = tz
         # The last snapshot, kept so a failed tick can leave the previous
         # table on screen rather than blanking it. Public because it is
         # what the tests assert against.
@@ -191,5 +197,10 @@ class Panel(App[None]):
                 error=snapshot.error,
             )
         self.query_one("#table", Static).update(
-            panel(self.latest, window=self._window, refresh=self._refresh)
+            panel(
+                self.latest,
+                window=self._window,
+                refresh=self._refresh,
+                tz=self._tz,
+            )
         )

--- a/src/labmon/cli/tui.py
+++ b/src/labmon/cli/tui.py
@@ -1,9 +1,9 @@
 """The Textual application `labmon monitor` runs.
 
 Thin on purpose. Everything that decides *what* to show lives in
-`labmon.cli.monitor`, which needs no event loop and is tested without
-one; this module places it on a screen and arranges for it to happen
-again in two seconds.
+`labmon.cli.monitor` and `labmon.cli.render`, neither of which needs an
+event loop; this module gives those rows a border, a colour scheme and a
+reason to happen again in two seconds.
 
 Imported only from inside `labmon.cli.commands.monitor`, because Textual
 lives behind the `tui` extra and pulls Rich and a tree of its own
@@ -13,13 +13,101 @@ dependencies. Nothing that merely writes readings should pay for that.
 from datetime import UTC, datetime
 from typing import ClassVar, final, override
 
+from rich import box
+from rich.align import Align
+from rich.console import RenderableType
+from rich.table import Table
 from rich.text import Text
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import BindingType
+from textual.containers import Center, Middle
 from textual.widgets import Footer, Header, Static
 
+from labmon.cli.age import Freshness
 from labmon.cli.monitor import Snapshot, status, take
+
+# The panel's default look. Nord is calm at a glance and legible on a
+# projector, which is where a panel beside an experiment tends to end
+# up. It is a default, not a decision: Textual ships twenty themes and
+# the command palette switches between them live.
+THEME = "nord"
+
+# Columns holding a number, right-aligned so digits line up under each
+# other. A column of left-aligned floats has to be read digit by digit
+# to compare two of them.
+_NUMERIC: frozenset[str] = frozenset({"value", "mean", "sd", "n"})
+
+# What each column is called on screen. The internal names are the
+# database's; a panel has room to spell them.
+_HEADINGS: dict[str, str] = {
+    "measurement": "measurement",
+    "sensor_id": "sensor",
+    "value": "value",
+    "unit": "unit",
+    "age": "age",
+    "mean": "mean",
+    "sd": "sd",
+    "n": "n",
+}
+
+# How a row is tinted by how long ago it last reported. Fresh rows are
+# left alone: colouring everything colours nothing.
+_STATE_STYLE: dict[Freshness, str] = {
+    Freshness.FRESH: "",
+    Freshness.AGEING: "yellow",
+    Freshness.STALE: "red",
+}
+
+
+def panel(snapshot: Snapshot, *, window: str, refresh: float) -> RenderableType:
+    """One tick, as something Rich can draw.
+
+    Separate from the widget so it can be rendered to text and asserted
+    against without starting an application.
+    """
+    if not snapshot.rows:
+        return Align.center(
+            Text(
+                "no readings matched"
+                if snapshot.error is None
+                else str(snapshot.error),
+                style="dim italic",
+            )
+        )
+
+    table = Table(
+        box=box.ROUNDED,
+        border_style="dim",
+        header_style="bold",
+        title=Text("labmon", style="bold"),
+        caption=Text(status(snapshot, window=window, refresh=refresh), style="dim"),
+        expand=False,
+    )
+    for name in snapshot.columns:
+        heading = _HEADINGS.get(name, name)
+        if name in _NUMERIC:
+            # Right-aligned so digits line up under each other, and
+            # never wrapped: a reading split across two lines is a
+            # reading nobody can compare against the one above it.
+            table.add_column(heading, justify="right", no_wrap=True)
+        else:
+            # Folded rather than ellipsised when the terminal is too
+            # narrow. `wavemeter-1` and `wavemeter-thz` both truncate to
+            # `wavemet…`, which makes two rows indistinguishable; folded
+            # onto a second line they stay readable. Giving the text
+            # columns the folding also keeps the numbers at full width.
+            table.add_column(
+                heading,
+                justify="left",
+                style="dim" if name == "unit" else "",
+                overflow="fold",
+            )
+
+    for row in snapshot.rows:
+        table.add_row(*row.cells, style=_STATE_STYLE[row.state])
+
+    return Align.center(table)
 
 
 @final
@@ -33,13 +121,16 @@ class Panel(App[None]):
     """
 
     CSS = """
-    Static { padding: 1 2; }
-    #status { color: $text-muted; }
+    #table {
+        width: auto;
+        height: auto;
+    }
     """
 
     BINDINGS: ClassVar[list[BindingType]] = [
         ("q", "quit", "Quit"),
         ("r", "refresh_now", "Refresh"),
+        ("p", "command_palette", "Theme"),
     ]
 
     def __init__(
@@ -58,16 +149,17 @@ class Panel(App[None]):
         # The last snapshot, kept so a failed tick can leave the previous
         # table on screen rather than blanking it. Public because it is
         # what the tests assert against.
-        self.latest: Snapshot = Snapshot(body="", taken=datetime.now(UTC))
+        self.latest: Snapshot = Snapshot(taken=datetime.now(UTC))
 
     @override
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        yield Static(id="table")
-        yield Static(id="status")
+        with Middle(), Center():
+            yield Static(id="table")
         yield Footer()
 
     def on_mount(self) -> None:
+        self.theme = THEME
         self.title = "labmon"
         self.sub_title = self._window
         _ = self.set_interval(self._refresh, self.refresh_now)
@@ -86,15 +178,18 @@ class Panel(App[None]):
         self.call_from_thread(self._show, snapshot)
 
     def _show(self, snapshot: Snapshot) -> None:
-        # A failed tick keeps the previous table: a blank panel says
-        # less than a stale one labelled as stale.
-        if snapshot.error is None or not self.latest.body:
+        # A failed tick keeps the previous rows: a blank panel says less
+        # than a stale one labelled as stale, and the caption says so.
+        if snapshot.error is None or not self.latest.rows:
             self.latest = snapshot
         else:
             self.latest = Snapshot(
-                body=self.latest.body, taken=snapshot.taken, error=snapshot.error
+                taken=snapshot.taken,
+                columns=self.latest.columns,
+                rows=self.latest.rows,
+                quiet=self.latest.quiet,
+                error=snapshot.error,
             )
-        self.query_one("#table", Static).update(Text.from_ansi(self.latest.body))
-        self.query_one("#status", Static).update(
-            status(self.latest, window=self._window, refresh=self._refresh)
+        self.query_one("#table", Static).update(
+            panel(self.latest, window=self._window, refresh=self._refresh)
         )

--- a/src/labmon/config.py
+++ b/src/labmon/config.py
@@ -48,16 +48,43 @@ class ConfigError(Exception):
     """
 
 
+# What `labmon monitor` does when the file says nothing. Two seconds is
+# fast enough that a value looks live and slow enough that a 14 ms query
+# is nowhere near the duty cycle; fifteen minutes of history is enough
+# for a trend without being enough to wait for.
+DEFAULT_REFRESH = "2s"
+DEFAULT_WINDOW = "15m"
+
+
+@dataclass(frozen=True)
+class Monitor:
+    """How the terminal panel behaves.
+
+    `refresh` is seconds, already parsed: the file spells it "2s" the
+    way `--since` is spelled, and resolving it here means a bad value is
+    caught on load rather than on the first tick, after the panel has
+    drawn itself over the terminal.
+
+    `window` stays as written, because that is what the selection layer
+    takes. It is parsed on load all the same, and the result thrown
+    away, so a typo cannot wait for a refresh to surface.
+    """
+
+    refresh: float = 2.0
+    window: str = DEFAULT_WINDOW
+
+
 @dataclass(frozen=True)
 class Config:
     """Everything the configuration file settles.
 
-    One field today. It is a dataclass rather than a bare timezone so
-    that adding the monitor's layout does not change every signature
-    that carries the configuration around.
+    A dataclass rather than a bare timezone so that adding a section
+    does not change every signature that carries the configuration
+    around.
     """
 
     timezone: tzinfo = UTC
+    monitor: Monitor = Monitor()
 
 
 def config_path() -> Path:
@@ -99,7 +126,7 @@ def load(path: Path | None = None) -> Config:
 
 def _from_document(document: dict[str, object], where: Path) -> Config:
     """Build a `Config` from a parsed document, or say what is wrong."""
-    unknown = sorted(set(document) - {"timezone"})
+    unknown = sorted(set(document) - {"timezone", "monitor"})
     if unknown:
         raise ConfigError(
             f"{where}: unknown setting{'s' if len(unknown) > 1 else ''}"
@@ -111,7 +138,60 @@ def _from_document(document: dict[str, object], where: Path) -> Config:
         raise ConfigError(
             f"{where}: timezone must be a string, not {type(zone).__name__}"
         )
-    return Config(timezone=_resolve(zone, where))
+    return Config(
+        timezone=_resolve(zone, where),
+        monitor=_monitor(document.get("monitor", {}), where),
+    )
+
+
+def _monitor(section: object, where: Path) -> Monitor:
+    """The `[monitor]` table, with every value checked on the way in."""
+    if not isinstance(section, dict):
+        raise ConfigError(
+            f"{where}: monitor must be a table written as [monitor],"
+            + f" not {type(section).__name__}"
+        )
+    table = cast(dict[str, object], section)
+
+    unknown = sorted(set(table) - {"refresh", "window"})
+    if unknown:
+        raise ConfigError(
+            f"{where}: unknown monitor setting{'s' if len(unknown) > 1 else ''}"
+            + f" {', '.join(repr(name) for name in unknown)}"
+        )
+
+    from labmon.export.window import WindowError, parse_duration, parse_instant
+
+    refresh = table.get("refresh", DEFAULT_REFRESH)
+    if not isinstance(refresh, str):
+        raise ConfigError(
+            f"{where}: monitor.refresh must be a duration in quotes such as"
+            + f' "2s", not {type(refresh).__name__}'
+        )
+    try:
+        seconds = parse_duration(refresh)
+    except WindowError as error:
+        raise ConfigError(f"{where}: monitor.refresh — {error}") from None
+    if seconds <= 0:
+        raise ConfigError(
+            f"{where}: monitor.refresh must be greater than zero;"
+            + " every zero seconds is a busy loop, not a fast panel"
+        )
+
+    window = table.get("window", DEFAULT_WINDOW)
+    if not isinstance(window, str):
+        raise ConfigError(
+            f'{where}: monitor.window must be a string such as "15m",'
+            + f" not {type(window).__name__}"
+        )
+    try:
+        # Parsed and thrown away. The selection layer wants the text, but
+        # a typo caught here beats one that surfaces on the first tick.
+        _ = parse_instant(window)
+    except WindowError as error:
+        raise ConfigError(f"{where}: monitor.window — {error}") from None
+
+    return Monitor(refresh=seconds, window=window)
 
 
 def _resolve(name: str, where: Path) -> tzinfo:

--- a/src/labmon/export/window.py
+++ b/src/labmon/export/window.py
@@ -34,6 +34,31 @@ class WindowError(ValueError):
     """A --since or --until value that cannot be understood."""
 
 
+def parse_duration(text: str) -> float:
+    """A duration such as "2s", "15m" or "24h", as seconds.
+
+    Split out from `parse_instant` so that the places wanting a plain
+    interval — how often a panel refreshes — spell one exactly as the
+    selection flags do. Two parsers would drift, and "2s" meaning
+    different things in two parts of the same config file is the kind of
+    difference nobody finds by reading.
+
+    A bare number is refused. "2" could be seconds or minutes, and a
+    panel that guesses wrong refreshes sixty times too often.
+    """
+    candidate = text.strip()
+    if not candidate:
+        raise WindowError("a duration cannot be empty")
+
+    matched = _DURATION.match(candidate)
+    if matched is None:
+        raise WindowError(
+            f"{text!r} is not a duration. Use a number and a unit:"
+            + " 2s, 90m, 24h, 7d, 1w"
+        )
+    return float(matched.group("amount")) * _UNIT_SECONDS[matched.group("unit")]
+
+
 def parse_instant(text: str, *, now: datetime | None = None) -> datetime:
     """Resolve one --since/--until value to an aware UTC datetime.
 
@@ -51,11 +76,8 @@ def parse_instant(text: str, *, now: datetime | None = None) -> datetime:
     if not candidate:
         raise WindowError("a time bound cannot be empty")
 
-    duration = _DURATION.match(candidate)
-    if duration is not None:
-        amount = float(duration.group("amount"))
-        seconds = amount * _UNIT_SECONDS[duration.group("unit")]
-        return moment - timedelta(seconds=seconds)
+    if _DURATION.match(candidate) is not None:
+        return moment - timedelta(seconds=parse_duration(candidate))
 
     try:
         parsed = datetime.fromisoformat(candidate)

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -136,6 +136,35 @@ def test_the_status_line_names_the_window_and_the_cadence(
     assert "2 sensors" in line
 
 
+def test_the_status_line_clock_follows_the_readers_zone() -> None:
+    # Textual's own header clock shows local time three lines above this
+    # one, so a UTC clock here puts two clocks on one screen disagreeing
+    # by whole hours — and #170 exists so terminal output follows the
+    # person rather than the storage.
+    from zoneinfo import ZoneInfo
+
+    taken = datetime(2026, 8, 28, 22, 30, 15, tzinfo=UTC)
+
+    line = monitor.status(
+        monitor.Snapshot(taken=taken),
+        window="15m",
+        refresh=2.0,
+        tz=ZoneInfo("Asia/Tokyo"),
+    )
+
+    assert line.endswith("07:30:15")
+
+
+def test_the_status_line_clock_defaults_to_utc() -> None:
+    # Nothing configured is the overwhelmingly common case, and it has to
+    # stay the behaviour it always was.
+    taken = datetime(2026, 8, 28, 22, 30, 15, tzinfo=UTC)
+
+    line = monitor.status(monitor.Snapshot(taken=taken), window="15m", refresh=2.0)
+
+    assert line.endswith("22:30:15")
+
+
 def test_the_status_line_leads_with_the_failure_when_there_is_one() -> None:
     line = monitor.status(
         monitor.Snapshot(taken=_NOW, error="database unreachable"),
@@ -258,6 +287,7 @@ def test_the_flags_reach_the_panel(monkeypatch: pytest.MonkeyPatch) -> None:
             "sensor_ids": ["cryo-77k"],
             "window": "1h",
             "refresh": 5.0,
+            "tz": UTC,
         }
     ]
 

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -1,6 +1,7 @@
 """`labmon monitor` — the panel, and the snapshot behind each tick."""
 
 import asyncio
+import io
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -14,6 +15,12 @@ from labmon.cli.main import build_app
 from tests.cli_runner import Invocation, invoke
 
 _NOW = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+
+
+def _sensors(snapshot: "monitor.Snapshot") -> list[str]:
+    """The sensor column of every row, in the order they are drawn."""
+    at = snapshot.columns.index("sensor_id")
+    return [row.cells[at] for row in snapshot.rows]
 
 
 def _run(*args: str) -> Invocation:
@@ -74,7 +81,7 @@ def test_a_snapshot_carries_the_table(monkeypatch: pytest.MonkeyPatch) -> None:
 
     taken = monitor.take(None, None, "15m", now=_NOW)
 
-    assert "cryo-77k" in taken.body
+    assert _sensors(taken) == ["abandoned", "cryo-77k"]
     assert taken.error is None
 
 
@@ -85,8 +92,8 @@ def test_a_snapshot_asks_for_statistics(monkeypatch: pytest.MonkeyPatch) -> None
 
     taken = monitor.take(None, None, "15m", now=_NOW)
 
-    assert "mean" in taken.body
-    assert "sd" in taken.body
+    assert "mean" in taken.columns
+    assert "sd" in taken.columns
 
 
 def test_a_failed_tick_becomes_a_message_rather_than_a_crash(
@@ -115,18 +122,23 @@ def test_a_snapshot_says_when_it_was_taken(
     assert taken.taken == _NOW
 
 
-def test_the_status_line_names_the_window_and_the_cadence() -> None:
+def test_the_status_line_names_the_window_and_the_cadence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
     line = monitor.status(
-        monitor.Snapshot(body="", taken=_NOW), window="15m", refresh=2.0
+        monitor.take(None, None, "15m", now=_NOW), window="15m", refresh=2.0
     )
 
     assert "15m" in line
-    assert "2" in line
+    assert "every 2s" in line
+    assert "2 sensors" in line
 
 
 def test_the_status_line_leads_with_the_failure_when_there_is_one() -> None:
     line = monitor.status(
-        monitor.Snapshot(body="", taken=_NOW, error="database unreachable"),
+        monitor.Snapshot(taken=_NOW, error="database unreachable"),
         window="15m",
         refresh=2.0,
     )
@@ -152,7 +164,7 @@ def test_the_panel_draws_the_table(monkeypatch: pytest.MonkeyPatch) -> None:
         app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=2.0)
         async with app.run_test() as pilot:
             await pilot.pause()
-            assert "cryo-77k" in app.latest.body
+            assert _sensors(app.latest) == ["abandoned", "cryo-77k"]
 
     _drive(scenario)
 
@@ -304,13 +316,11 @@ def test_a_failed_refresh_keeps_the_last_good_table(
         app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=3600.0)
         async with app.run_test() as pilot:
             await pilot.pause()
-            assert "cryo-77k" in app.latest.body
+            assert _sensors(app.latest) == ["abandoned", "cryo-77k"]
 
             def fail(*args: object, **kwargs: object) -> monitor.Snapshot:
                 _ = (args, kwargs)
-                return monitor.Snapshot(
-                    body="", taken=datetime.now(UTC), error="unreachable"
-                )
+                return monitor.Snapshot(taken=datetime.now(UTC), error="unreachable")
 
             monkeypatch.setattr("labmon.cli.tui.take", fail)
             await pilot.press("r")
@@ -318,7 +328,7 @@ def test_a_failed_refresh_keeps_the_last_good_table(
             await pilot.pause()
 
             assert app.latest.error == "unreachable"
-            assert "cryo-77k" in app.latest.body
+            assert _sensors(app.latest) == ["abandoned", "cryo-77k"]
 
     _drive(scenario)
 
@@ -339,7 +349,7 @@ def test_the_first_refresh_failing_leaves_nothing_to_keep(
             await pilot.pause()
             await pilot.pause()
             assert app.latest.error is not None
-            assert app.latest.body == ""
+            assert app.latest.rows == ()
 
     _drive(scenario)
 
@@ -386,3 +396,139 @@ def test_the_missing_extra_message_names_the_interpreter(
     result = _run("monitor")
 
     assert sys.executable in result.output
+
+
+# --------------------------------------------------------------------------
+# What the panel draws
+# --------------------------------------------------------------------------
+
+
+def _drawn(snapshot: "monitor.Snapshot", width: int = 100) -> str:
+    """The panel rendered to plain text, without starting an app."""
+    from rich.console import Console
+
+    from labmon.cli.tui import panel
+
+    console = Console(width=width, record=True, file=io.StringIO())
+    console.print(panel(snapshot, window="15m", refresh=2.0))
+    return console.export_text()
+
+
+def test_the_panel_has_a_border_and_a_caption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    drawn = _drawn(monitor.take(None, None, "15m", now=_NOW))
+
+    assert "─" in drawn
+    assert "cryo-77k" in drawn
+    assert "2 sensors" in drawn
+    assert "every 2s" in drawn
+
+
+def test_the_panel_names_the_sensor_column_something_shorter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A panel has room to spell a column; it does not have to use the
+    # database's name for it.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    drawn = _drawn(monitor.take(None, None, "15m", now=_NOW))
+
+    assert "sensor_id" not in drawn
+    assert "sensor" in drawn
+
+
+def test_nothing_to_show_says_so_rather_than_drawing_an_empty_box() -> None:
+    drawn = _drawn(monitor.Snapshot(taken=_NOW))
+
+    assert "no readings matched" in drawn
+    assert "─" not in drawn
+
+
+def test_a_failure_with_nothing_to_show_states_the_failure() -> None:
+    drawn = _drawn(monitor.Snapshot(taken=_NOW, error="database unreachable"))
+
+    assert "database unreachable" in drawn
+
+
+@pytest.mark.parametrize("width", [70, 92, 100, 140])
+def test_nothing_is_ever_ellipsised(
+    monkeypatch: pytest.MonkeyPatch, width: int
+) -> None:
+    # A truncated reading is a wrong reading, and a truncated name is
+    # worse than it looks: `wavemeter-1` and `wavemeter-thz` both become
+    # `wavemet…`, so two rows become indistinguishable. Narrow terminals
+    # fold names onto a second line instead.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    drawn = _drawn(monitor.take(None, None, "15m", now=_NOW), width=width)
+
+    assert "…" not in drawn
+
+
+def test_readings_are_rounded_for_a_glance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The panel is read from across a room. `labmon query latest` is the
+    # one that promises the value exactly as stored.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    taken = monitor.take(None, None, "15m", now=_NOW)
+    values = [row.cells[taken.columns.index("value")] for row in taken.rows]
+
+    assert "77.01" not in values
+    assert "77.010" in values
+
+
+def test_the_status_line_counts_the_sensors_that_have_gone_quiet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A remembered sensor is on screen with a blank value; the count is
+    # what says how many of the rows are in that state.
+    from labmon.cli.roster import Known, cache_path, merge, save
+
+    save(
+        cache_path(),
+        merge(
+            {},
+            [
+                Known(
+                    sensor_id="departed",
+                    measurement="temperature",
+                    unit="K",
+                    last_seen=_NOW - timedelta(days=3),
+                )
+            ],
+        ),
+    )
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    line = monitor.status(
+        monitor.take(None, None, "15m", now=_NOW), window="15m", refresh=2.0
+    )
+
+    assert "3 sensors, 1 quiet" in line
+
+
+def test_the_table_is_centred_on_a_wide_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pinned to the left edge of a wide terminal, the table reads as an
+    # accident. A margin either side reads as a panel.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+    from textual.widgets import Static
+
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=2.0)
+        async with app.run_test(size=(160, 30)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            region = app.query_one("#table", Static).region
+            assert region.x > 0
+            assert region.x + region.width < app.size.width
+
+    _drive(scenario)

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -1,0 +1,343 @@
+"""`labmon monitor` — the panel, and the snapshot behind each tick."""
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from labmon.cli import monitor
+from labmon.cli.main import build_app
+from tests.cli_runner import Invocation, invoke
+
+_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+
+
+def _run(*args: str) -> Invocation:
+    return invoke(build_app(), list(args))
+
+
+class PanelClient:
+    """Two sensors, one fresh and one that stopped, with statistics."""
+
+    def query(
+        self,
+        query: str,
+        language: str = "sql",
+        mode: str = "all",
+        database: str | None = None,
+        **kwargs: object,
+    ) -> pa.Table:
+        _ = (language, mode, database, kwargs)
+        if "SHOW TABLES" in query:
+            return pa.table(
+                {
+                    "table_schema": pa.array(["iox"]),
+                    "table_name": pa.array(["temperature"]),
+                }
+            )
+        if "information_schema.columns" in query:
+            return pa.table(
+                {"column_name": pa.array(["time", "value", "sensor_id", "unit"])}
+            )
+        now = datetime.now(UTC)
+        return pa.table(
+            {
+                "measurement": pa.array(["temperature", "temperature"]),
+                "sensor_id": pa.array(["cryo-77k", "abandoned"]),
+                "time": pa.array(
+                    [now - timedelta(seconds=2), now - timedelta(hours=3)],
+                    pa.timestamp("ms", tz="UTC"),
+                ),
+                "value": pa.array([77.01, 4.2]),
+                "unit": pa.array(["K", "K"]),
+                "mean": pa.array([76.98, 4.19]),
+                "sd": pa.array([0.031, 0.004]),
+                "n": pa.array([1800, 12], pa.int64()),
+            }
+        )
+
+    def close(self) -> None:
+        return None
+
+
+# --------------------------------------------------------------------------
+# One tick's worth of text
+# --------------------------------------------------------------------------
+
+
+def test_a_snapshot_carries_the_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    taken = monitor.take(None, None, "15m", now=_NOW)
+
+    assert "cryo-77k" in taken.body
+    assert taken.error is None
+
+
+def test_a_snapshot_asks_for_statistics(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The panel's whole point over `query latest` is showing how the
+    # window behaved, not only where it ended.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    taken = monitor.take(None, None, "15m", now=_NOW)
+
+    assert "mean" in taken.body
+    assert "sd" in taken.body
+
+
+def test_a_failed_tick_becomes_a_message_rather_than_a_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A panel that dies on one network blip is useless. Re-querying the
+    # window is self-healing: the next tick is simply correct.
+    def refuse() -> object:
+        raise OSError("no route to host")
+
+    monkeypatch.setattr("labmon.influx.get_client", refuse)
+
+    taken = monitor.take(None, None, "15m", now=_NOW)
+
+    assert taken.error is not None
+    assert "no route to host" in taken.error
+
+
+def test_a_snapshot_says_when_it_was_taken(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+
+    taken = monitor.take(None, None, "15m", now=_NOW)
+
+    assert taken.taken == _NOW
+
+
+def test_the_status_line_names_the_window_and_the_cadence() -> None:
+    line = monitor.status(
+        monitor.Snapshot(body="", taken=_NOW), window="15m", refresh=2.0
+    )
+
+    assert "15m" in line
+    assert "2" in line
+
+
+def test_the_status_line_leads_with_the_failure_when_there_is_one() -> None:
+    line = monitor.status(
+        monitor.Snapshot(body="", taken=_NOW, error="database unreachable"),
+        window="15m",
+        refresh=2.0,
+    )
+
+    assert line.startswith("database unreachable")
+
+
+# --------------------------------------------------------------------------
+# The panel itself
+# --------------------------------------------------------------------------
+
+
+def _drive(scenario: Callable[[], object]) -> None:
+    """Run one async Textual scenario from a synchronous test."""
+    asyncio.run(scenario())  # pyright: ignore[reportArgumentType]
+
+
+def test_the_panel_draws_the_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=2.0)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert "cryo-77k" in app.latest.body
+
+    _drive(scenario)
+
+
+def test_q_quits_the_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=2.0)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+            await pilot.pause()
+            assert not app.is_running
+
+    _drive(scenario)
+
+
+# --------------------------------------------------------------------------
+# The command
+# --------------------------------------------------------------------------
+
+
+def test_monitor_refuses_a_refresh_of_zero() -> None:
+    result = _run("monitor", "--refresh", "0s")
+
+    assert result.exit_code != 0
+
+
+def test_monitor_reports_a_missing_extra_rather_than_an_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Textual lives behind `labmon[tui]`, and an ImportError traceback
+    # names a module rather than the install command that fixes it.
+    # `None` in sys.modules is what an absent module looks like to an
+    # import statement, without disturbing anything else.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "textual", None)
+    monkeypatch.delitem(sys.modules, "labmon.cli.tui", raising=False)
+
+    result = _run("monitor")
+
+    assert result.exit_code != 0
+    assert "labmon[tui]" in result.output
+
+
+def test_monitor_refuses_a_refresh_that_is_not_a_duration() -> None:
+    result = _run("monitor", "--refresh", "soon")
+
+    assert result.exit_code != 0
+
+
+def test_monitor_refuses_a_window_it_cannot_read() -> None:
+    # Checked before the screen is cleared. A mistake that surfaced on
+    # the first tick would have already taken over the terminal.
+    result = _run("monitor", "--since", "last tuesday")
+
+    assert result.exit_code != 0
+
+
+def test_the_flags_reach_the_panel(monkeypatch: pytest.MonkeyPatch) -> None:
+    built: list[dict[str, object]] = []
+
+    class Recording:
+        def __init__(self, **kwargs: object) -> None:
+            built.append(kwargs)
+
+        def run(self) -> None:
+            return None
+
+    monkeypatch.setattr("labmon.cli.tui.Panel", Recording)
+
+    result = _run(
+        "monitor",
+        "--since",
+        "1h",
+        "--refresh",
+        "5s",
+        "--measurement",
+        "temperature",
+        "--sensor-id",
+        "cryo-77k",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert built == [
+        {
+            "measurements": ["temperature"],
+            "sensor_ids": ["cryo-77k"],
+            "window": "1h",
+            "refresh": 5.0,
+        }
+    ]
+
+
+def test_the_configuration_supplies_the_defaults(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config = tmp_path / "config" / "labmon" / "labmon.toml"
+    config.parent.mkdir(parents=True)
+    _ = config.write_text('[monitor]\nrefresh = "10s"\nwindow = "6h"\n')
+
+    built: list[dict[str, object]] = []
+
+    class Recording:
+        def __init__(self, **kwargs: object) -> None:
+            built.append(kwargs)
+
+        def run(self) -> None:
+            return None
+
+    monkeypatch.setattr("labmon.cli.tui.Panel", Recording)
+
+    result = _run("monitor")
+
+    assert result.exit_code == 0, result.output
+    assert built[0]["refresh"] == 10.0
+    assert built[0]["window"] == "6h"
+
+
+def test_r_refreshes_without_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=3600.0)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            first = app.latest.taken
+            await pilot.press("r")
+            await pilot.pause()
+            await pilot.pause()
+            assert app.latest.taken >= first
+
+    _drive(scenario)
+
+
+def test_a_failed_refresh_keeps_the_last_good_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A blank panel says less than a stale one labelled as stale, and
+    # the label is on the status line right below it.
+    monkeypatch.setattr("labmon.influx.get_client", PanelClient)
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=3600.0)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert "cryo-77k" in app.latest.body
+
+            def fail(*args: object, **kwargs: object) -> monitor.Snapshot:
+                _ = (args, kwargs)
+                return monitor.Snapshot(
+                    body="", taken=datetime.now(UTC), error="unreachable"
+                )
+
+            monkeypatch.setattr("labmon.cli.tui.take", fail)
+            await pilot.press("r")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert app.latest.error == "unreachable"
+            assert "cryo-77k" in app.latest.body
+
+    _drive(scenario)
+
+
+def test_the_first_refresh_failing_leaves_nothing_to_keep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Nothing good has been drawn yet, so the failure is all there is.
+    def refuse() -> object:
+        raise OSError("no route to host")
+
+    monkeypatch.setattr("labmon.influx.get_client", refuse)
+    from labmon.cli.tui import Panel
+
+    async def scenario() -> None:
+        app = Panel(measurements=None, sensor_ids=None, window="15m", refresh=3600.0)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app.latest.error is not None
+            assert app.latest.body == ""
+
+    _drive(scenario)

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import cast
 
 import pyarrow as pa
 import pytest
@@ -341,3 +342,47 @@ def test_the_first_refresh_failing_leaves_nothing_to_keep(
             assert app.latest.body == ""
 
     _drive(scenario)
+
+
+def test_an_import_failure_that_is_not_a_missing_extra_is_not_disguised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Textual is installed and the panel still failed to import: a
+    # renamed symbol after an upgrade, say. Reporting that as "install
+    # the extra" sends somebody to reinstall a package they already
+    # have, and hides the traceback that would have said what broke.
+    import sys
+
+    monkeypatch.delitem(sys.modules, "labmon.cli.tui", raising=False)
+
+    real = __import__
+
+    def half_broken(name: str, *args: object, **kwargs: object) -> object:
+        if name == "labmon.cli.tui":
+            raise ImportError("cannot import name 'Binding' from 'textual'")
+        return cast(object, real(name, *args, **kwargs))  # pyright: ignore[reportArgumentType]
+
+    import builtins
+
+    monkeypatch.setattr(builtins, "__import__", half_broken)
+
+    result = _run("monitor")
+
+    assert result.exit_code != 0
+    assert "labmon[tui]" not in result.output
+
+
+def test_the_missing_extra_message_names_the_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An editable checkout installed with `uv tool install` has its own
+    # environment, and `uv sync` does not touch it — so "not installed"
+    # is only half the answer without saying where.
+    import sys
+
+    monkeypatch.setitem(sys.modules, "textual", None)
+    monkeypatch.delitem(sys.modules, "labmon.cli.tui", raising=False)
+
+    result = _run("monitor")
+
+    assert sys.executable in result.output

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -382,6 +382,24 @@ def test_an_import_failure_that_is_not_a_missing_extra_is_not_disguised(
     assert "labmon[tui]" not in result.output
 
 
+def _unboxed(text: str) -> str:
+    """`text` with Rich's box and every space taken out of it.
+
+    Typer renders a `BadParameter` inside a Rich panel wrapped to the
+    terminal width, so an interpreter path long enough to wrap arrives
+    split across two lines with box rules and padding in the middle of
+    it. A checkout under a deep directory, a CI runner or a container
+    all reach that width; this one happens not to, which is the whole
+    reason the plain substring check survived being written.
+
+    Whitespace goes rather than just newlines, since the wrap leaves
+    padding either side of the rule. Both sides of the comparison are
+    put through it, so a path that legitimately holds a space still
+    matches.
+    """
+    return "".join(text.split()).replace("\u2502", "").replace("\u2500", "")
+
+
 def test_the_missing_extra_message_names_the_interpreter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -395,7 +413,7 @@ def test_the_missing_extra_message_names_the_interpreter(
 
     result = _run("monitor")
 
-    assert sys.executable in result.output
+    assert _unboxed(sys.executable) in _unboxed(result.output)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cli_quantity.py
+++ b/tests/test_cli_quantity.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from labmon.cli.quantity import PLAIN_BELOW, PLAIN_FROM, quote, show
+from labmon.cli.quantity import (
+    PLAIN_BELOW,
+    PLAIN_FROM,
+    at_the_precision_of,
+    quote,
+    show,
+)
 
 
 @pytest.mark.parametrize(
@@ -210,3 +216,20 @@ def test_a_deviation_that_is_not_finite_is_not_rounded_against() -> None:
 
     assert mean == "4.2"
     assert sd == "nan"
+
+
+def test_a_reading_can_be_shown_at_the_precision_of_its_spread() -> None:
+    # A beam position whose spread over the window is 16 µm has two
+    # meaningful characters, not nineteen.
+    assert at_the_precision_of(-7.441802197802218, 16.13679456395551) == "-7"
+    assert at_the_precision_of(99.76556776556775, 8.847037339748116) == "99.8"
+    assert at_the_precision_of(76.923, 2.3) == "76.9"
+
+
+def test_a_reading_with_nothing_to_round_against_says_so() -> None:
+    # `None` rather than a guess, so the caller falls back to showing
+    # the reading in full rather than inventing a precision.
+    assert at_the_precision_of(76.923, None) is None
+    assert at_the_precision_of(76.923, 0.0) is None
+    assert at_the_precision_of(76.923, float("inf")) is None
+    assert at_the_precision_of(float("nan"), 1.0) is None

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -11,7 +11,13 @@ import pytest
 
 from labmon.cli import selection
 from labmon.cli.main import build_app
-from labmon.cli.render import DEFAULT_LIMIT, render, render_latest, visible_columns
+from labmon.cli.render import (
+    DEFAULT_LIMIT,
+    latest_rows,
+    render,
+    render_latest,
+    visible_columns,
+)
 from labmon.cli.runtime import REFUSED
 from labmon.export.table import combine, normalise
 from tests.cli_runner import Invocation, invoke
@@ -488,21 +494,55 @@ def test_a_sensor_is_listed_once() -> None:
     assert len(body) == 2
 
 
-def test_the_stalest_sensor_is_listed_last() -> None:
-    # The one that stopped reporting is the one worth finding, and a
-    # reader's eye lands on the end of a short list.
+def test_rows_are_ordered_by_measurement_then_sensor() -> None:
+    # Stable ordering is the whole requirement. Sorting by age looks
+    # right on a one-shot listing and is unusable on a panel that
+    # redraws every two seconds: every row moves, so nothing can be
+    # followed. Staleness is carried by colour, which does not depend on
+    # position.
     table = _latest(
         [
-            ("fresh", "temperature", 1.0, "K", 2),
-            ("silent", "temperature", 2.0, "K", 9000),
+            ("room-1", "temperature", 1.0, "°C", 2),
+            ("vac-1", "pressure", 2.0, "mbar", 9000),
+            ("cryo-77k", "temperature", 3.0, "K", 40),
+            ("chamber-1", "pressure", 4.0, "mbar", 5),
         ]
     )
 
-    lines = [
-        line for line in render_latest(table, now=_NOW).splitlines() if " ago" in line
+    listed = [
+        tuple(line.split()[:2])
+        for line in render_latest(table, now=_NOW).splitlines()
+        if " ago" in line
     ]
 
-    assert lines[-1].startswith("silent")
+    assert listed == [
+        ("pressure", "chamber-1"),
+        ("pressure", "vac-1"),
+        ("temperature", "cryo-77k"),
+        ("temperature", "room-1"),
+    ]
+
+
+def test_a_silent_sensor_sorts_among_the_others_rather_than_at_the_end() -> None:
+    # It is remembered, not exiled. Age no longer decides position, so a
+    # roster entry belongs wherever its name puts it.
+    from labmon.cli.roster import Known
+
+    table = _latest([("room-1", "temperature", 1.0, "°C", 2)])
+    quiet = Known(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        unit="K",
+        last_seen=_NOW - timedelta(hours=4),
+    )
+
+    listed = [
+        line.split()[1]
+        for line in render_latest(table, now=_NOW, silent=[quiet]).splitlines()
+        if " ago" in line
+    ]
+
+    assert listed == ["cryo-77k", "room-1"]
 
 
 def test_columns_stay_aligned_when_an_age_is_coloured() -> None:
@@ -579,16 +619,18 @@ def test_latest_reports_how_long_ago_each_sensor_reported(
     assert "3h ago" in result.output
 
 
-def test_latest_puts_the_quietest_sensor_last(
+def test_latest_orders_by_measurement_then_sensor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("labmon.influx.get_client", LatestClient)
 
     body = [
-        line for line in _run("query", "latest").output.splitlines() if " ago" in line
+        line.split()[1]
+        for line in _run("query", "latest").output.splitlines()
+        if " ago" in line
     ]
 
-    assert body[-1].startswith("abandoned")
+    assert body == ["abandoned", "cryo-77k"]
 
 
 def test_latest_closes_the_client_when_the_query_fails(
@@ -698,7 +740,7 @@ def test_a_silent_sensor_shows_no_value_rather_than_a_stale_one(
     line = next(
         line
         for line in _run("query", "latest").output.splitlines()
-        if line.startswith("abandoned")
+        if " abandoned " in line
     )
 
     assert "77.01" not in line
@@ -902,9 +944,9 @@ def test_a_group_with_nothing_to_average_shows_blanks() -> None:
     table = _with_stats([("a", "temperature", 1.0, "K", 3)], [(None, None, 0)])
 
     lines = render_latest(table, now=_NOW).splitlines()
-    row = next(line for line in lines if line.startswith("a "))
+    row = next(line for line in lines if " ago" in line)
 
-    assert row.split() == ["a", "temperature", "1.0", "K", "3s", "ago", "0"]
+    assert row.split() == ["temperature", "a", "1.0", "K", "3s", "ago", "0"]
 
 
 def test_a_silent_sensor_has_no_statistics_to_show() -> None:
@@ -919,9 +961,9 @@ def test_a_silent_sensor_has_no_statistics_to_show() -> None:
     )
 
     lines = render_latest(table, now=_NOW, silent=[quiet]).splitlines()
-    row = next(line for line in lines if line.startswith("gone"))
+    row = next(line for line in lines if " gone " in line)
 
-    assert row.split() == ["gone", "temperature", "K", "4h", "ago"]
+    assert row.split() == ["temperature", "gone", "K", "4h", "ago"]
 
 
 class StatsClient(FakeClient):
@@ -976,3 +1018,48 @@ def test_latest_without_the_flag_asks_for_no_statistics(
     _ = _run("query", "latest")
 
     assert not any("stddev(" in query for query in seen)
+
+
+def test_a_reading_is_shown_exactly_as_stored_by_default() -> None:
+    # `labmon query latest` promises the value as recorded. Rounding it
+    # is the panel's choice, not this view's.
+    table = _with_stats(
+        [("beam-x", "position", -7.441802197802218, "µm", 2)], [(0.0196, 16.136, 900)]
+    )
+
+    _present, rows = latest_rows(table, _NOW)
+
+    assert "-7.441802197802218" in rows[0].cells
+
+
+def test_a_reading_can_be_rounded_to_the_precision_of_its_spread() -> None:
+    # For a panel read at a glance: nineteen digits of a beam position
+    # crowd out the rest of the row and two of them carry information.
+    table = _with_stats(
+        [("beam-x", "position", -7.441802197802218, "µm", 2)], [(0.0196, 16.136, 900)]
+    )
+
+    _present, rows = latest_rows(table, _NOW, round_values=True)
+
+    assert "-7" in rows[0].cells
+    assert "-7.441802197802218" not in rows[0].cells
+
+
+def test_rounding_a_reading_needs_a_spread_to_round_against() -> None:
+    # No statistics at all: the reading is shown in full, because
+    # nothing says where its digits stop meaning anything.
+    table = _latest([("beam-x", "position", -7.441802197802218, "µm", 2)])
+
+    _present, rows = latest_rows(table, _NOW, round_values=True)
+
+    assert "-7.441802197802218" in rows[0].cells
+
+
+def test_the_measurement_leads_so_the_ordering_is_visible() -> None:
+    # A table sorted by a column it does not show first looks arbitrary,
+    # which is the readability problem the ordering was meant to fix.
+    table = _latest([("room-1", "temperature", 1.0, "°C", 2)])
+
+    present, _rows = latest_rows(table, _NOW)
+
+    assert present[:2] == ("measurement", "sensor_id")

--- a/tests/test_cli_sensors_roster.py
+++ b/tests/test_cli_sensors_roster.py
@@ -263,3 +263,30 @@ def test_forgetting_works_with_the_database_unreachable(
 
     assert result.exit_code == 0
     assert ("old-probe", "temperature") not in load(roster)
+
+
+def test_the_roster_is_ordered_by_measurement_then_sensor(roster: Path) -> None:
+    # The same order as `query latest`. Three views of one kind of table
+    # sorting three different ways makes a sensor hard to find in
+    # whichever one you were not looking at.
+    for name, measurement, days in [
+        ("vac-1", "pressure", 1),
+        ("room-1", "temperature", 5),
+        ("cryo-77k", "temperature", 2),
+        ("chamber-1", "pressure", 9),
+    ]:
+        entry = Known(
+            sensor_id=name,
+            measurement=measurement,
+            unit="x",
+            last_seen=datetime.now(UTC) - timedelta(days=days),
+        )
+        save(roster, merge(load(roster), [entry]))
+
+    listed = [
+        line.split()[0]
+        for line in _run("sensors").output.splitlines()
+        if " ago" in line
+    ]
+
+    assert listed == ["chamber-1", "vac-1", "cryo-77k", "room-1"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,3 +97,68 @@ def test_a_file_that_cannot_be_read_is_reported(config_home: Path) -> None:
 
     with pytest.raises(ConfigError, match=r"labmon\.toml"):
         _ = load(config_home)
+
+
+# --------------------------------------------------------------------------
+# The monitor section
+# --------------------------------------------------------------------------
+
+
+def test_the_monitor_has_defaults_without_a_section(config_home: Path) -> None:
+    monitor = load(config_home).monitor
+
+    assert monitor.refresh == 2.0
+    assert monitor.window == "15m"
+
+
+def test_the_monitor_section_is_read(config_home: Path) -> None:
+    config = load(_write(config_home, '[monitor]\nrefresh = "5s"\nwindow = "1h"\n'))
+
+    assert config.monitor.refresh == 5.0
+    assert config.monitor.window == "1h"
+
+
+def test_a_refresh_is_spelled_the_way_since_is(config_home: Path) -> None:
+    # One duration spelling across the project. "2" would have to guess
+    # a unit, and guessing wrong refreshes sixty times too often.
+    with pytest.raises(ConfigError, match="duration"):
+        _ = load(_write(config_home, '[monitor]\nrefresh = "2"\n'))
+
+
+def test_a_refresh_that_is_not_a_string_is_refused(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match="refresh"):
+        _ = load(_write(config_home, "[monitor]\nrefresh = 2\n"))
+
+
+def test_a_refresh_of_zero_is_refused(config_home: Path) -> None:
+    # A panel that refreshes every zero seconds is a busy loop against
+    # the database, not a fast panel.
+    with pytest.raises(ConfigError, match="refresh"):
+        _ = load(_write(config_home, '[monitor]\nrefresh = "0s"\n'))
+
+
+def test_a_window_is_checked_when_it_is_read_not_when_it_is_used(
+    config_home: Path,
+) -> None:
+    # Otherwise the mistake surfaces on the first refresh, after the
+    # panel has already drawn itself and cleared the screen.
+    with pytest.raises(ConfigError, match="window"):
+        _ = load(_write(config_home, '[monitor]\nwindow = "last tuesday"\n'))
+
+
+def test_an_unknown_monitor_key_is_refused(config_home: Path) -> None:
+    # A plausible name for the same idea, which is how the mistake gets
+    # made — and silently ignoring it would leave the panel refreshing
+    # at the default while the file says otherwise.
+    with pytest.raises(ConfigError, match="interval"):
+        _ = load(_write(config_home, '[monitor]\ninterval = "2s"\n'))
+
+
+def test_a_monitor_that_is_not_a_table_is_refused(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match="monitor"):
+        _ = load(_write(config_home, 'monitor = "on"\n'))
+
+
+def test_a_window_that_is_not_a_string_is_refused(config_home: Path) -> None:
+    with pytest.raises(ConfigError, match="window"):
+        _ = load(_write(config_home, "[monitor]\nwindow = 15\n"))

--- a/tests/test_export_window.py
+++ b/tests/test_export_window.py
@@ -4,7 +4,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from labmon.export.window import Window, WindowError, parse_instant
+from labmon.export.window import (
+    Window,
+    WindowError,
+    parse_duration,
+    parse_instant,
+)
 
 _NOW = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
 
@@ -111,3 +116,48 @@ def test_window_parse_defaults_to_the_current_time() -> None:
     window = Window.parse("1s", None)
 
     assert before - timedelta(seconds=2) <= window.since <= datetime.now(UTC)
+
+
+# --------------------------------------------------------------------------
+# Durations on their own
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "seconds"),
+    [
+        ("2s", 2.0),
+        ("0.5s", 0.5),
+        ("90m", 5400.0),
+        ("1h", 3600.0),
+        ("7d", 604800.0),
+        ("1w", 604800.0),
+        (" 15m ", 900.0),
+    ],
+)
+def test_a_duration_reads_as_seconds(text: str, seconds: float) -> None:
+    assert parse_duration(text) == seconds
+
+
+def test_a_timestamp_is_not_a_duration() -> None:
+    # `parse_instant` accepts both spellings because "since" can mean
+    # either. A refresh interval cannot be a date.
+    with pytest.raises(WindowError, match="duration"):
+        _ = parse_duration("2026-08-01")
+
+
+def test_an_empty_duration_says_so() -> None:
+    with pytest.raises(WindowError):
+        _ = parse_duration("")
+
+
+def test_a_duration_without_a_unit_is_refused() -> None:
+    # "2" could be seconds or minutes, and guessing wrong is a panel
+    # that refreshes sixty times too often.
+    with pytest.raises(WindowError, match="duration"):
+        _ = parse_duration("2")
+
+
+def test_a_partial_unit_is_not_mistaken_for_a_whole_one() -> None:
+    with pytest.raises(WindowError, match="duration"):
+        _ = parse_duration("24hours")

--- a/uv.lock
+++ b/uv.lock
@@ -289,6 +289,9 @@ netcdf = [
 spline = [
     { name = "scipy" },
 ]
+tui = [
+    { name = "textual" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -304,6 +307,7 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
     { name = "scipy-stubs" },
+    { name = "textual" },
     { name = "typos" },
     { name = "xarray" },
 ]
@@ -317,10 +321,11 @@ requires-dist = [
     { name = "pint", specifier = ">=0.25.3" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "scipy", marker = "extra == 'spline'", specifier = ">=1.18.0" },
+    { name = "textual", marker = "extra == 'tui'", specifier = ">=8.2.8" },
     { name = "typer", specifier = ">=0.27.1" },
     { name = "xarray", marker = "extra == 'netcdf'", specifier = ">=2024.7.0" },
 ]
-provides-extras = ["spline", "netcdf"]
+provides-extras = ["spline", "netcdf", "tui"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -336,8 +341,21 @@ dev = [
     { name = "ruff", specifier = ">=0.16.3" },
     { name = "scipy", specifier = ">=1.18.0" },
     { name = "scipy-stubs", specifier = ">=1.18.0.1" },
+    { name = "textual", specifier = ">=8.2.8" },
     { name = "typos", specifier = ">=1.49.0" },
     { name = "xarray", specifier = ">=2026.7.0" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/3e/79f35b8c31a1881893b7e62be80b2573f06e38db47c33065749293ee1b97/linkify_it_py-2.1.1.tar.gz", hash = "sha256:a78f40fee177eb912e9d2375074108378523c38d3fde5d3ee804f465b6cfbfee", size = 30889, upload-time = "2026-08-24T17:16:57.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/3d/e34b19cd144071c583317268c4feb2c59c03ac57eef69753410c7abb11c0/linkify_it_py-2.1.1-py3-none-any.whl", hash = "sha256:8539a6b470efce90ba9b69e39b848e5b15b7ad89f7f98ca17d3532c243f987dc", size = 20532, upload-time = "2026-08-24T17:16:55.965Z" },
 ]
 
 [[package]]
@@ -350,6 +368,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -917,6 +952,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -964,6 +1016,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Third of the #156 stack. **Based on #171** — review #170 and #171 first.

1. #170 — the per-user configuration file
2. #171 — the window statistics, `labmon query latest --stats`
3. **this PR** — `labmon monitor`, the refreshing panel
4. #177 — the configured tiles, and the panel's finish

Four commits: the duration parser split out on its own, the panel, the missing-extra diagnosis, then the ordering and the panel's own table.

*Rebased onto #171 after #175 and #176 merged; no conflicts, no content changed. The screen below was recaptured afterwards, against a demo database rebuilt from scratch — so the readings carry the digits #148 gave them, the beam wanders rather than tracing a Lissajous figure (#176), and there is no quiet sensor left in the roster to show a red row.*

```bash
pip install 'labmon[tui]'
labmon monitor
```

```
                                                   labmon
╭─────────────┬──────────────┬─────────────────┬──────┬────────┬─────────────────┬─────────┬──────╮
│ measurement │ sensor       │           value │ unit │ age    │            mean │      sd │    n │
├─────────────┼──────────────┼─────────────────┼──────┼────────┼─────────────────┼─────────┼──────┤
│ frequency   │ wavemeter-1  │ 2.765612997e+14 │ Hz   │ 2s ago │ 2.765612998e+14 │ 1.8e+06 │  899 │
│ position    │ beam-x       │             5.9 │ µm   │ 1s ago │             1.0 │     9.9 │ 1798 │
│ position    │ beam-y       │             -10 │ µm   │ 1s ago │              -2 │      13 │ 1798 │
│ power       │ laser-1      │           105.9 │ mW   │ 1s ago │            95.0 │     8.8 │ 1798 │
│ pressure    │ chamber-1    │        1.14e-07 │ mbar │ 3s ago │        1.31e-07 │ 1.8e-08 │  360 │
│ pressure    │ pirani-1     │           1e-09 │ mbar │ 1s ago │         2.9e-08 │ 3.4e-08 │ 1798 │
│ temperature │ cryo-4k      │            4.29 │ K    │ 3s ago │            4.14 │    0.24 │  360 │
│ temperature │ cryo-77k     │            78.9 │ K    │ 3s ago │            77.4 │     1.7 │  360 │
│ temperature │ cryo-diode   │              44 │ K    │ 1s ago │              28 │      11 │ 1798 │
│ temperature │ room-1       │           19.83 │ °C   │ 3s ago │           20.66 │    0.88 │  360 │
│ temperature │ room-2       │           22.68 │ °C   │ 3s ago │           22.00 │    0.66 │  360 │
│ voltage     │ bias-monitor │             0.2 │ V    │ 1s ago │               0 │     2.3 │ 1798 │
╰─────────────┴──────────────┴─────────────────┴──────┴────────┴─────────────────┴─────────┴──────╯
                                12 sensors · window 30m · every 2s · 16:27:21
```
`q` quits, `r` redraws immediately, `p` opens the command palette to change the theme. A sensor the roster remembers but the window returned nothing for gets a row with a blank value, red on a terminal — the rebuilt demo database has none to show. #177 reworks all three keys.

This is the **fallback** view #156 describes — one row per sensor, refreshing in place. Configured tiles are the next PR.

## 1. Rows stay where you left them

**This was the bug that made the first version unusable.** Ordering by age looked right while the view printed once and exited — it put the sensor that had stopped on the last line, where an eye lands. On a panel that redraws every two seconds, every row moves on every tick, so no row can be followed and reading one value means finding it again first.

Rows are now ordered by **measurement, then sensor**, alphabetically and by nothing else. `labmon query latest` and `labmon sensors` take the same order, so a sensor sits in the same place in all three views rather than in three different places. `measurement` also moves to the first column: a table sorted by a column it does not show first looks arbitrary, which is the readability problem the ordering was meant to fix.

Staleness is carried by colour instead, which does not depend on position. That does lose the stale-last property argued for in #165, and it is the right trade — a panel nobody can follow surfaces nothing at all.

## 2. It shares the renderer rather than growing its own

The panel shows exactly what `labmon query latest --stats` shows: same selection layer, same renderer, same notion of staleness. #156 asked whether these should be one implementation or two, and one is the answer — two implementations of "the latest value and how old it is" would drift, and the one that drifted would be the one nobody was watching.

That also means the panel inherited the roster from #165 for free: a sensor silent for longer than the window still appears, with a blank value.

`labmon.cli.monitor` holds everything that decides *what* to show and needs no event loop; `labmon.cli.tui` is 42 statements that put it on a screen. Almost all of the panel is therefore tested synchronously, with only four tests driving Textual's `run_test` pilot through `asyncio.run`.

## 3. A failed tick does not tear down the terminal

```
cannot reach the database — showing the last good reading · window 15m · refreshing every 2s
```

The last good table stays on screen and the status line says it is stale. A panel that exited on one unreachable moment would be worse than useless beside a running experiment, and since the window is re-queried every tick, recovery needs no action at all.

`--since` and `--refresh` are validated **before** Textual starts. A bad value that surfaced on the first tick would already have cleared the screen.

## 4. Re-query the window, do not append

Each tick replaces the result. That is what Grafana does with a SQL datasource, and #156 measured why it is right here too — every reading from every sensor:

| window | rows | time |
|---|---|---|
| 5 minutes | 2 298 | 11 ms |
| 15 minutes | 6 918 | 14 ms |
| 1 hour | 27 694 | 19 ms |

Fourteen milliseconds against a two-second cadence is not worth optimising. An incremental design would carry per-sensor watermarks, handle late-arriving points and reconcile after a dropped connection — real state and real bugs, to save single-digit milliseconds. Re-querying is also self-healing: the tick after an outage is simply correct, with no gap to detect.

The query runs on a worker thread. It blocks for tens of milliseconds, which is long enough to make a keypress feel sticky, and there is no reason for `q` to wait for a database.

## 5. `[monitor]`, and one duration spelling

```toml
[monitor]
refresh = "2s"
window  = "15m"
```

`parse_instant` accepted a timestamp *or* a duration, because "since" can mean either; a refresh cadence can only ever be a duration. The first commit splits `parse_duration` out rather than letting a second parser appear — two would drift, and `"2s"` meaning different things in two parts of one config file is a difference nobody finds by reading.

A bare number is refused: `2` could be seconds or minutes, and a panel that guesses wrong refreshes sixty times too often.

## 6. The extra

`textual` goes in a `tui` extra, and also in the dev group — the same arrangement `netcdf`/`h5netcdf` already uses, so the suite exercises it while a sensor host that only writes readings does not carry Rich and its dependency tree.

Running `labmon monitor` without it gives the install command, not an import traceback. Tested by putting `None` in `sys.modules`, which is what an absent module looks like to an `import` statement.

The guard originally wrapped the whole import, so **any** ImportError raised while loading `labmon.cli.tui` — a renamed Textual symbol after an upgrade — would have been reported as a missing extra, sending somebody to reinstall a package they already had. `find_spec` now distinguishes the two, and anything else propagates with its traceback intact. The message also names the interpreter: an editable checkout installed with `uv tool install` has its own environment, and `uv sync --all-extras` does not touch it.

`textual-dev` was added and then removed — `App.run_test()` ships in `textual` itself, and it was pulling `textual-serve`, `aiohttp` and `yarl` for nothing.

The test that checks the message names the interpreter was asserting a plain substring against Typer's output. Typer renders a `BadParameter` inside a Rich panel wrapped to the terminal width, so a path long enough to reach it arrives split across two lines with a box rule and padding inserted mid-path — a deep checkout, a CI runner or a container all get there, and this working copy happens not to. Reproduced at 80 columns with a worktree-shaped path of 89 characters: the old assertion is `False`, the new one `True`. Both operands now have their whitespace and box rules stripped before the comparison, so a path that legitimately contains a space still matches.

## 7. What the panel actually looks like

Rounded box, centred (the table widget lands at x=10 on a 120-column screen), `nord` by default for being calm at a glance and legible on a projector, numbers right-aligned so digits line up, units dimmed, and headings spelled for a panel rather than for a database — `sensor`, not `sensor_id`.

**Readings are rounded to their own noise.** `78.6 K`, `-3.1 V`, `4 µm`. `-7.441802197802218 µm` on a beam whose spread over the window is 16 µm is nineteen characters of which two carry information, and it was forcing the table past a hundred columns on its own. `labmon query latest` is the view that promises the reading exactly as stored, and still does; this is `round_values=True`.

**#177 removes this rounding rather than overriding it**, which is worth saying here because the reasoning above is the part that turned out to be wrong. A deviation says how far a quantity moved while nobody was looking, which is no statement about how well the instrument measured it, so rounding a reading against it conflates two different things. The width problem was real and is solved twice over instead: #148 stops `serial-sensor` writing seventeen digits in the first place, and #177 adds an explicit per-sensor `precision` for anything still too long to read at a glance.

**The status line's clock follows the reader's zone.** `Snapshot.taken` is `datetime.now(UTC)` and the caption printed it unconverted, while Textual's header runs with `show_clock=True` and shows local time three lines above — two clocks on one screen disagreeing by whole hours for anyone outside UTC, with nothing on either saying which was which. `status()` and `panel()` now take a `tz`, `labmon monitor` passes `config.timezone`, and #170 is why that setting exists. UTC stays the default at every level, and `take()` still stamps in UTC: only the formatting moves.

**Nothing is ever ellipsised.** At ninety-two columns Rich was shortening both `wavemeter-1` and `wavemeter-thz` to `wavemet…`, which makes two rows indistinguishable. Names fold onto a second line instead and numbers hold their width; checked at 70, 92, 100 and 140 columns.

## Test plan

- [x] `pytest` — 827 passed, 100 % coverage
- [x] `ruff check` / `ruff format --check` / `typos` / `basedpyright` clean, zero warnings
- [x] driven against the live demo stack, both with sensors writing and with the `demo` profile stopped, to see fresh rows plain and stale rows red in the same table
- [x] `q`, `r`, a first tick that fails with nothing to keep, and a later tick that fails with a good table to keep
- [x] the missing-extra path
- [x] a long soak — left running for an hour against a database that is restarted underneath it, to confirm the status line recovers on its own rather than only in a fixture
- [x] a terminal narrower than the table — names fold, numbers do not, nothing truncates

Refs #156. Next in the stack: #177, `[[monitor.panels]]` — tiles and thresholds. Sparklines need a history query per configured sensor and are left to a PR of their own.





