### PR TITLE
fix(compose): bind the server's Alloy UI to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,7 +234,18 @@ services:
     ports:
       # Alloy's own UI, showing each component's health and what it last
       # sent. The first place to look when logs are not arriving.
-      - "12345:12345"
+      #
+      # Loopback only. The UI has no authentication and describes the
+      # deployment — component configuration, endpoints, recently sent
+      # data — so it sits on the same side of the line as InfluxDB's and
+      # Grafana's ports above. Reach it over SSH with
+      # `ssh -L 12345:127.0.0.1:12345 <host>`.
+      #
+      # Written out rather than taking LABMON_BIND_ADDRESS: that variable
+      # exists so a server can publish InfluxDB and Grafana to clients,
+      # which is a normal thing to want, and it must not quietly hand out
+      # an unauthenticated diagnostic UI along with them.
+      - "127.0.0.1:12345:12345"
     volumes:
       - type: bind
         source: ./alloy/config.alloy

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -361,6 +361,18 @@ Alloy has a UI at [http://localhost:12345](http://localhost:12345) showing
 every component, its health, and what it last sent. Check there before
 suspecting Loki: a component in a failed state names its own problem.
 
+It is bound to loopback, since it has no authentication and lists
+component configuration, endpoints and recently sent data. Setting
+`LABMON_BIND_ADDRESS` does not publish it, so administering the server
+from a workstation means forwarding it:
+
+```bash
+ssh -L 12345:127.0.0.1:12345 <server-host>
+```
+
+That is the same instruction [`docs/client-setup.md`](client-setup.md)
+gives for a client's UI, which is bound the same way.
+
 Loki itself has no healthcheck in `docker-compose.yml`, unlike every other
 service. Its image is distroless — it contains exactly one binary and no
 shell, `wget` or `curl` for a check to use. Alloy retries a failed push, so


### PR DESCRIPTION
Closes #136.

The server's Alloy UI was published on every interface. It now binds loopback, the way the client's has since #63.

The UI has no authentication and describes the deployment — each component's configuration, its endpoints, and the data it last sent. Secrets are redacted; the rest is a fair map of the stack to anything that can reach the port. #109 settled where that belongs for the plaintext ports, and this one was left alone only to keep the client change narrow at the time.

It is written out as `127.0.0.1` rather than taking `LABMON_BIND_ADDRESS`. That variable exists so a server can publish InfluxDB and Grafana to the clients that write to them, which is a normal thing to want, and it must not hand out an unauthenticated diagnostic UI along with them. `docs/configuration.md` already scopes the variable to those two ports, so nothing there changes.

The cost is worth stating plainly: administering the server from a workstation now needs `ssh -L 12345:127.0.0.1:12345 <host>`. That is already the instruction `docs/client-setup.md` gives for a client's UI, so it is one habit rather than two behaviours to remember. `docs/logging.md` now says the same thing and points at that page.

Nothing pins the published ports in a test, so the next service added can repeat the mistake this closes. A structural check over `docker-compose.yml` — every plaintext published port binds loopback or `${LABMON_BIND_ADDRESS:-127.0.0.1}`, the `tls` profile's three excepted — would guard #109 and this together, and is not in scope here.

## Test plan

- [x] `docker compose config` resolves `host_ip: 127.0.0.1` for the port, identical to Grafana's
- [x] on a running `demo,logs` stack, `docker port alloy` reports `127.0.0.1:12345`
- [x] `ss -ltn` shows `LISTEN 127.0.0.1:12345`, not `0.0.0.0:12345`
- [x] the UI answers 200 on `http://127.0.0.1:12345/`
- [x] the host's LAN address refuses the connection
- [x] CI
