### PR TITLE
fix(docker): run the containers as an unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,25 @@ ENV PATH="/app/.venv/bin:$PATH"
 # like a dead sensor rather than a buffering artefact.
 ENV PYTHONUNBUFFERED=1
 
+# Everything above this line runs as root because installing does. What
+# the image is built to run does not: a sensor reads a device and writes
+# to a database over the network, and neither needs uid 0. Container root
+# is not host root, so the practical risk was modest — but this is the
+# first finding any container scan reports, and a lab that runs one
+# before deploying the stack should find nothing rather than this.
+#
+# `dialout` owns the serial device nodes on Debian and Ubuntu, where its
+# gid is 20 and matches the group the host puts on /dev/tty*. A host that
+# numbers it differently — Arch, Fedora — passes its own gid through with
+# `group_add`, since a bind-mounted device carries the host's numbers
+# rather than the container's names. See docs/serial-sensor.md.
+RUN groupadd --system --gid 10001 labmon     && useradd --system --uid 10001 --gid labmon --shell /usr/sbin/nologin        --home-dir /home/labmon --create-home labmon     && usermod --append --groups dialout labmon     && chown labmon:labmon /app
+
+# The roster cache lands under $HOME, which for uid 0 was /root and is
+# now a directory this user owns. Set explicitly because a container
+# started without a login shell inherits no HOME at all.
+ENV HOME=/home/labmon
+
+USER labmon
+
 ENTRYPOINT ["labmon", "mock-sensor"]

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -170,6 +170,14 @@ services:
   # devices: passes the serial device through to the container.
   # volumes: the calibration file is read at startup and never written.
   #
+  # The container runs as an unprivileged user that is in `dialout`, whose
+  # gid is 20 on Debian and Ubuntu. A host that numbers that group
+  # differently has to pass its own gid through, because a device carries
+  # the host's numbers rather than the container's names:
+  #
+  #   group_add:
+  #     - "$(stat -c %g /dev/labmon-due)"
+  #
   # serial-sensor:
   #   <<: *labmon-sensor
   #   container_name: labmon-serial-sensor

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -88,6 +88,12 @@ reliably delivers the right file — and name where it landed:
 INFLUXDB_TLS_CA=/etc/labmon/labmon-ca.crt
 ```
 
+Leave it readable by everyone — `chmod 644`, which is what
+`export-ca.sh` writes. The sensor containers run as an unprivileged user
+and read the file through a bind mount, so an owner-only copy is one they
+cannot open. There is nothing in it to protect: the private key never
+leaves the server.
+
 The server signs its own certificates, and a private root is in no system
 trust store, so without this the sensor refuses to connect rather than
 merely warning. One variable is enough for both directions of traffic:

--- a/docs/custom-sensor.md
+++ b/docs/custom-sensor.md
@@ -108,6 +108,11 @@ on top of it. Putting them in the shared image instead means a failed SDK
 install stops the whole stack building, and a merge conflict on every
 `git pull`.
 
+The base image ends as an unprivileged user, so a layer that installs
+anything — a wheel, an apt package — asks for root back with `USER root`
+and hands it in again with `USER labmon` before the entrypoint. The
+template does that around the section meant for it.
+
 On a machine where the container is not an option — a locked-down control
 PC, or an SDK that will not containerise — the same two scripts run
 directly under systemd instead. See [`deploy/`](../deploy/) for the units

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -514,6 +514,17 @@ client machine — nothing about the code cares which.
 the image's default entrypoint, passes the device through, and mounts the
 calibration file read-only.
 
+The container runs as an unprivileged user that is a member of `dialout`,
+which is gid 20 on Debian and Ubuntu — the same group the host puts on
+the device. On a host that numbers it differently, add the host's gid to
+the service, since a passed-through device carries the host's numbers and
+not the container's names:
+
+```yaml
+group_add:
+  - "986"   # stat -c %g /dev/labmon-due
+```
+
 **Bare install**: use
 [`deploy/labmon-serial-sensor.service`](../deploy/labmon-serial-sensor.service)
 as a systemd unit so it starts on boot and restarts on failure.

--- a/scripts/export-ca.sh
+++ b/scripts/export-ca.sh
@@ -43,6 +43,12 @@ fi
 
 docker compose cp "caddy:${ROOT_IN_CONTAINER}" "$DESTINATION"
 
+# `cp` brings the mode out of the container with it, which is owner-only.
+# The containers that read this file run as an unprivileged user, so an
+# owner-only copy is one they cannot open — and there is nothing here to
+# protect: the file is a public certificate, as the header above says.
+chmod 644 "$DESTINATION"
+
 # Without openssl there is no way to tell a good export from a truncated
 # one. Say that, rather than reporting a file that is probably fine as
 # unreadable — the check is the optional part here, not the export.

--- a/templates/custom-sensor/Dockerfile
+++ b/templates/custom-sensor/Dockerfile
@@ -22,6 +22,11 @@
 # from your vendor has to sit next to this file; COPY cannot climb out.
 FROM labmon:latest
 
+# The base image ends as the unprivileged `labmon` user, so anything that
+# installs has to ask for root back and hand it in again before the
+# entrypoint. `COPY` is unaffected: it runs as root whatever USER is set.
+USER root
+
 # Your instrument's Python package. uv is already in the base image; the
 # --python flag points it at the venv labmon itself was installed into,
 # which is not the interpreter uv would pick on its own.
@@ -38,6 +43,9 @@ FROM labmon:latest
 #       && rm -rf /var/lib/apt/lists/*
 
 COPY sensor_continuous.py sensor_triggered.py /app/
+
+# Back to the unprivileged user the base image runs as.
+USER labmon
 
 # Overrides the base image's ENTRYPOINT ["mock-sensor"]. Swap in
 # sensor_triggered.py for a container a timer starts and stops.


### PR DESCRIPTION
Closes #116.

The image had no `USER`, so every container built from it — six mock sensors, the demo feeder, `serial-sensor` — ran as uid 0. Nothing needs it: a sensor reads a device and writes to a database over the network. It now ends as a system user, uid 10001, with `$HOME` set explicitly since a container started without a login shell inherits none and the roster cache lands under it.

Serial access comes from group membership rather than from root. The user is in `dialout`, gid 20 on Debian and Ubuntu, which is the group the host puts on the device node. A host that numbers it differently passes its own gid with `group_add`, because a bind-mounted device carries the host's numbers and not the container's names — said in both the commented-out service and `docs/serial-sensor.md`.

`templates/custom-sensor/Dockerfile` takes `USER root` around the section that installs a vendor SDK and hands it back before the entrypoint. `COPY` is unaffected; it runs as root whatever `USER` is set.

## One thing the smoke job caught

The TLS path died at startup with `PermissionError: [Errno 13] Permission denied: '/ca.crt'`. `docker compose cp` brings the mode out of the container with the file, and Caddy keeps its root owner-only — invisible while every container ran as uid 0. `export-ca.sh` now `chmod 644`s what it writes, which is what the file already claims to be: a public certificate whose private key never leaves the server. `docs/client-setup.md` says the same for an operator copying it into place by hand.

## Test plan

- [x] image rebuilt and `mock-cryo-4k` recreated from it: `uid=10001(labmon) gid=10001(labmon) groups=10001(labmon),20(dialout)`
- [x] readings arrive from that container — `labmon query latest --sensor-id cryo-4k` shows it two seconds old
- [x] `$HOME` and `/app` are writable by the new user; the venv is not
- [x] the custom-sensor template builds on the new base and reports the same identity
- [x] 979 tests, `ruff`, `basedpyright` and `typos` clean
- [x] the smoke job's cold start passes, TLS path included

Not verified locally: a physical board over `/dev`. The gid note is the part that wants a second pair of eyes from anyone with one plugged in.

