### PR TITLE
Store a calibrated reading at the resolution its input had

### DIFF
--- a/calibration.example.toml
+++ b/calibration.example.toml
@@ -39,6 +39,7 @@ measurement = "voltage" # remapping the [0, 3.3]V Arduino input range onto the [
 mode = "affine"
 conversion_factor = "9.0909091"
 offset = "-15 V"
+# offset_resolution = "5 mV"           # see "how many digits" below
 
 # --- spline: a cubic through measured points ----------------------------
 # For a curved response characterised by calibration measurements.
@@ -77,6 +78,39 @@ measurement = "pressure"
 mode = "expression"
 expression = "10**(1.667*v - 11.33)"       # a typical Pirani gauge curve
 value_unit = "mbar"
+
+# --- how many digits a reading keeps ------------------------------------
+# A converted value is rounded to the resolution the input actually had,
+# so what lands in InfluxDB does not claim seventeen digits of a 12-bit
+# measurement. Nothing above needs to say so: the step comes from
+# --resolution-bits and --vref, carried through the conversion. A 12-bit
+# input over 3.3 V steps by 806 uV, and channel A0's 50 mW/V turns that
+# into 40 uW, so its readings are written to two decimals of a milliwatt.
+#
+# Only `linear` and `affine` have one step across their whole range. A
+# spline's slope varies along its curve and an expression's is unknown,
+# so those channels keep the computed value unless told otherwise:
+#
+#   significant_digits = 4
+#
+# Significant rather than decimal places, because a calibrated channel
+# may sit anywhere on the scale — three decimals is far too coarse for
+# channel A4's 1e-8 mbar and far too fine for a room thermometer. It
+# overrides the derived step wherever it is set, which is also how a
+# board that averages several conversions per reading claims the extra
+# resolution that buys: the host sees only a fractional count, not how
+# many were averaged, so the derived step stays conservative.
+#
+# `offset_resolution` says how well an affine offset is itself known,
+# for one that came out of a fit rather than a divider ratio. It is
+# independent of the ADC's own step, so the two combine in quadrature.
+# The offset otherwise shifts the scale without dividing it, and adds
+# nothing.
+#
+# Rounding happens once, on the way in, and applies to `value` only.
+# `input_volts` keeps every digit it had — it is what a corrected
+# calibration would be re-applied to, and rounding it would make that
+# irrecoverable.
 
 # --- stop_recording_when: take a channel out of service while its -------
 # --- instrument is off --------------------------------------------------

--- a/demo/calibration.demo.toml
+++ b/demo/calibration.demo.toml
@@ -21,6 +21,10 @@ mode = "piecewise_linear"
 voltages = [0.50, 1.00, 1.15, 1.30]
 values = [300.0, 100.0, 40.0, 2.0]
 value_unit = "kelvin"
+# A curve has no one step to derive — its slope is steep between the
+# last two points and gentle between the first two — so the digits are
+# stated. Four covers 2 K to 300 K without claiming millikelvins.
+significant_digits = 4
 
 [channels.A0.provenance]
 date = "2026-07-14"
@@ -32,6 +36,10 @@ notes = "four points during a cooldown; clamps below 2 K by design"
 # A bipolar rail monitor: a divider maps the supply's [-15, 15] V onto
 # the Arduino's [0, 3.3] V. The factor is dimensionless, so the unit
 # comes from the offset.
+#
+# Nothing here states a resolution: the divider ratio carries the ADC's
+# 806 uV step onto 7.3 mV of rail, and that is what a reading is
+# written to.
 [channels.A1]
 sensor_id = "bias-monitor"
 measurement = "voltage"
@@ -55,6 +63,11 @@ measurement = "pressure"
 mode = "expression"
 expression = "10**(1.667*v - 11.33)"
 value_unit = "mbar"
+# Likewise: an expression's slope is unknown to the loader, and this one
+# is exponential, so no fixed step would suit both ends of the range.
+# Significant digits do, which is why they are counted rather than
+# decimals.
+significant_digits = 3
 
 [channels.A2.provenance]
 date = "2026-07-14"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,11 @@ Reads a real board. Full description in
 don't need to be: both scale the recorded voltage linearly, so getting
 either wrong stays correctable with a query.
 
+They do decide how finely `value` is rounded — see
+[How many digits a reading keeps](#how-many-digits-a-reading-keeps) —
+and digits dropped on the way in do not come back. `input_volts` keeps
+all of its own, which is what makes the correction possible.
+
 ## The calibration file
 
 One `[channels.<name>]` section per channel the board streams.
@@ -158,8 +163,48 @@ explains the choices between them.
 | `store_input` | `true` | Every channel; also settable file-wide at top level |
 | `conversion_factor` | *(required)* | `linear`, `affine` |
 | `offset` | *(required)* | `affine` |
+| `offset_resolution` | *(exact)* | `affine` |
+| `significant_digits` | *(derived)* | Every channel |
 | `voltages`, `values`, `value_unit` | *(required)* | `spline`, `piecewise_linear` |
 | `expression`, `value_unit` | *(required)* | `expression` |
+
+### How many digits a reading keeps
+
+A converted value is rounded to the resolution its input actually had,
+so a stored reading does not claim seventeen digits of a twelve-bit
+measurement. The step comes from `--resolution-bits` and `--vref`,
+carried through the conversion: a 12-bit input over 3.3 V steps by
+806 µV, and a factor of `42.5 kelvin / volt` turns that into 34 mK, so
+that channel is written to hundredths of a kelvin.
+
+Only `linear` and `affine` have one step across their whole range. A
+spline's slope varies along its curve and an expression's is unknown to
+the loader, so those channels keep the computed value unless the file
+names `significant_digits`.
+
+`significant_digits` overrides the derived step wherever it is set.
+Significant rather than decimal places, because a calibrated channel may
+sit anywhere on the scale — three decimals is far too coarse for a gauge
+reading 1e-8 mbar and far too fine for a room thermometer.
+
+`offset_resolution` says how well an affine offset is itself known, for
+one that came out of a fit rather than a divider ratio. It is
+independent of the ADC's own step, so the two combine in quadrature. An
+offset otherwise shifts the scale without dividing it, and adds nothing.
+The key is rejected on the other modes rather than ignored, since none
+of them has an offset.
+
+Rounding happens once, on the way in, and reaches `value` only.
+`input_volts` keeps every digit it had: it is what a corrected
+calibration would be re-applied to, and rounding it would make that
+irrecoverable. The `calibration_id` tag does not change either — it says
+which conversion produced a reading, and how many digits survived is as
+much a property of the board, which is not recorded.
+
+A board that averages several conversions per reading resolves finer
+than one ADC step and says so by reporting a fractional count. The host
+cannot see how many were averaged, so the derived step stays
+conservative; a channel that wants those digits states them.
 
 Two optional sub-tables per channel:
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -346,11 +346,11 @@ labmon therefore remembers the sensors it has seen, and unions that list
 into the result:
 
 ```
-sensor_id   measurement  value               unit  age
-----------  -----------  ------------------  ----  -------
-cryo-diode  temperature  17.097367521367556  K     1s ago
-room-1      temperature  20.518              °C    2s ago
-probe-158   temperature                      K     1h ago
+sensor_id   measurement  value   unit  age
+----------  -----------  ------  ----  -------
+cryo-diode  temperature  17.1    K     1s ago
+room-1      temperature  20.518  °C    2s ago
+probe-158   temperature          K     1h ago
 
 6 sensors
 1 of them reported nothing in this window — remembered from a previous run

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -20,10 +20,13 @@ means lives on the host, where it can be changed without reflashing:
    `--resolution-bits` and `--vref`.
 3. That voltage is converted to a physical quantity by the channel's
    entry in the calibration file (see the modes below).
-4. The result is written as a point, tagged with the channel's
+4. The result is rounded to the resolution the input actually had, so a
+   twelve-bit measurement is not stored to seventeen digits (see
+   [How many digits a reading keeps](#how-many-digits-a-reading-keeps)).
+5. The result is written as a point, tagged with the channel's
    `sensor_id`, its `unit`, and the `calibration_id` that produced it, in
    a `value` field — alongside an `input_volts` field holding the voltage
-   from step 2 (see
+   from step 2, unrounded (see
    [Keeping the conversion's input](#keeping-the-conversions-input)).
 
 A malformed line, or a channel with no calibration entry, is logged and
@@ -110,7 +113,88 @@ and won't pick up the new field unless asked.
 
 Note that `--vref` and `--resolution-bits` are *not* recorded. They don't
 need to be — both scale the stored voltage linearly, so getting either
-wrong stays correctable with a query.
+wrong stays correctable with a query. They do decide how finely `value`
+is rounded, though, and that part is not: see
+[how many digits a reading keeps](#how-many-digits-a-reading-keeps).
+
+### How many digits a reading keeps
+
+Floating point hands back seventeen digits whatever went into it. Left
+alone, an exported column reads:
+
+```
+cryo-diode   14.56589010989012
+cryo-diode   14.741460317460326
+cryo-diode   14.159628815628857
+```
+
+which claims a precision the hardware does not have, and leaves whoever
+opens the file unable to tell a physical millikelvin from an artefact of
+the conversion arithmetic.
+
+The resolution is derivable, so it is derived rather than guessed. A
+12-bit input over 3.3 V steps by 806 µV; a factor of
+`42.5 kelvin / volt` carries that onto 34 mK; and the reading is written
+to the decimal place that step reaches — hundredths of a kelvin. Change
+`--resolution-bits` or `--vref` and the digits follow.
+
+It is not put on a grid of whole steps. A derived step is not a round
+number, and stepping a reading onto multiples of 0.0342 K produces
+`14.555860805860807` where the honest answer is `14.57`.
+
+**Two modes derive nothing.** A spline's slope varies along its curve —
+steep between two close measured points, gentle between two far apart —
+and an expression's is unknown to the loader. Quoting a step that
+wandered with the reading would be worse than quoting none, so those
+channels keep the computed value until the file says otherwise:
+
+```toml
+[channels.A0]
+sensor_id = "cryo-diode"
+measurement = "temperature"
+mode = "piecewise_linear"
+voltages = [0.50, 1.00, 1.15, 1.30]
+values = [300.0, 100.0, 40.0, 2.0]
+value_unit = "kelvin"
+significant_digits = 4       # 2 K to 300 K, without claiming millikelvins
+```
+
+Significant digits rather than decimal places, because a calibrated
+channel may sit anywhere on the scale: three decimals is far too coarse
+for a gauge reading 1e-8 mbar and far too fine for a room thermometer.
+The key works on any channel and overrides the derived step wherever it
+is set.
+
+**An offset that came out of a fit** has an uncertainty of its own,
+which is independent of the ADC's and combines with it in quadrature:
+
+```toml
+[channels.A1]
+sensor_id = "beam-x"
+measurement = "position"
+mode = "affine"
+conversion_factor = "60 micrometer / volt"
+offset = "-99 micrometer"
+offset_resolution = "0.2 micrometer"
+```
+
+Without it the offset shifts the scale without dividing it, and adds
+nothing — an affine channel then resolves exactly as the linear one
+behind it does. `offset_resolution` is rejected on the other modes
+rather than ignored, since none of them has an offset.
+
+**Averaging is not accounted for.** A board reporting the mean of a
+burst of conversions resolves below one ADC step, and says so by sending
+a fractional count — but not how many it averaged, so the derived answer
+stays the conservative one. A channel on an averaging board states its
+own `significant_digits`.
+
+**Only `value` is rounded.** `input_volts` keeps every digit it had: it
+is what a corrected calibration would be re-applied to, and rounding it
+would make that irrecoverable. The `calibration_id` tag does not move
+either — it says which conversion produced a reading, and how many
+digits survived is as much a property of the board, which is not
+recorded at all.
 
 ### Recording which calibration produced a reading
 

--- a/src/labmon/calibration.py
+++ b/src/labmon/calibration.py
@@ -26,12 +26,17 @@ one, so they state their `value_unit` explicitly.
 
 Voltages are always in volts — the ADC's own output. A datasheet quoted
 in millivolts gets scaled once, visibly, when writing the config.
+
+A converted value is then rounded to the resolution the input actually
+had, so what reaches the database does not claim seventeen digits of a
+twelve-bit measurement. See `Conversion.resolution`.
 """
 
 import bisect
 import functools
 import hashlib
 import itertools
+import math
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -44,6 +49,7 @@ from asteval import Interpreter
 
 from labmon import adc
 from labmon.gate import StopRecordingRule
+from labmon.quantise import quantise, to_resolution
 
 ureg: pint.UnitRegistry = pint.UnitRegistry()
 
@@ -79,6 +85,16 @@ PROBE_VOLTAGES: tuple[pint.Quantity, ...] = (
 )
 
 DEFAULT_MODE = "linear"
+
+# The key that fixes a channel's digits by hand, for a conversion whose
+# resolution cannot be derived — and for one where it can, but the
+# derived answer is wrong. Significant rather than decimal, because a
+# calibrated channel may sit anywhere on the scale.
+SIGNIFICANT_DIGITS_KEY = "significant_digits"
+
+# How precisely the affine offset is known. Only affine has an offset,
+# so the key is refused elsewhere rather than silently ignored.
+OFFSET_RESOLUTION_KEY = "offset_resolution"
 
 # Whether to store the voltage a reading was converted from alongside the
 # converted value. On by default: a conversion is not generally
@@ -177,6 +193,22 @@ class Conversion(Protocol):
 
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity: ...
 
+    def resolution(self, voltage_step: pint.Quantity, /) -> pint.Quantity | None:
+        """How finely this conversion's output is actually resolved.
+
+        `voltage_step` is what one ADC count is worth, so the answer is
+        the input's own granularity carried through the conversion — a
+        12-bit input over 3.3 V steps by 806 µV, and a factor of
+        42.5 K/V turns that into 34 mK. Anything past it is arithmetic,
+        not measurement.
+
+        `None` where the conversion has no single answer: a spline's
+        slope varies along its curve, and an expression's is unknown.
+        Those channels keep the computed value unless the file says
+        otherwise.
+        """
+        ...
+
     def fingerprint(self) -> str:
         """A canonical description of this conversion, for hashing.
 
@@ -196,6 +228,12 @@ class LinearConversion:
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
         return voltage * self.factor
 
+    def resolution(self, voltage_step: pint.Quantity, /) -> pint.Quantity:
+        # One factor scales the whole range, so the voltage step scales
+        # with it and nothing else enters.
+        step = self.factor * voltage_step
+        return abs(float(step.magnitude)) * step.units
+
     def fingerprint(self) -> str:
         return f"linear|{_quantity_key(self.factor)}"
 
@@ -206,11 +244,34 @@ class AffineConversion:
 
     factor: pint.Quantity
     offset: pint.Quantity
+    # How well the offset itself is known, in the value's units. None
+    # means it is taken at face value, which is the usual case: an
+    # offset read off a divider ratio is exact as far as the conversion
+    # is concerned. A fit that reported an uncertainty puts it here.
+    offset_resolution: pint.Quantity | None = None
 
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
         return voltage * self.factor + self.offset
 
+    def resolution(self, voltage_step: pint.Quantity, /) -> pint.Quantity:
+        # The offset shifts the whole scale rather than quantising it, so
+        # on its own it adds nothing to the step. What it can add is its
+        # own uncertainty, which is independent of the ADC's and
+        # therefore combines in quadrature.
+        step = self.factor * voltage_step
+        units = step.units
+        span = abs(float(step.magnitude))
+        if self.offset_resolution is None:
+            return span * units
+        spread = float(self.offset_resolution.to(units).magnitude)
+        return math.hypot(spread, span) * units
+
     def fingerprint(self) -> str:
+        # `offset_resolution` is deliberately absent. The id says which
+        # conversion produced a reading; how many digits survived it is
+        # a property of the board as much as the file — `--vref` and
+        # `--resolution-bits` are not recorded either — and adding a
+        # field here would re-tag every affine channel already written.
         return f"affine|{_quantity_key(self.factor)}|{_quantity_key(self.offset)}"
 
 
@@ -234,6 +295,14 @@ class InterpolatedConversion:
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
         return self.interpolate(voltage.to(ureg.volt).magnitude) * self.unit
 
+    def resolution(self, _voltage_step: pint.Quantity, /) -> None:
+        # The slope varies along the curve — steeply between two close
+        # measured points, gently between two far apart — so there is no
+        # one step to quote. Deriving it per reading would make a
+        # channel's precision wander with its value, which is worse than
+        # leaving it to the file.
+        return None
+
     def fingerprint(self) -> str:
         digits = FINGERPRINT_SIGNIFICANT_DIGITS
         points = ",".join(
@@ -253,6 +322,12 @@ class ExpressionConversion:
 
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
         return self._evaluate(voltage.to(ureg.volt).magnitude) * self.unit
+
+    def resolution(self, _voltage_step: pint.Quantity, /) -> None:
+        # An arbitrary formula has no derivative this module can read
+        # off. A Pirani gauge's is exponential, so a fixed step would be
+        # wrong across most of its range anyway.
+        return None
 
     def fingerprint(self) -> str:
         # The expression is kept verbatim: whitespace inside a formula is
@@ -290,6 +365,10 @@ class Calibration:
     # None means record everything, which is the default: a gate is a
     # deliberate decision to leave gaps in a series.
     stop_recording_when: StopRecordingRule | None = None
+    # Digits the file insists on, overriding whatever the conversion
+    # derives. None means take the derived answer, or keep the computed
+    # value where there is none.
+    significant_digits: int | None = None
 
     @functools.cached_property
     def calibration_id(self) -> str:
@@ -320,7 +399,44 @@ class Calibration:
         Uses the same probe sequence as load-time validation, so a
         conversion with a pole at one volt still reports its unit.
         """
-        return f"{probe(self.conversion).units:~}"
+        return f"{self.value_units:~}"
+
+    @functools.cached_property
+    def value_units(self) -> pint.Unit:
+        """The units a converted reading's magnitude is expressed in.
+
+        Read from the conversion rather than the file, for the same
+        reason `unit` is, and cached for the same reason: it is fixed
+        once the file is parsed.
+        """
+        return probe(self.conversion).units
+
+    def rounding(self, voltage_step: pint.Quantity) -> Callable[[float], float]:
+        """A filter dropping digits this channel's input never carried.
+
+        Built once per run and applied per reading, because the answer
+        depends on the board and the conversion — neither of which
+        changes while the loop runs — and not on the reading.
+
+        `significant_digits` in the file wins; otherwise the conversion
+        derives a step from `voltage_step`; and where it cannot, the
+        computed value is kept as it is.
+        """
+        if self.significant_digits is not None:
+            digits = self.significant_digits
+            return lambda value: quantise(value, significant_digits=digits)
+
+        derived = self.conversion.resolution(voltage_step)
+        if derived is None:
+            return _unrounded
+
+        step = float(derived.to(self.value_units).magnitude)
+        if not math.isfinite(step) or step <= 0:
+            # A zero factor, or an offset_resolution large enough to
+            # overflow. Neither describes a place to round to, and
+            # log10(0) has no answer.
+            return _unrounded
+        return lambda value: to_resolution(value, step)
 
 
 def raw_to_voltage(
@@ -339,6 +455,28 @@ def raw_to_voltage(
     # (1 << bits) - 1 is 2**bits - 1, the highest count the ADC reports.
     full_scale = (1 << resolution_bits) - 1
     return (raw_count / full_scale) * v_ref * ureg.volt
+
+
+def voltage_step(
+    resolution_bits: int = ADC_RESOLUTION_BITS,
+    v_ref: float = ADC_VREF_VOLTS,
+) -> pint.Quantity:
+    """What one ADC count is worth — the smallest difference it can show.
+
+    Expressed through `raw_to_voltage` so the two cannot drift apart:
+    one count is exactly the voltage a count of one represents.
+
+    A board averaging several conversions per reading resolves finer
+    than this, and says so by reporting a fractional count. The host
+    cannot see how many were averaged, so this stays the conservative
+    answer; a channel that wants the extra digits states them.
+    """
+    return raw_to_voltage(1.0, resolution_bits, v_ref)
+
+
+def _unrounded(value: float) -> float:
+    """Keep a reading as computed, for a conversion with no known step."""
+    return value
 
 
 def load_calibration(path: Path) -> dict[str, Calibration]:
@@ -386,6 +524,14 @@ def _parse_channel(
             + f" expected one of {', '.join(sorted(_MODE_BUILDERS))}"
         )
 
+    if mode != "affine" and OFFSET_RESOLUTION_KEY in fields:
+        # Silently ignoring it would give a setting that does nothing the
+        # exact appearance of one that works.
+        raise CalibrationError(
+            f"{where} sets '{OFFSET_RESOLUTION_KEY}' in mode {mode!r},"
+            + " which has no offset; it applies to mode 'affine' only"
+        )
+
     conversion = builder(where, fields)
     _trial_apply(where, conversion)
     return Calibration(
@@ -395,6 +541,7 @@ def _parse_channel(
         store_input=_optional_bool(where, fields, "store_input", default_store_input),
         provenance=_optional_provenance(where, fields),
         stop_recording_when=_optional_stop_rule(where, fields, conversion),
+        significant_digits=_optional_significant_digits(where, fields),
     )
 
 
@@ -442,9 +589,11 @@ def _build_linear(where: Location, fields: dict[str, object]) -> Conversion:
 
 
 def _build_affine(where: Location, fields: dict[str, object]) -> Conversion:
+    offset = _require_quantity(where, fields, "offset")
     return AffineConversion(
         factor=_require_quantity(where, fields, "conversion_factor"),
-        offset=_require_quantity(where, fields, "offset"),
+        offset=offset,
+        offset_resolution=_optional_offset_resolution(where, fields, offset),
     )
 
 
@@ -545,6 +694,44 @@ def _quantity_key(quantity: pint.Quantity) -> str:
     base = quantity.to_base_units()
     magnitude = f"{base.magnitude:.{FINGERPRINT_SIGNIFICANT_DIGITS}g}"
     return f"{magnitude} {base.units}"
+
+
+def _optional_offset_resolution(
+    where: Location, fields: dict[str, object], offset: pint.Quantity
+) -> pint.Quantity | None:
+    """Read how well the offset is known, in the offset's own dimension."""
+    if OFFSET_RESOLUTION_KEY not in fields:
+        return None
+    spread = _require_comparable(
+        where,
+        fields,
+        OFFSET_RESOLUTION_KEY,
+        offset.units,
+        f"has an offset in {offset.units:~}",
+    )
+    if float(spread.magnitude) < 0:
+        raise CalibrationError(
+            f"{where} key '{OFFSET_RESOLUTION_KEY}' is {spread:~};"
+            + " a resolution cannot be negative"
+        )
+    return spread
+
+
+def _optional_significant_digits(
+    where: Location, fields: dict[str, object]
+) -> int | None:
+    """Read the digit count a channel insists on, if it names one."""
+    if SIGNIFICANT_DIGITS_KEY not in fields:
+        return None
+    digits = fields[SIGNIFICANT_DIGITS_KEY]
+    # bool is an int in Python, and `significant_digits = true` is a
+    # mistake rather than a request for one digit.
+    if not isinstance(digits, int) or isinstance(digits, bool) or digits < 1:
+        raise CalibrationError(
+            f"{where} key '{SIGNIFICANT_DIGITS_KEY}' must be a whole number"
+            + f" of digits, at least 1, not {digits!r}"
+        )
+    return digits
 
 
 def _optional_provenance(

--- a/src/labmon/quantise.py
+++ b/src/labmon/quantise.py
@@ -1,0 +1,89 @@
+"""Dropping digits a reading was never entitled to.
+
+Floating point arithmetic hands back seventeen digits whatever went into
+it. Writing all of them claims a precision no instrument has, and leaves
+whoever opens the exported column unable to tell a physical millikelvin
+from an artefact of the conversion.
+
+Two ways of saying how far to keep, because instruments are specified
+both ways: an absolute step, for a part with a fixed least-significant
+digit, and a count of significant figures, for a quantity that may sit
+anywhere on the scale.
+
+Shared between the simulated sensor, which is simply told how precise to
+pretend to be, and the calibrated one, which derives the answer from its
+ADC and its conversion.
+"""
+
+import math
+from decimal import ROUND_HALF_EVEN, Decimal, InvalidOperation
+
+from labmon.sensors import constants
+
+# How many digits a reading carries when no absolute step is given.
+# Significant digits rather than decimal places because a sensor may sit
+# anywhere on the scale: the demo alone spans 4 K and 1.5e-7 mbar, and a
+# fixed number of decimals reports one of those as zero.
+DEFAULT_SIGNIFICANT_DIGITS = constants.DEFAULT_SIGNIFICANT_DIGITS
+
+
+def quantise(
+    value: float,
+    resolution: float | None = None,
+    significant_digits: int = DEFAULT_SIGNIFICANT_DIGITS,
+) -> float:
+    """Round a reading to the precision the instrument has.
+
+    `resolution` is an absolute step in the reading's own units, which is
+    how an instrument with a fixed least-significant digit is specified
+    (a thermometer resolving 0.001 K). Without one, the value is rounded
+    to `significant_digits` instead, which stays meaningful at any
+    magnitude — the safe default, since an absolute step large enough for
+    a thermometer reports a vacuum gauge as zero.
+
+    Stepping is done in Decimal rather than as `round(value / step) *
+    step`: the arithmetic form puts back the noise it is removing, giving
+    76.85000000000001 where the decimal form gives 76.85.
+    """
+    if not math.isfinite(value):
+        # `polling` refuses a non-finite value before it becomes a field;
+        # rounding should not be the thing that raises first.
+        return value
+    if resolution is not None:
+        step = Decimal(str(resolution))
+        return float(
+            (Decimal(repr(value)) / step).quantize(Decimal(1), rounding=ROUND_HALF_EVEN)
+            * step
+        )
+    return float(f"{value:.{significant_digits}g}")
+
+
+def to_resolution(value: float, resolution: float) -> float:
+    """Round `value` to the decimal place `resolution` reaches.
+
+    Unlike `quantise`, this does not put the reading on a grid of whole
+    steps. A derived resolution is not a round number — a 12-bit input
+    scaled by 60 µm/V resolves 0.0484 µm — and stepping to it produces
+    5.99560439, which is longer than the number it set out to shorten
+    and no more honest.
+
+    What a person writes instead is the decimal place the step reaches:
+    0.0484 µm means two decimals, so the reading is 5.98. That keeps at
+    most one digit more than the hardware supports, which is how every
+    instrument front panel is specified, and never keeps fewer.
+    """
+    if not math.isfinite(value):
+        return value
+    place = math.floor(math.log10(resolution))
+    try:
+        return float(
+            Decimal(repr(value)).quantize(
+                Decimal(1).scaleb(place), rounding=ROUND_HALF_EVEN
+            )
+        )
+    except InvalidOperation:
+        # Asking for more digits than the decimal context carries, which
+        # needs a resolution some 1e28 below the reading. Nothing
+        # physical gets there, and the un-rounded value is the honest
+        # answer when the rounding itself is meaningless.
+        return value

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -13,56 +13,16 @@ import math
 import random
 import time
 from datetime import UTC, datetime
-from decimal import ROUND_HALF_EVEN, Decimal
 
 from influxdb_client_3 import Point
 
 from labmon.influx import influx_database
-from labmon.sensors import constants
+from labmon.quantise import DEFAULT_SIGNIFICANT_DIGITS, quantise
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# How many digits a reading carries when no absolute step is given.
-# Significant digits rather than decimal places because a mock sensor may
-# sit anywhere on the scale: the demo alone spans 4 K and 1.5e-7 mbar, and
-# a fixed number of decimals reports one of those as zero.
-DEFAULT_SIGNIFICANT_DIGITS = constants.DEFAULT_SIGNIFICANT_DIGITS
-
-
-def quantise(
-    value: float,
-    resolution: float | None = None,
-    significant_digits: int = DEFAULT_SIGNIFICANT_DIGITS,
-) -> float:
-    """Round a reading to the precision the simulated instrument has.
-
-    A walk in floating point produces sixteen digits, and writing them
-    claims a precision no instrument has — someone reading the exported
-    column cannot tell simulated jitter from a real millikelvin.
-
-    `resolution` is an absolute step in the reading's own units, which is
-    how an instrument with a fixed least-significant digit is specified
-    (a thermometer resolving 0.001 K). Without one, the value is rounded
-    to `significant_digits` instead, which stays meaningful at any
-    magnitude — the safe default, since an absolute step large enough for
-    a thermometer reports a vacuum gauge as zero.
-
-    Stepping is done in Decimal rather than as `round(value / step) *
-    step`: the arithmetic form puts back the noise it is removing, giving
-    76.85000000000001 where the decimal form gives 76.85.
-    """
-    if not math.isfinite(value):
-        # `polling` refuses a non-finite value before it becomes a field;
-        # rounding should not be the thing that raises first.
-        return value
-    if resolution is not None:
-        step = Decimal(str(resolution))
-        return float(
-            (Decimal(repr(value)) / step).quantize(Decimal(1), rounding=ROUND_HALF_EVEN)
-            * step
-        )
-    return float(f"{value:.{significant_digits}g}")
+__all__ = ["DEFAULT_SIGNIFICANT_DIGITS", "quantise", "run"]
 
 
 class RandomWalk:

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -16,6 +16,7 @@ from labmon.calibration import (
     Calibration,
     raw_to_voltage,
     ureg,
+    voltage_step,
 )
 from labmon.gate import RecordingGate
 from labmon.influx import influx_database
@@ -129,6 +130,15 @@ def run(
         if calibration.stop_recording_when is not None
     }
 
+    # One rounding filter per channel, built here because it depends on
+    # the board's resolution as well as the channel's conversion, and
+    # the board is only known once the command line has been read.
+    step = voltage_step(resolution_bits, v_ref)
+    rounding = {
+        channel: calibration.rounding(step)
+        for channel, calibration in calibrations.items()
+    }
+
     while True:
         # `finally`, so the summary runs whatever this iteration did. Every
         # path below can `continue` — a read timeout, an uncalibrated
@@ -163,6 +173,12 @@ def run(
 
             voltage = raw_to_voltage(reading.raw_count, resolution_bits, v_ref)
             value = calibration.conversion.apply(voltage)
+            # Rounded before anything looks at it, so the gate compares
+            # against the number that will actually be stored and the
+            # log line quotes it too. `input_volts` below is left whole:
+            # it is what a corrected calibration would be re-applied to,
+            # and rounding it would make that irrecoverable.
+            value = rounding[reading.channel](value.magnitude) * value.units
 
             # Before the gate, which compares against bounds: every comparison
             # with a NaN is False, so a gate would admit it and a gate-less

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,3 +1,4 @@
+import math
 import re
 from pathlib import Path
 from typing import cast
@@ -19,6 +20,7 @@ from labmon.calibration import (
     load_calibration,
     raw_to_voltage,
     ureg,
+    voltage_step,
 )
 
 
@@ -37,6 +39,9 @@ class _CountingConversion:
     def apply(self, voltage: pint.Quantity, /) -> pint.Quantity:
         self.applications += 1
         return voltage * ureg("42.5 kelvin / volt")
+
+    def resolution(self, _voltage_step: pint.Quantity, /) -> None:
+        return None
 
     def fingerprint(self) -> str:
         self.fingerprints += 1
@@ -267,6 +272,9 @@ def test_trial_apply_wraps_an_unexpected_failure() -> None:
         def apply(self, _voltage: pint.Quantity, /) -> pint.Quantity:
             raise RuntimeError("sensor on fire")
 
+        def resolution(self, _voltage_step: pint.Quantity, /) -> None:
+            return None
+
         def fingerprint(self) -> str:
             return "broken"
 
@@ -278,6 +286,19 @@ def test_trial_apply_wraps_an_unexpected_failure() -> None:
 # --------------------------------------------------------------------------
 # Loading and validation
 # --------------------------------------------------------------------------
+
+
+def test_the_demo_file_states_digits_wherever_none_can_be_derived() -> None:
+    # The demo is what the dashboards are read off, and the two curved
+    # channels have no step to derive. Without a stated count they would
+    # be the seventeen-digit column this rounding exists to stop.
+    demo = Path(__file__).parent.parent / "demo" / "calibration.demo.toml"
+
+    channels = load_calibration(demo)
+
+    for channel in channels.values():
+        derivable = channel.conversion.resolution(voltage_step()) is not None
+        assert derivable or channel.significant_digits is not None
 
 
 def test_the_shipped_example_file_is_valid() -> None:
@@ -1380,3 +1401,419 @@ def test_the_unit_of_a_conversion_with_a_pole_is_still_derivable() -> None:
     )
 
     assert calibration.unit == "mbar"
+
+
+# --------------------------------------------------------------------------
+# What a reading is resolved to
+# --------------------------------------------------------------------------
+
+
+def test_voltage_step_is_what_one_count_is_worth() -> None:
+    # Full scale divided by the highest count the ADC reports.
+    step = voltage_step(resolution_bits=12, v_ref=3.3)
+
+    assert step.to(ureg.volt).magnitude == pytest.approx(3.3 / 4095)
+
+
+def test_voltage_step_follows_the_board_it_is_given() -> None:
+    step = voltage_step(resolution_bits=10, v_ref=5.0)
+
+    assert step.to(ureg.volt).magnitude == pytest.approx(5.0 / 1023)
+
+
+def test_a_linear_conversion_scales_the_voltage_step() -> None:
+    # 806 uV through 42.5 K/V is 34 mK, and nothing else enters.
+    conversion = LinearConversion(factor=ureg("42.5 kelvin / volt"))
+
+    resolution = conversion.resolution(voltage_step())
+
+    assert resolution.to(ureg.kelvin).magnitude == pytest.approx(42.5 * 3.3 / 4095)
+
+
+def test_a_falling_response_still_resolves_a_positive_step() -> None:
+    # A thermistor divider drops as it warms. The step is a distance,
+    # and log10 of a negative number has no answer.
+    conversion = LinearConversion(factor=ureg("-42.5 kelvin / volt"))
+
+    resolution = conversion.resolution(voltage_step())
+
+    assert resolution.to(ureg.kelvin).magnitude > 0
+
+
+def test_an_affine_offset_does_not_quantise_by_itself() -> None:
+    # The offset shifts the whole scale rather than dividing it, so an
+    # affine channel resolves exactly as the linear one behind it does.
+    factor = ureg("60 micrometer / volt")
+    step = voltage_step()
+    affine = AffineConversion(factor=factor, offset=ureg("-99 micrometer"))
+
+    assert affine.resolution(step) == LinearConversion(factor=factor).resolution(step)
+
+
+def test_an_uncertain_offset_combines_in_quadrature() -> None:
+    # The offset's uncertainty and the ADC's are independent, so they add
+    # as squares rather than end to end.
+    conversion = AffineConversion(
+        factor=ureg("60 micrometer / volt"),
+        offset=ureg("-99 micrometer"),
+        offset_resolution=ureg("0.2 micrometer"),
+    )
+
+    resolution = conversion.resolution(voltage_step())
+
+    expected = math.hypot(0.2, 60 * 3.3 / 4095)
+    assert resolution.to(ureg.micrometer).magnitude == pytest.approx(expected)
+
+
+def test_an_uncertain_offset_is_converted_before_it_is_combined() -> None:
+    # Written in nanometres against a factor in micrometres: the two
+    # terms have to reach a common unit before they are squared.
+    conversion = AffineConversion(
+        factor=ureg("60 micrometer / volt"),
+        offset=ureg("-99 micrometer"),
+        offset_resolution=ureg("200 nanometer"),
+    )
+
+    resolution = conversion.resolution(voltage_step())
+
+    assert resolution.to(ureg.micrometer).magnitude == pytest.approx(
+        math.hypot(0.2, 60 * 3.3 / 4095)
+    )
+
+
+def test_an_interpolated_conversion_has_no_single_step(tmp_path: Path) -> None:
+    # The slope varies along the curve, so there is no one answer to
+    # quote and quoting a wandering one would be worse than none.
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "cryo-diode"
+            measurement = "temperature"
+            mode = "piecewise_linear"
+            voltages = [0.5, 1.0]
+            values = [300.0, 100.0]
+            value_unit = "kelvin"
+            """,
+        )
+    ).values()
+
+    assert calibration.conversion.resolution(voltage_step()) is None
+
+
+def test_an_expression_conversion_has_no_single_step(tmp_path: Path) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "pirani-1"
+            measurement = "pressure"
+            mode = "expression"
+            expression = "10**(1.667*v - 11.33)"
+            value_unit = "mbar"
+            """,
+        )
+    ).values()
+
+    assert calibration.conversion.resolution(voltage_step()) is None
+
+
+# --------------------------------------------------------------------------
+# Calibration.rounding
+# --------------------------------------------------------------------------
+
+
+def _linear_calibration(significant_digits: int | None = None) -> Calibration:
+    return Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=LinearConversion(factor=ureg("42.5 kelvin / volt")),
+        significant_digits=significant_digits,
+    )
+
+
+def test_rounding_keeps_the_places_the_derived_step_reaches() -> None:
+    # 34 mK resolves to hundredths of a kelvin.
+    rounding = _linear_calibration().rounding(voltage_step())
+
+    assert rounding(140.24999999999997) == 140.25
+
+
+def test_rounding_drops_the_digits_below_the_step() -> None:
+    rounding = _linear_calibration().rounding(voltage_step())
+
+    assert rounding(20.575123456789) == 20.58
+
+
+def test_a_declared_digit_count_wins_over_the_derived_step() -> None:
+    # The board averages, or the person knows something the file cannot
+    # derive. Either way what they wrote is what happens.
+    rounding = _linear_calibration(significant_digits=8).rounding(voltage_step())
+
+    assert rounding(20.575123456789) == 20.575123
+
+
+def test_a_conversion_with_no_step_keeps_the_computed_value(
+    tmp_path: Path,
+) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "pirani-1"
+            measurement = "pressure"
+            mode = "expression"
+            expression = "10**(1.667*v - 11.33)"
+            value_unit = "mbar"
+            """,
+        )
+    ).values()
+
+    rounding = calibration.rounding(voltage_step())
+
+    assert rounding(2.6348494304336958e-09) == 2.6348494304336958e-09
+
+
+def test_a_declared_digit_count_reaches_a_conversion_with_no_step(
+    tmp_path: Path,
+) -> None:
+    # The whole reason the key exists: a spline or an expression has no
+    # derivable step, so the file is the only place the answer can come
+    # from.
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "pirani-1"
+            measurement = "pressure"
+            mode = "expression"
+            expression = "10**(1.667*v - 11.33)"
+            value_unit = "mbar"
+            significant_digits = 3
+            """,
+        )
+    ).values()
+
+    rounding = calibration.rounding(voltage_step())
+
+    assert rounding(2.6348494304336958e-09) == 2.63e-09
+
+
+def test_a_zero_factor_is_not_a_place_to_round_to() -> None:
+    # A dead channel wired to nothing. log10(0) has no answer, and the
+    # value is already whatever the conversion made of it.
+    calibration = Calibration(
+        sensor_id="dead",
+        measurement="temperature",
+        conversion=LinearConversion(factor=ureg("0 kelvin / volt")),
+    )
+
+    rounding = calibration.rounding(voltage_step())
+
+    assert rounding(0.1234567) == 0.1234567
+
+
+def test_the_value_units_are_read_from_the_conversion() -> None:
+    calibration = _linear_calibration()
+
+    assert calibration.value_units == ureg.kelvin
+
+
+def test_the_value_units_are_computed_once() -> None:
+    # Read once per reading through `rounding` and `unit`, and fixed as
+    # soon as the file is parsed.
+    conversion = _CountingConversion()
+    calibration = Calibration(
+        sensor_id="cryo-77k", measurement="temperature", conversion=conversion
+    )
+
+    _ = calibration.value_units
+    _ = calibration.value_units
+    _ = calibration.unit
+
+    assert conversion.applications == 1
+
+
+# --------------------------------------------------------------------------
+# Reading the resolution keys
+# --------------------------------------------------------------------------
+
+
+def test_load_calibration_reads_an_offset_resolution(tmp_path: Path) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "beam-x"
+            measurement = "position"
+            mode = "affine"
+            conversion_factor = "60 micrometer / volt"
+            offset = "-99 micrometer"
+            offset_resolution = "0.2 micrometer"
+            """,
+        )
+    ).values()
+
+    conversion = cast(AffineConversion, calibration.conversion)
+    assert conversion.offset_resolution is not None
+    assert conversion.offset_resolution.to(ureg.micrometer).magnitude == 0.2
+
+
+def test_load_calibration_defaults_to_an_exact_offset(tmp_path: Path) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "beam-x"
+            measurement = "position"
+            mode = "affine"
+            conversion_factor = "60 micrometer / volt"
+            offset = "-99 micrometer"
+            """,
+        )
+    ).values()
+
+    assert cast(AffineConversion, calibration.conversion).offset_resolution is None
+
+
+def test_load_calibration_rejects_an_offset_resolution_of_the_wrong_dimension(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+        [channels.A0]
+        sensor_id = "beam-x"
+        measurement = "position"
+        mode = "affine"
+        conversion_factor = "60 micrometer / volt"
+        offset = "-99 micrometer"
+        offset_resolution = "0.2 kelvin"
+        """,
+    )
+
+    with pytest.raises(CalibrationError, match="offset_resolution"):
+        _ = load_calibration(path)
+
+
+def test_load_calibration_rejects_a_negative_offset_resolution(
+    tmp_path: Path,
+) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+        [channels.A0]
+        sensor_id = "beam-x"
+        measurement = "position"
+        mode = "affine"
+        conversion_factor = "60 micrometer / volt"
+        offset = "-99 micrometer"
+        offset_resolution = "-0.2 micrometer"
+        """,
+    )
+
+    with pytest.raises(CalibrationError, match="cannot be negative"):
+        _ = load_calibration(path)
+
+
+def test_load_calibration_rejects_an_offset_resolution_without_an_offset(
+    tmp_path: Path,
+) -> None:
+    # Only affine has an offset. Ignoring the key would give a setting
+    # that does nothing the exact appearance of one that works.
+    path = _write_config(
+        tmp_path,
+        """
+        [channels.A0]
+        sensor_id = "cryo-77k"
+        measurement = "temperature"
+        conversion_factor = "42.5 kelvin / volt"
+        offset_resolution = "0.2 kelvin"
+        """,
+    )
+
+    with pytest.raises(CalibrationError, match="has no offset"):
+        _ = load_calibration(path)
+
+
+def test_an_offset_resolution_does_not_change_the_calibration_id(
+    tmp_path: Path,
+) -> None:
+    # The id says which conversion produced a reading. How many digits
+    # survived it is as much a property of the board — `--vref` and
+    # `--resolution-bits` are not recorded either — so adding it here
+    # would re-tag every affine channel already written.
+    body = """
+        [channels.A0]
+        sensor_id = "beam-x"
+        measurement = "position"
+        mode = "affine"
+        conversion_factor = "60 micrometer / volt"
+        offset = "-99 micrometer"
+        """
+    [plain] = load_calibration(_write_config(tmp_path / "plain", body)).values()
+    [declared] = load_calibration(
+        _write_config(tmp_path / "declared", body + 'offset_resolution = "0.2 um"\n')
+    ).values()
+
+    assert plain.calibration_id == declared.calibration_id
+
+
+def test_load_calibration_reads_a_significant_digit_count(tmp_path: Path) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "cryo-77k"
+            measurement = "temperature"
+            conversion_factor = "42.5 kelvin / volt"
+            significant_digits = 4
+            """,
+        )
+    ).values()
+
+    assert calibration.significant_digits == 4
+
+
+def test_load_calibration_defaults_to_no_declared_digits(tmp_path: Path) -> None:
+    [calibration] = load_calibration(
+        _write_config(
+            tmp_path,
+            """
+            [channels.A0]
+            sensor_id = "cryo-77k"
+            measurement = "temperature"
+            conversion_factor = "42.5 kelvin / volt"
+            """,
+        )
+    ).values()
+
+    assert calibration.significant_digits is None
+
+
+@pytest.mark.parametrize("written", ["0", '"4"', "true", "4.5", "-2"])
+def test_load_calibration_rejects_a_digit_count_that_is_not_one(
+    tmp_path: Path, written: str
+) -> None:
+    # `true` included on purpose: bool is an int in Python, so it would
+    # otherwise be read as a request for one digit.
+    path = _write_config(
+        tmp_path,
+        f"""
+        [channels.A0]
+        sensor_id = "cryo-77k"
+        measurement = "temperature"
+        conversion_factor = "42.5 kelvin / volt"
+        significant_digits = {written}
+        """,
+    )
+
+    with pytest.raises(CalibrationError, match="significant_digits"):
+        _ = load_calibration(path)

--- a/tests/test_quantise.py
+++ b/tests/test_quantise.py
@@ -1,0 +1,80 @@
+"""Dropping digits a reading was never entitled to."""
+
+import math
+
+import pytest
+
+from labmon.quantise import to_resolution
+
+
+def test_a_reading_is_rounded_to_the_place_its_step_reaches() -> None:
+    # A 12-bit input scaled by 60 um/V resolves 0.0484 um, which is two
+    # decimals' worth. Everything past them is conversion arithmetic.
+    assert to_resolution(5.981234567890123, 0.0483516484) == 5.98
+
+
+def test_a_reading_is_not_put_on_a_grid_of_whole_steps() -> None:
+    # Stepping to 0.0483516484 would give 5.99560439 — longer than the
+    # number it set out to shorten, and no more honest.
+    rounded = to_resolution(5.981234567890123, 0.0483516484)
+
+    assert len(repr(rounded)) < len("5.99560439")
+
+
+@pytest.mark.parametrize(
+    ("resolution", "expected"),
+    [
+        # 76.8 rather than 76.9 at tenths: halfway goes to even.
+        (0.001, 76.85),
+        (0.01, 76.85),
+        (0.1, 76.8),
+        (1.0, 77.0),
+        (10.0, 80.0),
+        (100.0, 100.0),
+    ],
+)
+def test_a_coarser_step_keeps_fewer_places(resolution: float, expected: float) -> None:
+    assert to_resolution(76.85, resolution) == expected
+
+
+def test_the_step_is_read_at_its_leading_digit() -> None:
+    # 0.5 and 0.1 reach the same place; a step of 0.5 cannot buy a
+    # display of hundredths, and rounding to tenths never claims fewer
+    # digits than the hardware has.
+    assert to_resolution(76.85, 0.5) == to_resolution(76.85, 0.1)
+
+
+def test_a_step_larger_than_the_reading_rounds_it_away() -> None:
+    # Honest: the quantity is smaller than the smallest difference the
+    # input can show.
+    assert to_resolution(0.004, 0.5) == 0.0
+
+
+def test_rounding_does_not_leak_binary_error() -> None:
+    # Dividing and multiplying back gives 76.85000000000001 here.
+    assert repr(to_resolution(76.85006139177405, 0.001)) == "76.85"
+
+
+def test_halfway_goes_to_even() -> None:
+    # Consistent with the rest of the stack, and unbiased over a series.
+    assert to_resolution(0.125, 0.01) == 0.12
+    assert to_resolution(0.135, 0.01) == 0.14
+
+
+def test_a_reading_that_is_not_a_number_passes_through() -> None:
+    # The loop refuses a non-finite value before it becomes a field;
+    # rounding should not be the thing that raises first.
+    assert math.isnan(to_resolution(float("nan"), 0.001))
+    assert math.isinf(to_resolution(float("inf"), 0.001))
+
+
+def test_a_step_beyond_the_decimal_context_leaves_the_reading_alone() -> None:
+    # Some 1e30 below the reading, which nothing physical reaches. The
+    # un-rounded value is the honest answer when the rounding itself is
+    # meaningless.
+    assert to_resolution(2.765613e14, 1e-30) == 2.765613e14
+
+
+def test_a_scientific_magnitude_keeps_its_significant_digits() -> None:
+    # A step of 1e-10 on a reading of 1.02e-07 leaves three of them.
+    assert to_resolution(1.0215499803546169e-07, 1e-10) == 1.022e-07

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -88,6 +88,9 @@ class _UndefinedBelowMidscale:
         volts = voltage.to(ureg.volt).magnitude
         return (float("nan") if volts < 1.65 else 42.5 * volts) * ureg.kelvin
 
+    def resolution(self, _voltage_step: pint.Quantity, /) -> None:
+        return None
+
     def fingerprint(self) -> str:
         return "test|undefined-below-midscale"
 
@@ -679,3 +682,118 @@ def test_each_channel_gets_its_own_gate_state(
 
     [batch] = fake_client.batches
     assert len(batch) == 1
+
+
+# --------------------------------------------------------------------------
+# What reaches the database
+# --------------------------------------------------------------------------
+
+
+def test_a_stored_reading_carries_only_the_digits_the_input_had(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # 70.14212454212455 K claims seventeen digits of a twelve-bit
+    # measurement. The input steps by 806 uV, which through 42.5 K/V is
+    # 34 mK, so hundredths of a kelvin is what was actually measured.
+    source = FakeRawSource([RawReading(channel="A0", raw_count=2048)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "value=70.14 " in point.to_line_protocol()
+
+
+def test_the_conversion_input_keeps_every_digit_it_had(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # `input_volts` is what a corrected calibration would be re-applied
+    # to. Rounding it would make that irrecoverable, which is the whole
+    # reason the field is stored.
+    source = FakeRawSource([RawReading(channel="A0", raw_count=2048)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": _temperature_calibration()})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "input_volts=1.6504029304029304" in point.to_line_protocol()
+
+
+def test_a_coarser_board_stores_coarser_readings(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # Ten bits over 5 V steps by 4.9 mV, which through 42.5 K/V is
+    # 0.21 K — a whole decimal place coarser than the 12-bit default.
+    source = FakeRawSource([RawReading(channel="A0", raw_count=512)])
+
+    with pytest.raises(_StopLoop):
+        run(
+            source=source,
+            calibrations={"A0": _temperature_calibration()},
+            resolution_bits=10,
+            v_ref=5.0,
+        )
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "value=106.4 " in point.to_line_protocol()
+
+
+def test_a_channel_may_state_its_own_digits(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # A board averaging a burst of conversions resolves below one ADC
+    # step, and the host cannot see how many it averaged.
+    calibration = Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=LinearConversion(factor=ureg("42.5 kelvin / volt")),
+        significant_digits=7,
+    )
+    source = FakeRawSource([RawReading(channel="A0", raw_count=2048)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": calibration})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "value=70.14212 " in point.to_line_protocol()
+
+
+def test_the_gate_compares_against_the_reading_that_will_be_stored(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    # 70.14212454212455 K rounds to 70.14, which is under the bound the
+    # unrounded value sits over. A gate reading one number while the
+    # database keeps another would be unexplainable from the data.
+    calibration = Calibration(
+        sensor_id="cryo-77k",
+        measurement="temperature",
+        conversion=LinearConversion(factor=ureg("42.5 kelvin / volt")),
+        stop_recording_when=StopRecordingRule(above=ureg("70.141 kelvin")),
+    )
+    source = FakeRawSource([RawReading(channel="A0", raw_count=2048)])
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": calibration})
+
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    assert "value=70.14 " in point.to_line_protocol()


### PR DESCRIPTION
Readings from `serial-sensor` were written at full float64 precision, so an exported column claimed sixteen digits of a twelve-bit measurement and nobody could tell which of them were physical. The resolution of a calibrated value is computable from what the program already knows, so this computes it rather than picking a flat constant.

Live against the demo stack, before and after:

```
cryo-diode   temperature  14.56589010989012   ->  14.57      K
beam-x       position     -13.843956043956    ->  -13.84     um
pirani-1     pressure     9.3412...e-09       ->  9.34e-09   mbar
input_volts  1.2503655677655676               ->  1.2503655677655676   (untouched)
```

## Where the step comes from

One ADC count is `v_ref / (2**bits - 1)` — 806 µV for a 12-bit part at 3.3 V. Each conversion carries that onto its own scale:

| mode | step | why |
|---|---|---|
| `linear` | `\|K\|·δv` | one factor scales the whole range |
| `affine` | `hypot(δoffset, K·δv)` | the offset shifts the scale without dividing it; its own uncertainty, where it has one, is independent of the ADC's |
| `spline`, `piecewise_linear`, `expression` | *none* | the slope varies along the curve, or is unknown to the loader |

The reading is then rounded to the decimal place that step reaches, not onto a grid of whole steps. A derived step is never a round number, and stepping 14.5659 K onto multiples of 0.0342 gives `14.555860805860807` — longer than the number it set out to shorten, and no more honest. Rounding to the place the step reaches gives `14.57`, keeps at most one digit more than the hardware supports and never fewer, and is how an instrument front panel is specified.

## Two new keys in `[channels.<name>]`

`significant_digits` overrides the derived answer on any channel, and is the only source of one for the two modes that derive nothing. Significant rather than decimal places because a calibrated channel may sit anywhere on the scale: three decimals is far too coarse for a gauge reading 1e-8 mbar and far too fine for a room thermometer.

```toml
[channels.A0]
sensor_id = "cryo-diode"
measurement = "temperature"
mode = "piecewise_linear"
voltages = [0.50, 1.00, 1.15, 1.30]
values = [300.0, 100.0, 40.0, 2.0]
value_unit = "kelvin"
significant_digits = 4       # 2 K to 300 K, without claiming millikelvins
```

`offset_resolution` says how well an affine offset is itself known, for one that came out of a fit rather than a divider ratio. Without it an affine channel resolves exactly as the linear one behind it does. It is rejected on the other modes rather than ignored, since none of them has an offset — a setting that does nothing should not look like one that works.

The demo's two curved channels now set `significant_digits`, and a test asserts that every demo channel either derives a step or states one. That is what turns the sixteen-digit column in #148 into `14.57 K`.

## Decisions worth flagging in review

**Rounding is storage, not presentation.** It happens once, immediately after conversion, so the gate compares against the number that will actually be written and the debug line quotes the same one. The alternative — store everything and round in `labmon export` from a recorded resolution — keeps the database lossless, but it means every reader has to know about the extra metadata to get the right answer, and the digits it would hide are not information in the first place.

**Only `value` is touched.** `input_volts` keeps every digit: it is what a corrected calibration gets re-applied to, and rounding it would make that irrecoverable. That is also what keeps `--vref` and `--resolution-bits` correctable after the fact, as documented.

**`calibration_id` deliberately does not move.** It says which conversion produced a reading. How many digits survived is as much a property of the board — neither `--vref` nor `--resolution-bits` is recorded at all — so folding `offset_resolution` into the affine fingerprint would re-tag every affine channel already in a database, for a distinction the id cannot express anyway.

**Averaging is not accounted for.** The reference sketch reports the mean of a burst and sends a fractional count, which resolves below one ADC step — but not by how much, so the derived answer stays the conservative one. `significant_digits` covers it by hand today. Filed as #174, which proposes letting the effective step be stated rather than always starting from `v_ref / (2**bits - 1)`.

## Test plan

- [x] 721 tests, 100% coverage; `ruff check`, `ruff format --check`, `basedpyright` (0 errors, 0 warnings), `typos` all clean
- [x] `to_resolution` covered for the place rule, the half-to-even boundary, non-finite input, and a step far below the decimal context
- [x] each conversion's derived step, including a falling response, a quadrature offset, and a unit mismatch between the two terms
- [x] `Calibration.rounding` for the derived path, the declared override, a conversion with no step, and a zero factor
- [x] the loader for both new keys, their rejections, and the calibration_id staying put
- [x] `serial_sensor.run` for the rounded field, the untouched `input_volts`, a coarser board, a declared digit count, and the gate seeing the rounded value
- [x] a test pinning that the demo file states digits wherever none can be derived
- [x] end to end against the demo stack, checked in both `labmon query latest` and a CSV export

Fixes #148.
