### PR TITLE
test(smoke): run every dashboard's queries, not just lab-overview

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,11 +20,12 @@ CONTRIBUTING asks commit bodies to. If it fixes an issue, "Closes #n".
 
 <!--
 Touching docker-compose.yml, the Dockerfile, grafana/ or demo/? Bring the
-stack up and run `python3 scripts/smoke_dashboard.py` as well — the unit
-tests cannot see anything that only breaks once containers are running.
+stack up with `COMPOSE_PROFILES=demo,logs` and run
+`python3 scripts/smoke_dashboard.py` as well — the unit tests cannot see
+anything that only breaks once containers are running.
 
 Verified something by hand? Say what you actually observed, not just that
-you checked. "All 14 dashboard queries returned rows" beats "tested locally".
+you checked. "All 20 dashboard queries returned rows" beats "tested locally".
 -->
 
 ## Notes for the reviewer

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -55,17 +55,23 @@ jobs:
       - name: Every service is up
         run: docker compose ps
 
-      - name: Every dashboard query returns rows
-        run: python3 scripts/smoke_dashboard.py --timeout 180
-
       # Adding the profile to a running stack rather than starting a second
       # one: Loki and Alloy join what is already up, so this costs two
       # containers rather than another full bootstrap.
+      #
+      # Ahead of the dashboard check, which now runs the Logs dashboard's
+      # LogQL as well and so needs Loki up. Collection is asserted first
+      # for the same reason: when Alloy is not shipping, every Loki panel
+      # is empty too, and this check names the container that is missing
+      # rather than the six panels that noticed.
       - name: Start log collection
         run: COMPOSE_PROFILES=demo,logs docker compose up -d --wait loki alloy
 
       - name: Every container's logs reach Loki
         run: python3 scripts/smoke_logs.py --timeout 120
+
+      - name: Every dashboard query returns rows
+        run: python3 scripts/smoke_dashboard.py --timeout 180
 
       # Same trick again: the proxy joins the running stack rather than
       # starting a second one. The site lists name `caddy` as well as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,9 +168,12 @@ for when you've been using `--no-verify`.
   through Grafana. It has no coverage requirement and mocks nothing — its
   whole job is to catch what unit tests structurally cannot, like a bind
   mount created with the wrong owner. To run it yourself, bring the stack
-  up and then `python3 scripts/smoke_dashboard.py` — adding
+  up with `COMPOSE_PROFILES=demo,logs` and then
+  `python3 scripts/smoke_dashboard.py` — adding
   `--password "$GRAFANA_ADMIN_PASSWORD"` if you set one in `.env`, which
-  Compose reads but your shell does not.
+  Compose reads but your shell does not. The profile is needed because
+  every dashboard is checked, the Logs one included; `--dashboard
+  lab-overview` skips it on a stack without Loki.
 - `# pragma: no cover` is reserved for code that is genuinely untestable
   in a meaningful way (e.g. the `if __name__ == "__main__":` guard, where
   testing it would only prove Python's own import mechanism works, not

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -166,8 +166,19 @@ off by using a backend nobody taught it about.
 
 None of them run a query, so SQL that is structurally fine but names a
 column the schema does not have passes here. Catching that needs a live
-stack, not a JSON parse — which is what `scripts/smoke_dashboard.py` does,
-though only for `lab-overview.json`: it speaks SQL and reads `rawSql`, so
-the Logs dashboard's LogQL is checked for shape here and not for meaning
-anywhere. `scripts/smoke_logs.py` covers the other half, proving collection
-reaches Loki at all.
+stack, not a JSON parse, which is what `scripts/smoke_dashboard.py` does:
+it sends every panel target on every dashboard through Grafana's query
+endpoint and counts the rows that come back.
+
+Counting rows rather than settling for "no error" is what makes it worth
+running against LogQL. A bad column name is at least a SQL error, but Loki
+answers a renamed logfmt field, a `msg=` that matches nothing and a
+mistyped label with an empty result and no complaint — so a query that has
+stopped meaning anything is indistinguishable from a healthy one until the
+rows are counted. Panels that filter on severity are exempt, since a run
+that logged no warnings is a good run; everything else has to return rows,
+and a new panel is held to that until someone exempts it by name.
+
+Every dashboard means every profile that backs one has to be running, so
+`--dashboard` narrows it to a subset. `scripts/smoke_logs.py` covers the
+half neither reaches, proving collection gets to Loki at all.

--- a/scripts/smoke_dashboard.py
+++ b/scripts/smoke_dashboard.py
@@ -1,20 +1,31 @@
-"""Run every dashboard query against a live stack and assert it returns rows.
+"""Run every dashboard's queries against a live stack and count the rows.
 
-The unit tests in `tests/test_dashboard.py` check the dashboard's shape.
-This checks that it *works*: it takes each panel's `rawSql`, substitutes the
+The unit tests in `tests/test_dashboard.py` check each dashboard's shape.
+This checks that it *works*: it takes every panel target, substitutes the
 dashboard variables the way Grafana's frontend would, and sends it through
-Grafana's own query endpoint — same datasource, same token, same Flight SQL
-connection a browser would use.
+Grafana's own query endpoint — same datasource, same token, same connection
+a browser would use.
 
 That covers the gap nothing else does. A query can be structurally perfect
 and still name a column InfluxDB never created, or reference a table only a
 mock sensor writes; both render as an empty panel and log nothing. Here they
 fail out loud.
 
+Both backends are covered, which matters more for Loki than for InfluxDB. A
+column that does not exist is at least a SQL error, but LogQL answers a
+renamed logfmt field, a `msg=` that matches nothing and a mistyped label
+with an empty result and no error at all — so counting rows is the only
+thing that can tell a working query from one that has stopped meaning
+anything.
+
+Every dashboard in `grafana/dashboards/` is checked, so the profile behind
+each one has to be running. `--dashboard` narrows it to a subset.
+
 Stdlib only, so CI can run it without installing the project.
 
 Usage:
-    python3 scripts/smoke_dashboard.py [--timeout SECONDS] [--password PASSWORD]
+    python3 scripts/smoke_dashboard.py [--dashboard NAME] [--timeout SECONDS]
+                                      [--password PASSWORD]
 
 The password defaults to $GRAFANA_ADMIN_PASSWORD, then to `admin`. Note that
 `.env` is read by Compose, not by your shell, so a password set there has to
@@ -31,11 +42,48 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections import Counter
 from pathlib import Path
-from typing import cast
+from typing import NamedTuple, cast
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-_DASHBOARD = _REPO_ROOT / "grafana" / "dashboards" / "lab-overview.json"
+_DASHBOARD_DIR = _REPO_ROOT / "grafana" / "dashboards"
+
+# The key each datasource type reads its query from. A query written under
+# any other name is accepted by the JSON, sent to the backend empty, and
+# comes back as an error the panel never shows. `tests/test_dashboard.py`
+# holds the same table for its structural checks; a type missing from
+# either fails rather than being skipped, so adding a backend cannot
+# silently switch the check off for the dashboard that uses it.
+_QUERY_FIELD = {"influxdb": "rawSql", "loki": "expr"}
+
+# Panels a healthy stack may leave empty, as (dashboard stem, panel title).
+#
+# The three named here filter on severity, and a run where nothing logged a
+# warning is a good run rather than a broken dashboard. They would also
+# pass for the wrong reason: the one error a quiet stack does produce is
+# Loki's transient ring-initialisation failure at startup, so requiring
+# rows would really be asserting an upstream bug, and the check would begin
+# failing the day that bug is fixed.
+#
+# Anything not listed has to return rows. Defaulting the other way would
+# let a panel stop meaning anything without a word, which is the whole
+# failure this file exists to catch.
+_MAY_BE_EMPTY = frozenset(
+    {
+        ("logs", "Warnings"),
+        ("logs", "Errors"),
+        ("logs", "Warnings and errors"),
+    }
+)
+
+# What Grafana puts in a variable's `current.value` when All is selected.
+_ALL_SENTINEL = "$__all"
+
+# A logs panel returns raw lines, and this only needs to know that some
+# arrived. Grafana's own default is 1000, which is 1000 log lines per panel
+# over the wire for no gain.
+_LOG_LINE_LIMIT = 100
 
 # Where Grafana is by default. `--url` points this at the `tls` profile's
 # proxy instead (https://127.0.0.1:3443), which is the same Grafana reached
@@ -47,10 +95,12 @@ _DEFAULT_GRAFANA_URL = "http://127.0.0.1:3000"
 # of the UI as well, long after the password was corrected.
 _TERMINAL_STATUSES = frozenset({401, 403})
 
-# Grafana's own macros ($__timeFrom() and friends) are expanded server-side by
-# the datasource backend, so they are left alone. Dashboard variables are not:
-# the frontend substitutes those before the query is ever sent, which is what
-# this has to reproduce.
+# Grafana's own macros are expanded server-side by the datasource backend, so
+# they are left alone — `$__timeFrom()` by InfluxDB, and `$__auto` and
+# `$__range` by Loki, which is worth stating because those two read like
+# frontend interpolation and are not. Dashboard variables are the other way
+# round: the frontend substitutes those before the query is ever sent, which
+# is what this has to reproduce.
 _PLAIN_VARIABLE = re.compile(r"\$\{(\w+)\}|\$(\w+)\b")
 _FORMATTED_VARIABLE = re.compile(r"\$\{(\w+):(\w+)\}")
 
@@ -74,11 +124,38 @@ def _mappings(value: object) -> list[dict[str, object]]:
 
 
 def _values_of(variable: dict[str, object]) -> list[str]:
-    """A custom variable's values come from its comma-separated `query`."""
-    query = variable.get("query")
-    if not isinstance(query, str):
-        return []
-    return [value.strip() for value in query.split(",") if value.strip()]
+    """The values Grafana's frontend would substitute for one variable.
+
+    A custom variable's values are its comma-separated `query`, and all of
+    them are used: `${room:singlequote}` reaching `IN (...)` is the case
+    that matters, and taking only the first would quietly narrow it. That
+    covers a custom variable set to All as well, which Grafana expands to
+    exactly the same list.
+
+    A query variable's values come from the datasource, which this script
+    does not ask. One shipped with All selected interpolates `allValue`
+    instead, and that is what a browser sends on load — enough to resolve
+    the Logs dashboard's container filter without a round trip.
+    """
+    if variable.get("type") == "custom":
+        query = variable.get("query")
+        if not isinstance(query, str):
+            return []
+        return [value.strip() for value in query.split(",") if value.strip()]
+
+    current = _mapping(variable.get("current", {})).get("value")
+    selected = cast(list[object], current if isinstance(current, list) else [current])
+    if _ALL_SENTINEL not in selected:
+        return [value for value in selected if isinstance(value, str)]
+
+    all_value = variable.get("allValue")
+    if not isinstance(all_value, str) or not all_value.strip():
+        raise SystemExit(
+            f"variable {variable.get('name')!r} ships with All selected and"
+            + " declares no allValue, so its values cannot be resolved"
+            + " without asking the datasource"
+        )
+    return [all_value]
 
 
 def _interpolate(sql: str, variables: dict[str, list[str]]) -> str:
@@ -169,45 +246,94 @@ def _first(value: object) -> object:
 
 
 def _row_count(result: object) -> int:
-    """Rows in the first frame of a Grafana query result, 0 if there are none."""
-    frame = _first(_child(result, "frames"))
-    first_column = _first(_child(_child(frame, "data"), "values"))
-    if not isinstance(first_column, list):
+    """Rows across every frame of a Grafana query result.
+
+    Every frame rather than the first: a Loki range query returns one per
+    stream, and an empty leading frame would otherwise read as a dead
+    query. A SQL result has a single frame, so nothing changes for it.
+    """
+    frames = _child(result, "frames")
+    if not isinstance(frames, list):
         return 0
-    return len(cast(list[object], first_column))
+    counted = 0
+    for frame in cast(list[object], frames):
+        column = _first(_child(_child(frame, "data"), "values"))
+        if isinstance(column, list):
+            counted += len(cast(list[object], column))
+    return counted
 
 
 class _Rejected(Exception):
     """A failure no amount of waiting will fix, so the retry loop gives up."""
 
 
-def _load_queries(dashboard: dict[str, object]) -> list[tuple[str, dict[str, object]]]:
-    """Every panel target, as a payload for Grafana's query endpoint."""
+class _Query(NamedTuple):
+    """One panel target, ready to send and to report on."""
+
+    label: str
+    payload: dict[str, object]
+    may_be_empty: bool
+
+
+def _payload(
+    kind: str, target: dict[str, object], variables: dict[str, list[str]]
+) -> dict[str, object]:
+    """One target as its datasource backend expects to receive it.
+
+    The backends differ in more than the key the query sits under.
+    InfluxDB wants the frame `format`; Loki wants the `queryType` that
+    decides between a range and an instant query, and a line limit. Send
+    one's keys to the other and the panel comes back empty rather than
+    complaining.
+    """
+    field = _QUERY_FIELD[kind]
+    common: dict[str, object] = {
+        "refId": str(target["refId"]),
+        "datasource": target["datasource"],
+        field: _interpolate(str(target[field]), variables),
+        "intervalMs": 1000,
+        "maxDataPoints": 1000,
+    }
+    if kind == "loki":
+        return {
+            **common,
+            "queryType": target.get("queryType", "range"),
+            "maxLines": _LOG_LINE_LIMIT,
+        }
+    return {**common, "format": target.get("format", "time_series")}
+
+
+def _load_queries(path: Path, dashboard: dict[str, object]) -> list[_Query]:
+    """Every panel target on one dashboard, ready for the query endpoint."""
     templating = _mapping(dashboard["templating"])
     variables = {
         str(variable["name"]): _values_of(variable)
         for variable in _mappings(templating["list"])
     }
 
-    return [
-        (
-            f"{panel['title']} [{target.get('refId')}]",
-            {
-                "refId": str(target["refId"]),
-                "datasource": target["datasource"],
-                "rawSql": _interpolate(str(target["rawSql"]), variables),
-                "format": target.get("format", "time_series"),
-                "intervalMs": 1000,
-                "maxDataPoints": 1000,
-            },
-        )
-        for panel in _mappings(dashboard["panels"])
-        for target in _mappings(panel.get("targets", []))
-    ]
+    queries: list[_Query] = []
+    for panel in _mappings(dashboard["panels"]):
+        title = str(panel.get("title", ""))
+        for target in _mappings(panel.get("targets", [])):
+            kind = str(_mapping(target.get("datasource", {})).get("type"))
+            if kind not in _QUERY_FIELD:
+                raise SystemExit(
+                    f"{path.name}: {title!r} targets a {kind!r} datasource,"
+                    + " whose query field this script does not know; add it"
+                    + f" to _QUERY_FIELD (it knows {sorted(_QUERY_FIELD)})"
+                )
+            queries.append(
+                _Query(
+                    label=f"{path.stem}/{title} [{target.get('refId')}]",
+                    payload=_payload(kind, target, variables),
+                    may_be_empty=(path.stem, title) in _MAY_BE_EMPTY,
+                )
+            )
+    return queries
 
 
 def _attempt(
-    queries: list[tuple[str, dict[str, object]]],
+    queries: list[_Query],
     window: dict[str, str],
     password: str,
     endpoint: str,
@@ -216,13 +342,13 @@ def _attempt(
     """Run every query once, returning `(panel label, what went wrong)`.
 
     The two are kept apart so the report can group by the reason: when the
-    stack is down, all fourteen share one reason and differ only by label.
+    stack is down, every query shares one reason and differs only by label.
     """
     failures: list[tuple[str, str]] = []
-    for label, query in queries:
+    for query in queries:
         try:
             response = _post(
-                {"queries": [query], **window}, password, endpoint, context
+                {"queries": [query.payload], **window}, password, endpoint, context
             )
         except urllib.error.HTTPError as http_error:
             # The status line alone says nothing useful — a bad column name
@@ -230,34 +356,37 @@ def _attempt(
             # what the datasource actually objected to.
             detail = f"{http_error} — {http_error.read().decode()[:400]}"
             if http_error.code in _TERMINAL_STATUSES:
-                raise _Rejected(f"{label}: {detail}") from http_error
-            failures.append((label, detail))
+                raise _Rejected(f"{query.label}: {detail}") from http_error
+            failures.append((query.label, detail))
             continue
         except urllib.error.URLError as url_error:
-            failures.append((label, str(url_error)))
+            failures.append((query.label, str(url_error)))
             continue
 
-        result = _child(_child(response, "results"), str(query["refId"]))
+        result = _child(_child(response, "results"), str(query.payload["refId"]))
         reported = _child(result, "error")
         if reported:
-            failures.append((label, str(reported)))
-        elif _row_count(result) == 0:
-            failures.append((label, "query succeeded but returned no rows"))
+            failures.append((query.label, str(reported)))
+        elif _row_count(result) == 0 and not query.may_be_empty:
+            failures.append((query.label, "query succeeded but returned no rows"))
     return failures
 
 
 def _report(
-    failures: list[tuple[str, str]], total: int, timeout: float, attempts: int
+    failures: list[tuple[str, str]],
+    queries: list[_Query],
+    timeout: float,
+    attempts: int,
 ) -> None:
     """Print the failures, one entry per distinct reason.
 
     When the stack itself is the problem every query fails the same way, and
-    fourteen copies of one Flight SQL traceback buries the case this exists
-    to show: a single panel broken among working ones.
+    twenty copies of one Flight SQL traceback bury the case this exists to
+    show: a single panel broken among working ones.
     """
     summary = (
-        f"{len(failures)} of {total} dashboard queries still failing after"
-        + f" {timeout:.0f}s ({attempts} attempts):"
+        f"{len(failures)} of {len(queries)} dashboard queries still failing"
+        + f" after {timeout:.0f}s ({attempts} attempts):"
     )
     print(summary, file=sys.stderr)
 
@@ -266,6 +395,41 @@ def _report(
         by_reason.setdefault(reason, []).append(label)
     for reason, labels in by_reason.items():
         print(f"  - {', '.join(labels)}: {reason}", file=sys.stderr)
+
+    # Only when a whole dashboard went down at once. Against a single
+    # broken panel among working ones it points at the wrong thing, which
+    # is worse than saying nothing.
+    asked = Counter(query.label.split("/", 1)[0] for query in queries)
+    failed = Counter(label.split("/", 1)[0] for label, _ in failures)
+    if not any(failed[name] == count for name, count in asked.items()):
+        return
+    hint = (
+        "\nA whole dashboard failing at once usually means the profile behind"
+        + " its datasource is not running — the Logs dashboard needs `logs`."
+        + " Use --dashboard to check a subset."
+    )
+    print(hint, file=sys.stderr)
+
+
+def _selected(wanted: list[str] | None) -> list[Path]:
+    """The dashboards to check, every one of them unless `--dashboard` said.
+
+    An unknown name is an error rather than an empty run: a typo would
+    otherwise report success having checked nothing at all.
+    """
+    found = {path.stem: path for path in sorted(_DASHBOARD_DIR.glob("*.json"))}
+    if not found:
+        raise SystemExit(f"no dashboards found in {_DASHBOARD_DIR}")
+    if wanted is None:
+        return list(found.values())
+
+    unknown = sorted(set(wanted) - set(found))
+    if unknown:
+        raise SystemExit(
+            f"no dashboard named {', '.join(unknown)} in {_DASHBOARD_DIR}"
+            + f" (it holds {sorted(found)})"
+        )
+    return [found[name] for name in sorted(set(wanted))]
 
 
 def main() -> int:
@@ -291,15 +455,26 @@ def main() -> int:
         default=None,
         help="CA certificate to verify --url against, for the tls profile",
     )
+    _ = parser.add_argument(
+        "--dashboard",
+        action="append",
+        metavar="NAME",
+        help="check only this dashboard, named by its file stem; repeatable."
+        + " The default is every dashboard in grafana/dashboards, which needs"
+        + " every profile backing one to be running",
+    )
     args = parser.parse_args()
     timeout = cast(float, args.timeout)
     password = cast(str, args.password)
     endpoint = f"{cast(str, args.url).rstrip('/')}/api/ds/query"
     context = _tls_context(cast("str | None", args.cacert))
 
-    # `json.loads` is typed as returning `Any`; nothing here wants that.
-    parsed: object = json.loads(_DASHBOARD.read_text("utf-8"))  # pyright: ignore[reportAny]
-    queries = _load_queries(_mapping(parsed))
+    paths = _selected(cast("list[str] | None", args.dashboard))
+    queries: list[_Query] = []
+    for path in paths:
+        # `json.loads` is typed as returning `Any`; nothing here wants that.
+        parsed: object = json.loads(path.read_text("utf-8"))  # pyright: ignore[reportAny]
+        queries.extend(_load_queries(path, _mapping(parsed)))
 
     # The dashboard's own window. Wide enough that a query is judged on
     # whether it works, not on how long the stack has been up.
@@ -316,11 +491,17 @@ def main() -> int:
             return 1
 
         if not failures:
-            print(f"all {len(queries)} dashboard queries returned rows")
+            exempt = sum(1 for query in queries if query.may_be_empty)
+            note = f", not counting {exempt} allowed to be empty" if exempt else ""
+            plural = "" if len(paths) == 1 else "s"
+            print(
+                f"all {len(queries)} queries across {len(paths)} dashboard"
+                + f"{plural} returned rows{note}"
+            )
             return 0
 
         if time.monotonic() >= deadline:
-            _report(failures, len(queries), timeout, attempts)
+            _report(failures, queries, timeout, attempts)
             return 1
 
         print(f"{len(failures)} not ready yet, retrying...", flush=True)


### PR DESCRIPTION
Closes #118.

`scripts/smoke_dashboard.py` named `lab-overview.json` directly and read `rawSql` from every target, so since #45 the Logs dashboard's LogQL has been checked for shape by `tests/test_dashboard.py` and for meaning nowhere. It now runs every dashboard in `grafana/dashboards/`.

## What changed

The query key is chosen by datasource type, from the same `{influxdb: rawSql, loki: expr}` table the test suite keeps, and a type neither knows is an error rather than a skip. Loki targets go through the same `/api/ds/query` endpoint as the SQL ones — the datasource-proxy route was the other option, but the query endpoint is the one a panel actually uses, and it keeps both backends on one code path. They carry `queryType` and a line limit where an InfluxDB target carries `format`.

Two smaller corrections fell out of it. `_row_count` now sums every frame instead of reading the first, because a Loki range query returns one frame per stream. And variable interpolation gained the query-variable case: `$container` is populated by the datasource, which this script does not ask, but a dashboard shipping with All selected interpolates `allValue`, which is what a browser sends on load. Custom variables keep enumerating their `query` — that is what makes `${room:singlequote}` reach `IN (...)`.

`--dashboard NAME` narrows the run to a subset, and an unknown name is an error rather than an empty pass.

## The assertion

The issue was right that this needed thought rather than copying, so I measured it rather than reasoning about it. Against the running stack, all three of these came back as an empty result with **no error at all**:

| Mutation | Result |
|---|---|
| `msg="wrote readings"` → `msg="wrote readingsXX"` | `ok frames=0 rows=0` |
| `unwrap skipped` → `unwrap skippedXX` | `ok frames=0 rows=0` |
| `{container=~".+"}` → `{containerXX=~".+"}` | `ok frames=1 rows=0` |

An error-only assertion would have passed every one, and those are exactly the failures a logfmt field rename or a change to Alloy's relabel rules produces. So the check counts rows, as it does for SQL.

Exempting nothing would have been flaky in both directions. `Warnings`, `Errors` and `Warnings and errors` filter on severity, and a run where nothing logged a warning is a good run. They would also pass for the wrong reason today: the one error a quiet stack produces is Loki's transient ring-initialisation failure at startup — the same one `smoke_logs.py` already exempts `loki` itself over — so a strict check there would really be asserting an upstream bug, and would start failing the day it is fixed.

Those three are named in `_MAY_BE_EMPTY` and nothing else is. A new panel is held to the row count until someone exempts it deliberately, which is the same default `_QUERY_FIELD` and `_EXPECTED_SILENT` already use: unknown fails, it does not skip. An exempt panel is still checked for errors — a syntax error in `Warnings` is caught, and I verified that.

## Ordering

The dashboard check now needs Loki, so the smoke workflow starts the `logs` profile ahead of it. Collection is asserted first, by `smoke_logs.py`, for a diagnostic reason: when Alloy is not shipping, every Loki panel is empty too, and the dedicated check names the container that is missing rather than the six panels that noticed. A SQL-side failure is still reported on its own, since `smoke_logs.py` passes in that case.

`docs/grafana.md`, `CONTRIBUTING.md` and the PR template say to bring the stack up with `COMPOSE_PROFILES=demo,logs`, and mention `--dashboard lab-overview` for a stack without Loki.

## Test plan

- [x] `python3 scripts/smoke_dashboard.py` against a live `demo,logs` stack — 20 queries across 2 dashboards returned rows, not counting 3 allowed to be empty
- [x] `--dashboard logs` — 6 of 6; `--dashboard nope` errors and names what the directory holds
- [x] each of the three mutations above reported, and a LogQL syntax error reported in both a strict panel and an exempt one
- [x] whole dashboard down (`docker compose stop loki`) reports every panel and prints the profile hint; a single broken panel does not print it
- [x] `uv run pytest --cov=src --cov-fail-under=100` — 979 passed, 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright`, `typos`
- [x] the smoke job on this PR

No CHANGELOG entry: nothing here is user-facing, and the file carries no CI entries.
