### PR TITLE
docs(changelog): record everything merged since the changelog began

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ so the sections below map onto commit types.
 
 ### Added
 
+- **A terminal panel for watching current values.** `labmon monitor`
+  draws where every sensor stands and redraws itself, for the terminal
+  already open beside the experiment — where Grafana is the wrong tool,
+  and over a bare SSH session is no tool at all.
+  [`docs/monitor.md`](docs/monitor.md) —
+  [#172](https://github.com/quentinmarolleau/labmon/pull/172),
+  [#177](https://github.com/quentinmarolleau/labmon/pull/177)
+  - **A tile per sensor**, from `[[monitor.panels]]`: the reading large
+    enough to read across a room, its unit, how long ago it arrived,
+    and a border that changes colour when it crosses `warn_above` or
+    `warn_below`. With no layout the panel falls back to a table of
+    every sensor the database has.
+  - **A sensor that has gone quiet still shows what it was reading**,
+    marked as not reporting. A cryostat that went quiet at 4 K is a
+    different morning from one that went quiet at 300 K.
+  - **`[[monitor.sensors]]` display rules** say how many digits an
+    instrument is worth, in the table and in any tile alike — for the
+    readings behind a calibration, where a conversion turns four honest
+    digits into seventeen.
+  - `q` quits, `r` changes the refresh rate, `s` writes a screenshot,
+    `m` opens the command palette — where a theme is worn as the
+    selector passes over it — and `?` lists the keys.
+  - Needs the `tui` extra: `pip install 'labmon[tui]'`. An install that
+    only writes readings does not carry Textual.
+- **`labmon query latest`, one row per sensor and how long ago it
+  reported.** Every measurement reduced to its most recent reading in a
+  single round trip, with the stale ones coloured.
+  [`docs/export.md`](docs/export.md) —
+  [#163](https://github.com/quentinmarolleau/labmon/pull/163),
+  [#164](https://github.com/quentinmarolleau/labmon/pull/164),
+  [#165](https://github.com/quentinmarolleau/labmon/pull/165)
+  - **`labmon sensors`** lists the roster: every sensor labmon has seen,
+    cached between runs, so one that has stopped reporting is still on
+    the list rather than silently absent.
+  - **`--stats`** adds the window's average, standard deviation and
+    reading count beside each value, rounded against each other so the
+    average is never quoted finer than the spread supports.
+    [#171](https://github.com/quentinmarolleau/labmon/pull/171)
+- **A per-user configuration file**, read from
+  `$XDG_CONFIG_HOME/labmon/labmon.toml`: the timezone timestamps are
+  shown in, and the `[monitor]` section the panel reads. Not having one
+  is the ordinary case — every key has a default.
+  [`docs/configuration.md`](docs/configuration.md) —
+  [#170](https://github.com/quentinmarolleau/labmon/pull/170)
 - **A command line for reading recorded data.** `labmon query` prints
   readings as an aligned table; `labmon export` writes them to a file.
   Both take the same selection flags — `--measurement`, `--sensor-id`,
@@ -45,6 +89,15 @@ so the sections below map onto commit types.
 
 ### Changed
 
+- **A calibrated reading is stored at the resolution its input had.**
+  `serial-sensor` wrote the full float64 result of a conversion, so an
+  exported column claimed sixteen digits of a twelve-bit measurement
+  and nothing said which of them were physical.
+  [#175](https://github.com/quentinmarolleau/labmon/pull/175)
+- The demo's beam channels wander as a beam does, rather than tracing
+  the tidy Lissajous figure two sines at incommensurate periods gave
+  them.
+  [#176](https://github.com/quentinmarolleau/labmon/pull/176)
 - **`mock-sensor` and `serial-sensor` are now `labmon mock-sensor` and
   `labmon serial-sensor`.** The old spellings still work and print a
   deprecation warning, so unit files already installed on lab machines
@@ -56,6 +109,10 @@ so the sections below map onto commit types.
 
 ### Fixed
 
+- `labmon mock-sensor` with no `--measurement` and no `--unit` wrote a
+  walk around 21.0 into the `temperature` table with no unit tag. Both
+  are now required.
+  [#158](https://github.com/quentinmarolleau/labmon/issues/158)
 - Simulated sensors reported values to full float64 precision, filling
   the database with readings like `76.85006139177405 K` that no
   thermometer could produce.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,111 +11,69 @@ so the sections below map onto commit types.
 
 ### Added
 
-- **A terminal panel for watching current values.** `labmon monitor`
-  draws where every sensor stands and redraws itself, for the terminal
-  already open beside the experiment — where Grafana is the wrong tool,
-  and over a bare SSH session is no tool at all.
+#### The command line
+
+- **`labmon query` and `labmon export`** — print readings as a table,
+  or write them to CSV, Parquet, Feather or netCDF (netCDF is opt-in as
+  `labmon[netcdf]`). Both take the same selection flags, and the unit
+  travels with the readings in every format.
+  [`docs/export.md`](docs/export.md),
+  [`docs/loading-exports.md`](docs/loading-exports.md) —
+  [#154](https://github.com/quentinmarolleau/labmon/pull/154)
+  - `--split-per-sensor` writes one file per sensor; `--no-raw-input`
+    leaves the provenance columns out.
+- **`labmon query latest`** — one row per sensor, with how long ago it
+  reported. `--stats` adds the window's average, deviation and count,
+  the average rounded against the deviation.
+  [#164](https://github.com/quentinmarolleau/labmon/pull/164),
+  [#171](https://github.com/quentinmarolleau/labmon/pull/171)
+- **`labmon sensors`** — the roster of every sensor labmon has seen,
+  cached between runs, so one that stops reporting is still listed.
+  [#165](https://github.com/quentinmarolleau/labmon/pull/165)
+- **`labmon monitor`** — a panel that redraws in place, for the
+  terminal beside the experiment. A tile per sensor from
+  `[[monitor.panels]]`, with thresholds and per-sensor digits, or a
+  table of everything when no layout is configured. Needs the `tui`
+  extra.
   [`docs/monitor.md`](docs/monitor.md) —
   [#172](https://github.com/quentinmarolleau/labmon/pull/172),
   [#177](https://github.com/quentinmarolleau/labmon/pull/177)
-  - **A tile per sensor**, from `[[monitor.panels]]`: the reading large
-    enough to read across a room, its unit, how long ago it arrived,
-    and a border that changes colour when it crosses `warn_above` or
-    `warn_below`. With no layout the panel falls back to a table of
-    every sensor the database has.
-  - **A sensor that has gone quiet still shows what it was reading**,
-    marked as not reporting. A cryostat that went quiet at 4 K is a
-    different morning from one that went quiet at 300 K.
-  - **`[[monitor.sensors]]` display rules** say how many digits an
-    instrument is worth, in the table and in any tile alike — for the
-    readings behind a calibration, where a conversion turns four honest
-    digits into seventeen.
-  - `q` quits, `r` changes the refresh rate, `s` writes a screenshot,
-    `m` opens the command palette — where a theme is worn as the
-    selector passes over it — and `?` lists the keys.
-  - Needs the `tui` extra: `pip install 'labmon[tui]'`. An install that
-    only writes readings does not carry Textual.
-- **`labmon query latest`, one row per sensor and how long ago it
-  reported.** Every measurement reduced to its most recent reading in a
-  single round trip, with the stale ones coloured.
-  [`docs/export.md`](docs/export.md) —
-  [#163](https://github.com/quentinmarolleau/labmon/pull/163),
-  [#164](https://github.com/quentinmarolleau/labmon/pull/164),
-  [#165](https://github.com/quentinmarolleau/labmon/pull/165)
-  - **`labmon sensors`** lists the roster: every sensor labmon has seen,
-    cached between runs, so one that has stopped reporting is still on
-    the list rather than silently absent.
-  - **`--stats`** adds the window's average, standard deviation and
-    reading count beside each value, rounded against each other so the
-    average is never quoted finer than the spread supports.
-    [#171](https://github.com/quentinmarolleau/labmon/pull/171)
+- **Tab completion** for bash, zsh, fish and powershell, through
+  `labmon --install-completion`.
+  [#154](https://github.com/quentinmarolleau/labmon/pull/154)
+
+#### Elsewhere
+
 - **A per-user configuration file**, read from
-  `$XDG_CONFIG_HOME/labmon/labmon.toml`: the timezone timestamps are
-  shown in, and the `[monitor]` section the panel reads. Not having one
-  is the ordinary case — every key has a default.
+  `$XDG_CONFIG_HOME/labmon/labmon.toml`: the display timezone, and the
+  `[monitor]` section the panel reads.
   [`docs/configuration.md`](docs/configuration.md) —
   [#170](https://github.com/quentinmarolleau/labmon/pull/170)
-- **A command line for reading recorded data.** `labmon query` prints
-  readings as an aligned table; `labmon export` writes them to a file.
-  Both take the same selection flags — `--measurement`, `--sensor-id`,
-  `--since`, `--until` — so whichever is learned first teaches the
-  other.
-  [`docs/export.md`](docs/export.md) —
-  [#154](https://github.com/quentinmarolleau/labmon/pull/154)
-  - **Four export formats.** CSV, Parquet and Feather need nothing
-    extra, since pyarrow already arrives with the InfluxDB client.
-    netCDF is opt-in as `labmon[netcdf]`, so a sensor host that only
-    writes does not pay for it.
-  - **The unit travels with the readings**, as a column in every format
-    and additionally as Arrow field metadata in Parquet and Feather,
-    and as a CF `units` attribute in netCDF. pandas and polars both
-    discard schema metadata on read, which is why the column is not
-    optional.
-  - **Tab completion** for bash, zsh, fish and powershell, via
-    `labmon --install-completion`. Completing a flag shows its help
-    text beside it.
-  - `--split-per-sensor`, writing one file per sensor rather than one
-    monolithic file.
-  - `--no-raw-input`, leaving the `input_volts` and `calibration_id`
-    provenance columns out of an export.
-  - **Documentation for loading an export back**, covering all four
-    files in pandas, polars and xarray, and what the shape of the data
-    means once it is there.
-    [`docs/loading-exports.md`](docs/loading-exports.md)
 - Simulated readings are rounded to a plausible instrument resolution,
-  through `--resolution` for an absolute step or `--significant-digits`
-  otherwise.
+  through `--resolution` or `--significant-digits`.
   [#153](https://github.com/quentinmarolleau/labmon/pull/153)
 
 ### Changed
 
-- **A calibrated reading is stored at the resolution its input had.**
-  `serial-sensor` wrote the full float64 result of a conversion, so an
-  exported column claimed sixteen digits of a twelve-bit measurement
-  and nothing said which of them were physical.
+- `mock-sensor` and `serial-sensor` are now `labmon mock-sensor` and
+  `labmon serial-sensor`. The old spellings still work and warn.
+- A calibrated reading is stored at the resolution of its input rather
+  than at full float64 precision.
   [#175](https://github.com/quentinmarolleau/labmon/pull/175)
-- The demo's beam channels wander as a beam does, rather than tracing
-  the tidy Lissajous figure two sines at incommensurate periods gave
-  them.
+- Startup imports pyarrow, pint, numpy and the InfluxDB client only
+  when the command needs them: `labmon query --help` goes from 0.79 s
+  to 0.19 s.
+- The demo's beam channels wander rather than tracing a Lissajous
+  figure.
   [#176](https://github.com/quentinmarolleau/labmon/pull/176)
-- **`mock-sensor` and `serial-sensor` are now `labmon mock-sensor` and
-  `labmon serial-sensor`.** The old spellings still work and print a
-  deprecation warning, so unit files already installed on lab machines
-  keep running.
-- Startup no longer imports pyarrow, pint, numpy and the InfluxDB
-  client unless the command being run needs them. `labmon query --help`
-  goes from 0.79 s to 0.19 s, and a tab completion from roughly 1.8 s
-  to 0.4 s.
 
 ### Fixed
 
-- `labmon mock-sensor` with no `--measurement` and no `--unit` wrote a
-  walk around 21.0 into the `temperature` table with no unit tag. Both
-  are now required.
+- `labmon mock-sensor` given neither `--measurement` nor `--unit` wrote
+  to `temperature` with no unit; both are now required.
   [#158](https://github.com/quentinmarolleau/labmon/issues/158)
-- Simulated sensors reported values to full float64 precision, filling
-  the database with readings like `76.85006139177405 K` that no
-  thermometer could produce.
+- Simulated sensors reported full float64 precision, filling the
+  database with readings no thermometer could produce.
   [#152](https://github.com/quentinmarolleau/labmon/issues/152)
 
 ## [0.2.0-beta.1] — 2026-08-23


### PR DESCRIPTION
Eight pull requests have merged since the changelog was written and none of them were in it. This adds them, and reworks the `[Unreleased]` section while it is open.

The command line is most of what this release adds, so it gets a heading of its own — `labmon query`, `export`, `query latest`, `sensors`, `monitor` and the completions — with the rest under **Elsewhere**.

Entries are one or two sentences each. The old ones argued their case: how a unit survives a round trip through pandas, what every key in the panel does, why a cryostat that stopped at 4 K is a different morning from one that stopped at 300 K. That belongs in the linked documentation and the linked pull request, which is what the links are for. The section is half the length it was.

Recorded: the terminal panel (#170, #172, #177), `labmon query latest` with the cached roster and `--stats` (#163, #164, #165, #171), the per-user configuration file (#170), the calibrated-resolution change (#175), the demo's beam channels (#176), and #158.

Two merges are deliberately left out: the signed-commit note in CONTRIBUTING (#159) and the writer test that slept instead of waiting (#160). Neither changes anything an installed labmon does.

## Test plan

- [x] `typos` clean; the file renders as one list per section, with no gaps
- [x] every link checked against the pull request or issue it names
