### PR TITLE
perf(export): ask the schema once for every table

### DIFF
--- a/src/labmon/export/query.py
+++ b/src/labmon/export/query.py
@@ -112,6 +112,37 @@ def columns_of(client: Queryable, measurement: str) -> frozenset[str]:
     return frozenset(cast(list[str], table.to_pydict().get("column_name", [])))
 
 
+def columns_of_all(client: Queryable) -> dict[str, frozenset[str]]:
+    """The columns of every user table, in one round trip.
+
+    The same question `columns_of` asks about a single table, asked
+    about all of them at once. A query that reads several measurements
+    otherwise spends one round trip per table before sending the one it
+    came for — which is the cost the latest query was designed around,
+    applied to the schema rather than to the readings.
+
+    `columns_of` stays for the callers that genuinely want one table:
+    `fetch` is handed a single measurement and issues a query per table
+    regardless, so it has nothing to batch against.
+
+    A table the server does not describe is simply absent from the map,
+    which reads the same as a table with no usable columns.
+    """
+    table = client.query(
+        "SELECT table_name, column_name FROM information_schema.columns"
+        + " WHERE table_schema = $schema",
+        query_parameters={"schema": _USER_SCHEMA},
+    )
+    rows = table.to_pydict()
+    names = cast(list[str], rows.get("table_name", []))
+    columns = cast(list[str], rows.get("column_name", []))
+
+    found: dict[str, set[str]] = {}
+    for name, column in zip(names, columns, strict=True):
+        found.setdefault(name, set()).add(column)
+    return {name: frozenset(columns) for name, columns in found.items()}
+
+
 def _select_clause(present: frozenset[str]) -> str:
     wanted = [TIME_COLUMN, VALUE_COLUMN]
     wanted.extend(name for name in OPTIONAL_COLUMNS if name in present)
@@ -323,9 +354,12 @@ def fetch_latest(
 ) -> pa.Table:
     """The most recent reading each sensor produced within `window`.
 
-    One round trip for every measurement, as a UNION of one arm per
-    table. The round trips are what cost — the scan itself is cheap — so
-    asking six times would be six times the latency for the same answer.
+    Two round trips whatever the number of measurements: one sweep of
+    the schema, and one UNION of an arm per table. The round trips are
+    what cost — the scan itself is cheap — so asking six times would be
+    six times the latency for the same answer. Against the demo stack's
+    six measurements that is 46 ms rather than the 71 ms the same call
+    took at seven trips.
 
     A table with no `sensor_id` is skipped rather than refused: "the
     latest per sensor" has no meaning there, and a measurement written by
@@ -349,9 +383,13 @@ def fetch_latest(
         parameters[name] = sensor
         placeholders.append(f"${name}")
 
+    # One sweep for every table rather than one question each: the
+    # round trip is what costs here, exactly as it does for the readings.
+    known = columns_of_all(client)
+
     usable: list[tuple[str, frozenset[str]]] = []
     for measurement in measurements:
-        present = columns_of(client, measurement)
+        present = known.get(measurement, frozenset())
         if not {TIME_COLUMN, VALUE_COLUMN, SENSOR_COLUMN} <= present:
             logger.debug(
                 "measurement has no per-sensor readings",

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -43,11 +43,14 @@ class FakeClient:
                 }
             )
         if "information_schema.columns" in query:
+            # `table_name` is named in every row, as the server names it,
+            # so the same answer serves the sweep over every table and
+            # the question about one.
+            columns = ["time", "value", "sensor_id", "unit", "calibration_id"]
             return pa.table(
                 {
-                    "column_name": pa.array(
-                        ["time", "value", "sensor_id", "unit", "calibration_id"]
-                    )
+                    "table_name": pa.array(["temperature"] * len(columns)),
+                    "column_name": pa.array(columns),
                 }
             )
         return pa.table(

--- a/tests/test_cli_monitor.py
+++ b/tests/test_cli_monitor.py
@@ -50,8 +50,15 @@ class PanelClient:
                 }
             )
         if "information_schema.columns" in query:
+            # `table_name` is named in every row, as the server names it,
+            # so the same answer serves the sweep over every table and
+            # the question about one.
+            columns = ["time", "value", "sensor_id", "unit"]
             return pa.table(
-                {"column_name": pa.array(["time", "value", "sensor_id", "unit"])}
+                {
+                    "table_name": pa.array(["temperature"] * len(columns)),
+                    "column_name": pa.array(columns),
+                }
             )
         now = datetime.now(UTC)
         return pa.table(

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -140,8 +140,15 @@ class FakeClient:
                 }
             )
         if "information_schema.columns" in query:
+            # `table_name` is named in every row, as the server names it,
+            # so the same answer serves the sweep over every table and
+            # the question about one.
+            columns = ["time", "value", "sensor_id", "unit"]
             return pa.table(
-                {"column_name": pa.array(["time", "value", "sensor_id", "unit"])}
+                {
+                    "table_name": pa.array(["temperature"] * len(columns)),
+                    "column_name": pa.array(columns),
+                }
             )
         return pa.table(
             {

--- a/tests/test_cli_sensors_roster.py
+++ b/tests/test_cli_sensors_roster.py
@@ -35,8 +35,15 @@ class RosterClient:
                 }
             )
         if "information_schema.columns" in query:
+            # `table_name` is named in every row, as the server names it,
+            # so the same answer serves the sweep over every table and
+            # the question about one.
+            columns = ["time", "value", "sensor_id", "unit"]
             return pa.table(
-                {"column_name": pa.array(["time", "value", "sensor_id", "unit"])}
+                {
+                    "table_name": pa.array(["temperature"] * len(columns)),
+                    "column_name": pa.array(columns),
+                }
             )
         return pa.table(
             {

--- a/tests/test_export_query.py
+++ b/tests/test_export_query.py
@@ -9,6 +9,7 @@ import pytest
 from labmon.export.query import (
     QueryError,
     columns_of,
+    columns_of_all,
     fetch,
     fetch_latest,
     list_measurements,
@@ -55,6 +56,28 @@ class FakeClient:
         if "SHOW TABLES" in query:
             return _TABLES
         if "information_schema.columns" in query:
+            if "table" not in parameters:
+                # The sweep, which asks about every table at once. Each
+                # of them has the same columns in this fake.
+                names = [
+                    name
+                    for schema, name in zip(
+                        cast(list[str], _TABLES.column("table_schema").to_pylist()),
+                        cast(list[str], _TABLES.column("table_name").to_pylist()),
+                        strict=True,
+                    )
+                    if schema == "iox"
+                ]
+                return pa.table(
+                    {
+                        "table_name": pa.array(
+                            [name for name in names for _ in self._columns]
+                        ),
+                        "column_name": pa.array(
+                            [column for _ in names for column in self._columns]
+                        ),
+                    }
+                )
             return pa.table({"column_name": pa.array(list(self._columns))})
         return pa.table({"time": pa.array([], pa.timestamp("ns"))})
 
@@ -301,9 +324,29 @@ class UnevenClient(FakeClient):
         if "information_schema.columns" in query:
             raw = kwargs.get("query_parameters")
             parameters = cast(dict[str, str], raw) if isinstance(raw, dict) else {}
+            self.calls.append((query, dict(parameters)))
+            if "table" not in parameters:
+                self._asked.append("")
+                return pa.table(
+                    {
+                        "table_name": pa.array(
+                            [
+                                name
+                                for name, columns in self._per_table.items()
+                                for _ in columns
+                            ]
+                        ),
+                        "column_name": pa.array(
+                            [
+                                column
+                                for columns in self._per_table.values()
+                                for column in columns
+                            ]
+                        ),
+                    }
+                )
             table = parameters.get("table", "")
             self._asked.append(table)
-            self.calls.append((query, dict(parameters)))
             return pa.table({"column_name": pa.array(list(self._per_table[table]))})
         return super().query(query, *args, **kwargs)  # pyright: ignore[reportArgumentType]
 
@@ -417,3 +460,36 @@ def test_an_empty_result_without_statistics_does_not_invent_them() -> None:
     result = fetch_latest(client, ("temperature",), _WINDOW)
 
     assert not {"mean", "sd", "n"} & set(result.column_names)
+
+
+def test_the_columns_of_every_table_come_in_one_round_trip() -> None:
+    # One question about six tables rather than six questions about one
+    # each: the round trip is what costs, which is the argument the
+    # latest query was built on in the first place.
+    client = FakeClient(("time", "value", "sensor_id"))
+
+    known = columns_of_all(client)
+
+    assert known["temperature"] == frozenset({"time", "value", "sensor_id"})
+    assert set(known) == {"temperature", "pressure", "voltage"}
+    assert len(client.calls) == 1
+
+
+def test_the_latest_query_asks_about_the_schema_once() -> None:
+    client = FakeClient(_FULL)
+
+    _ = fetch_latest(client, ("temperature", "pressure", "voltage"), _WINDOW)
+
+    schema = [sql for sql, _ in client.calls if "information_schema" in sql]
+    assert len(schema) == 1
+
+
+def test_a_table_the_sweep_did_not_report_is_skipped() -> None:
+    # It was dropped between the listing and the sweep, or it is a table
+    # the server will not describe. Either way there is nothing to
+    # project, which is the same answer as a table with no readings.
+    client = FakeClient(())
+
+    result = fetch_latest(client, ("temperature",), _WINDOW)
+
+    assert result.num_rows == 0


### PR DESCRIPTION
Closes #167.

`fetch_latest` asked every table for its column list before sending the UNION it came for — seven round trips for the demo stack's six measurements. `information_schema.columns` answers for all of them at once, so `columns_of_all` sweeps it in one query and the arms are built from the result.

Measured against the demo stack, per call:

| | round trips | median |
|---|---|---|
| before | 7 | 71 ms |
| after | 2 | 46 ms |

A `labmon monitor` tick, which runs this query every two seconds, goes from 83 ms to 60 ms. The saving grows with the number of tables a deployment writes and not at all with how much data is in them.

`columns_of` is kept rather than replaced, which is the first of the two questions the issue left open. `fetch` is handed one measurement at a time and issues a query per table regardless, so it has nothing to batch against.

The second question — whether the export path should batch too — I am leaving open. A six-measurement export spends about 20 ms of 92 ms on schema questions, before it writes anything to disk, so the change would be larger and buy proportionally less. Worth revisiting if a deployment with many tables says otherwise.

The fakes in the command-level tests now name the table in every row of their schema answer, as a real server does; one answer then serves both the sweep and the single-table question.

## Test plan

- [x] 979 tests, 100% coverage; `ruff check`, `ruff format --check`, `basedpyright` (0 errors, 0 warnings) clean
- [x] round trips counted through a wrapping client against the live demo stack, before and after
- [x] `labmon query latest --stats`, `labmon export` and `labmon monitor` all exercised against that stack
