### PR TITLE
feat(cli): read .env, and install the CLI before the README uses it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Copy to .env and fill in real values (loaded automatically via direnv).
+# Copy to .env and fill in real values. Compose reads it, and so does a
+# `labmon` run from this directory. A shell does not: to use these
+# elsewhere, run `direnv allow` (an .envrc is committed here) or export
+# them with `set -a; . ./.env; set +a`.
 
 # Node identifier for the local InfluxDB 3 instance.
 INFLUXDB_NODE_ID=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ so the sections below map onto commit types.
 - The demo's beam channels wander rather than tracing a Lissajous
   figure.
   [#176](https://github.com/quentinmarolleau/labmon/pull/176)
+- Commands read `.env` from the directory they run in, so a token set
+  for Compose also reaches a `labmon` typed at a prompt. The process
+  environment still wins.
+  [#185](https://github.com/quentinmarolleau/labmon/issues/185)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -275,12 +275,23 @@ which level, and the setup.
 ## Getting the data out
 
 Dashboards are for watching. When it is time to look at numbers or plot
-a figure, two commands read the recorded readings:
+a figure, two commands read the recorded readings. They run on your
+machine rather than in a container, so install the CLI first:
+
+```bash
+uv tool install --editable '.[tui]'   # puts `labmon` on your PATH
+```
+
+Then:
 
 ```bash
 labmon query  --measurement temperature --since 5m        # print a table
 labmon export --measurement temperature --since 24h -o run # write a file
 ```
+
+Run them from the directory holding `.env` and they pick up the token and
+host from it. From anywhere else, set those in the environment yourself —
+[`docs/configuration.md`](docs/configuration.md) covers both.
 
 Both take the same selection flags — `--measurement`, `--sensor-id`,
 `--since`, `--until` — so learning one teaches the other.
@@ -311,7 +322,6 @@ Tab completion is a command away, and doubles as documentation —
 completing a flag shows its help text beside it:
 
 ```bash
-uv tool install --editable .   # puts `labmon` on your PATH
 labmon --install-completion
 ```
 
@@ -333,8 +343,9 @@ the terminal already open next to the experiment, and it is unavailable
 over a bare SSH session — which is exactly when *is the cryostat still
 cold?* is worth asking.
 
+The `[tui]` extra in the install above is what this needs:
+
 ```bash
-pip install 'labmon[tui]'
 labmon monitor
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,10 +12,28 @@ anyway.
 
 ## Environment variables
 
-Read from `.env` by Compose, or from the process environment for a bare
-install. `.env` is **not** read by your shell — a value set there reaches
-a container but not a `uv run labmon mock-sensor` you type yourself, unless
-something like direnv exports it.
+Read from the process environment, and from `.env` when a command runs in
+the directory holding that file. The process environment wins: a container,
+a systemd unit and a `VAR=x labmon …` prefix all keep the value they set.
+
+Only the working directory is read, never a parent, so a `.env` further up
+the tree belonging to something else cannot configure a sensor. When the
+file supplies a value the command says so, naming the file — worth reading
+if two checkouts sit side by side, since it is the line that distinguishes
+a run against the test stack from one against the real one.
+
+`.env` is **not** read by your shell. That matters wherever a command runs
+somewhere else: a sensor under systemd on a client machine gets its
+settings from the unit, not from a file in a checkout. To use `.env` from
+another directory, either export it —
+
+```bash
+set -a; . ./.env; set +a
+```
+
+— or install [direnv](https://direnv.net/), which does it on `cd`. An
+`.envrc` containing `dotenv` is committed, so `direnv allow` is the whole
+setup.
 
 ### Connection settings
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -517,5 +517,5 @@ attaches completions to a command word, and `uv run labmon …` is the
 command `uv`. Installing it as a tool puts it on the PATH:
 
 ```bash
-uv tool install --editable .
+uv tool install --editable '.[tui]'
 ```

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -130,7 +130,8 @@ data. Left unset (the default), no `unit` tag is written at all.
 
 ## Configuration
 
-Read from the environment (see `.env`, loaded automatically via direnv):
+Read from the environment, and from `.env` when the command runs in the
+directory holding it (see [`docs/configuration.md`](configuration.md)):
 
 | Variable               | Default                 | Purpose                          |
 |-------------------------|--------------------------|-----------------------------------|

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -115,11 +115,14 @@ everywhere.
 Needs the `tui` extra, which brings in Textual:
 
 ```bash
-pip install 'labmon[tui]'
+uv tool install --editable '.[tui]'
 ```
 
-Running it without that gives the install command rather than an import
-traceback.
+`pip install 'labmon[tui]'` works for an ordinary virtualenv, but not for
+a checkout installed as a uv tool — that installs into the environment
+`pip` happens to belong to, leaving the `labmon` on your PATH unchanged.
+Running the command without Textual names the interpreter it looked in
+and the install line for it, rather than an import traceback.
 
 ## Why not just leave Grafana open
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "influxdb3-python>=0.20.0",
     "pint>=0.25.3",
     "pyserial>=3.5",
+    "python-dotenv>=1.2.3",
     "typer>=0.27.1",
 ]
 

--- a/src/labmon/cli/runtime.py
+++ b/src/labmon/cli/runtime.py
@@ -9,8 +9,9 @@ the app in it. Each command calls `configure()` first so its own
 import functools
 import logging
 from collections.abc import Callable
+from pathlib import Path
 
-from labmon import logs
+from labmon import env, logs
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -22,14 +23,47 @@ UNREACHABLE = 3
 
 
 def configure(level: object) -> None:
-    """Apply a command's --log-level. Accepts the enum or its value."""
+    """Apply a command's --log-level, then read `./.env`.
+
+    In that order, and as a command's first act. The level has to be in
+    force before the line naming the file is emitted, and the file has
+    to be read before any setting is looked up — every command calls
+    this before it touches the environment, which is what makes one call
+    site enough. Tab completion never reaches a command body, so it
+    never pays for the read.
+
+    Accepts the enum or its value.
+    """
     name = getattr(level, "value", level)
     logs.configure(logs.level_from_name(str(name)))
+    _ = env.load()
 
 
 def _first_line(message: str) -> str:
     """The first sentence of a client error, without the gRPC dump."""
     return message.split(". gRPC")[0].strip()
+
+
+def _no_token_reason() -> str:
+    """Why the token is missing, in terms of what the reader can see.
+
+    Naming the variable and pointing at the manual is what this said
+    before, and it sent somebody who had set that variable — in `.env`,
+    where the containers were visibly reading it — round three wrong
+    turns. The useful fact is which file was in play, so the message
+    distinguishes the two cases rather than describing the mechanism.
+    """
+    if (Path.cwd() / env.ENV_FILE).is_file():
+        return (
+            f"INFLUXDB3_AUTH_TOKEN is not set, and the {env.ENV_FILE} in this"
+            + " directory does not define it either"
+        )
+    return (
+        f"INFLUXDB3_AUTH_TOKEN is not set, and there is no {env.ENV_FILE} in"
+        + f" this directory. {env.ENV_FILE} is read by Docker Compose rather"
+        + " than by your shell, so run labmon where that file is, or export"
+        + " it first with: set -a; . ./.env; set +a"
+    )
 
 
 def reporting[**P](command: Callable[P, None]) -> Callable[P, None]:
@@ -87,12 +121,6 @@ def _report(action: Callable[[], None]) -> None:
         # get_client() raises this when INFLUXDB3_AUTH_TOKEN is unset,
         # which as a bare traceback names the variable and nothing else.
         if error.args and error.args[0] == "INFLUXDB3_AUTH_TOKEN":
-            logger.error(
-                "no auth token",
-                extra={
-                    "reason": "INFLUXDB3_AUTH_TOKEN is not set;"
-                    + " see docs/configuration.md"
-                },
-            )
+            logger.error("no auth token", extra={"reason": _no_token_reason()})
             raise SystemExit(UNREACHABLE) from None
         raise

--- a/src/labmon/env.py
+++ b/src/labmon/env.py
@@ -1,0 +1,78 @@
+"""Read `.env` for a command typed at a prompt.
+
+`.env` is read by Docker Compose, not by the shell. A token set there
+reaches every container and no `labmon` anyone types, which is a
+surprise nobody has to make twice: the file is right there, the
+containers are visibly using it, and the command says the variable is
+unset.
+
+The repository ships an `.envrc` containing `dotenv`, so a machine with
+direnv has never had the problem — which is exactly why it survived this
+long. direnv is one more thing to install, and a monitoring tool should
+not need it to read its own configuration.
+
+Only entry points call this. A library that rewrote its importer's
+environment would be a nasty thing to depend on.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# The name Compose looks for, so both read the same file. Spelled once
+# here because the "no auth token" message names it too.
+ENV_FILE = ".env"
+
+
+def load(directory: Path | None = None) -> Path | None:
+    """Fill in settings from `./.env`, returning the file it read.
+
+    The process environment wins over the file. A container, a systemd
+    unit and a `VAR=x labmon …` prefix all set their variables
+    deliberately, and none of them should start behaving differently
+    because a file happens to sit in the working directory — so `.env`
+    stays a convenience, not a second source of truth.
+
+    Only the working directory is searched. Walking up would let a
+    `.env` three levels above, belonging to something else entirely,
+    configure a sensor; that surprise is worth more than the
+    convenience.
+
+    Parsing is `python-dotenv`'s rather than ours, because Compose reads
+    this same file and the two have to agree on quoting. A deployment's
+    `LABMON_LOKI_PUSH_HASH` is a bcrypt hash in single quotes, full of
+    `$`, and a hand-rolled reader that expanded those would hand back a
+    credential that silently does not match.
+    """
+    path = (directory or Path.cwd()) / ENV_FILE
+    if not path.is_file():
+        return None
+
+    # `None` is what dotenv reports for a bare `KEY` line with no `=`.
+    # Setting it would put an empty string in the environment, which
+    # `influx._setting` treats as unset anyway, so the only thing it
+    # could achieve is masking a value inherited from the parent.
+    applied = {
+        name: value
+        for name, value in dotenv_values(path).items()
+        if value is not None and name not in os.environ
+    }
+    os.environ.update(applied)
+
+    # Announced when it changed something, and only then. That is
+    # exactly when the quiet failure is possible — two checkouts side by
+    # side, a command run in the wrong one, readings written to the
+    # wrong database with nothing on screen to say which file decided
+    # that. A file that supplied nothing decided nothing, and saying so
+    # on every command would be noise for anyone whose shell already
+    # exports these, which is everyone using the `.envrc` beside it.
+    logger.log(
+        logging.INFO if applied else logging.DEBUG,
+        "read environment file",
+        extra={"path": str(path), "applied": len(applied)},
+    )
+    return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,23 @@ def _isolated_config(  # pyright: ignore[reportUnusedFunction]
     passing run on one machine says nothing about another.
     """
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+
+@pytest.fixture(autouse=True)
+def _isolated_working_directory(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run each test somewhere that is not the repository.
+
+    Every command reads `./.env` now, and the repository root has a real
+    one on any machine the stack has been started on. Without this the
+    suite would load a developer's own token and host into `os.environ`
+    and pass or fail accordingly — the sharpest form of the problem this
+    file exists to prevent, since it would also differ between a
+    contributor's checkout and CI.
+
+    It doubles as protection for the other direction: a command that
+    writes a file relative to the working directory now writes it into
+    the test's own directory rather than into the tree.
+    """
+    monkeypatch.chdir(tmp_path)

--- a/tests/test_cli_query.py
+++ b/tests/test_cli_query.py
@@ -334,6 +334,51 @@ def test_a_missing_token_says_which_variable(
     assert "Traceback" not in written
 
 
+def test_a_missing_token_with_no_env_file_explains_where_it_is_read(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Naming the variable is not enough on its own.
+
+    Somebody who set it in `.env`, and can see the containers using it,
+    needs to be told that a shell does not read that file — otherwise
+    the message describes a state they can prove is false.
+    """
+    from labmon.cli import main as cli_main
+
+    monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("sys.argv", ["labmon", "query"])
+
+    with pytest.raises(SystemExit):
+        cli_main.main()
+
+    written = capsys.readouterr().err
+    assert "Docker Compose" in written
+    assert "set -a" in written
+
+
+def test_a_missing_token_beside_an_env_file_says_that_file_lacks_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The other case, and a different problem.
+
+    The file was found and read; it simply has no token in it. Repeating
+    the advice about shells there would send the reader to look for a
+    fault that is not the one they have.
+    """
+    from labmon.cli import main as cli_main
+
+    _ = (tmp_path / ".env").write_text("INFLUXDB_DATABASE=lab\n")
+    monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("sys.argv", ["labmon", "query"])
+
+    with pytest.raises(SystemExit):
+        cli_main.main()
+
+    written = capsys.readouterr().err
+    assert "does not define it" in written
+    assert "set -a" not in written
+
+
 def test_an_unrelated_key_error_is_not_swallowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,166 @@
+"""Reading `.env` for a command typed at a prompt.
+
+Compose reads `.env`; a shell does not. Everything here is about that
+gap, and about the two ways closing it could go wrong: overriding a
+variable somebody set deliberately, and reading a file they did not mean
+to point at.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from labmon import env
+
+# Two fake tokens rather than one, so an assertion says which source won
+# rather than only that something was set. Named constants rather than
+# literals at the comparison, which ruff's S105 reads as a hardcoded
+# credential — rightly, since it cannot tell these from a real one.
+_IN_THE_FILE = "apiv3_from_the_file"
+_IN_THE_SHELL = "apiv3_from_the_shell"
+
+
+def test_no_file_means_nothing_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory with no `.env` is the normal case, not an error."""
+    monkeypatch.chdir(tmp_path)
+    before = dict(os.environ)
+
+    assert env.load() is None
+    assert dict(os.environ) == before
+
+
+def test_a_setting_only_in_the_file_reaches_the_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+    _ = (tmp_path / ".env").write_text(f"INFLUXDB3_AUTH_TOKEN={_IN_THE_FILE}\n")
+
+    assert env.load() == tmp_path / ".env"
+    assert os.environ["INFLUXDB3_AUTH_TOKEN"] == _IN_THE_FILE
+
+
+def test_the_environment_wins_over_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A container, a systemd unit and a `VAR=x labmon …` prefix all set
+    the variable themselves, and none of them should change behaviour
+    because a file happens to sit in the working directory."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", _IN_THE_SHELL)
+    _ = (tmp_path / ".env").write_text(f"INFLUXDB3_AUTH_TOKEN={_IN_THE_FILE}\n")
+
+    _ = env.load()
+
+    assert os.environ["INFLUXDB3_AUTH_TOKEN"] == _IN_THE_SHELL
+
+
+def test_a_key_with_no_value_is_not_applied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`dotenv` reports a bare `KEY` line as None.
+
+    Setting it would put an empty string in the environment, and
+    `_setting()` treats empty as unset anyway — so the only thing it
+    could achieve is masking a value inherited from the parent process.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INFLUXDB_DATABASE", "inherited")
+    _ = (tmp_path / ".env").write_text("BARE_KEY\n")
+
+    _ = env.load()
+
+    assert "BARE_KEY" not in os.environ
+    assert os.environ["INFLUXDB_DATABASE"] == "inherited"
+
+
+def test_the_file_it_read_is_logged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The whole point of announcing it.
+
+    Two checkouts side by side, a command run in the wrong one, and
+    readings written to the wrong database — silently, unless the file
+    that configured the run is named.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("INFLUXDB_HOST", raising=False)
+    _ = (tmp_path / ".env").write_text("INFLUXDB_HOST=http://elsewhere:8181\n")
+
+    with caplog.at_level(logging.INFO, logger="labmon.env"):
+        _ = env.load()
+
+    # The path rides in `extra`, which reaches the line through
+    # LogfmtFormatter rather than through the record's message — so the
+    # attribute is what the assertion can see here.
+    (record,) = caplog.records
+    assert record.getMessage() == "read environment file"
+    assert getattr(record, "path", None) == str(tmp_path / ".env")
+
+
+def test_a_file_that_changed_nothing_is_not_announced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Every variable already set means the file decided nothing.
+
+    Which is the normal case for anyone using the `.envrc` beside it, so
+    an INFO line there would be noise on every command they run. It
+    stays at DEBUG rather than disappearing, because "which file did it
+    look at" is still a question worth being able to answer.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("INFLUXDB_HOST", "http://from-the-shell:8181")
+    _ = (tmp_path / ".env").write_text("INFLUXDB_HOST=http://elsewhere:8181\n")
+
+    with caplog.at_level(logging.INFO, logger="labmon.env"):
+        _ = env.load()
+    assert caplog.records == []
+
+    with caplog.at_level(logging.DEBUG, logger="labmon.env"):
+        _ = env.load()
+    assert len(caplog.records) == 1
+
+
+def test_nothing_is_logged_when_there_is_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Most invocations are somewhere without one, and say nothing."""
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.INFO, logger="labmon.env"):
+        _ = env.load()
+
+    assert caplog.text == ""
+
+
+def test_only_the_working_directory_is_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No walking upwards.
+
+    A `.env` three levels up belongs to something else, and letting it
+    configure a sensor is a worse surprise than the convenience is
+    worth.
+    """
+    _ = (tmp_path / ".env").write_text(f"INFLUXDB3_AUTH_TOKEN={_IN_THE_FILE}\n")
+    below = tmp_path / "checkout"
+    below.mkdir()
+    monkeypatch.chdir(below)
+    monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+
+    assert env.load() is None
+    assert "INFLUXDB3_AUTH_TOKEN" not in os.environ
+
+
+def test_a_directory_named_env_is_not_a_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Docker creates one of these when a bind mount source is missing."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").mkdir()
+
+    assert env.load() is None

--- a/uv.lock
+++ b/uv.lock
@@ -277,6 +277,7 @@ dependencies = [
     { name = "influxdb3-python" },
     { name = "pint" },
     { name = "pyserial" },
+    { name = "python-dotenv" },
     { name = "typer" },
 ]
 
@@ -320,6 +321,7 @@ requires-dist = [
     { name = "influxdb3-python", specifier = ">=0.20.0" },
     { name = "pint", specifier = ">=0.25.3" },
     { name = "pyserial", specifier = ">=3.5" },
+    { name = "python-dotenv", specifier = ">=1.2.3" },
     { name = "scipy", marker = "extra == 'spline'", specifier = ">=1.18.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.2.8" },
     { name = "typer", specifier = ">=0.27.1" },
@@ -752,6 +754,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #185, closes #187.

## `.env` is read by Compose, not by your shell (#185)

They set `INFLUXDB3_AUTH_TOKEN` in `.env`, watched the containers use it, and were then told by `labmon query` that the variable was unset — a message describing a state they could prove was false. `uv run`, then activating the venv, then a shell prefix, before working it out.

It survived this long because the repository ships an `.envrc` containing `dotenv`, so any machine with direnv has never had the problem. That is every machine this was developed on.

Every command now reads `./.env` before it looks anything up, with three properties worth stating:

- **The process environment wins.** A container, a systemd unit and a `VAR=x labmon …` prefix keep the value they set, so `.env` is a convenience rather than a second source of truth.
- **Only the working directory**, never a parent. A `.env` three levels up belongs to something else, and letting it configure a sensor is a worse surprise than the convenience is worth.
- **The file is named when it supplied something**, at INFO; at DEBUG when it did not. Announcing unconditionally would print a line on every command for everyone whose shell already exports these — which is what the `.envrc` arranges. Announcing when it *did* matters, because two checkouts side by side and a command run in the wrong one is otherwise a silent write to the wrong database.

Parsing is python-dotenv's rather than ours, since Compose reads the same file and the two have to agree on quoting. A deployment's `LABMON_LOKI_PUSH_HASH` is a bcrypt hash in single quotes full of `$`; a hand-rolled reader that expanded those would hand back a credential that silently does not match. Checked against a sample carrying that hash, an `export ` prefix and a `#` inside a quoted value.
Reading the file on every command costs about 7 ms, paid once per process rather than once per reading:

| | |
|---|---|
| `dotenv` import, marginal | ~5 ms |
| Parsing this repository's `.env` (9 assignments) | ~1.4 ms |
| No `.env` present — one `stat` | ~20 µs |
| `labmon --help`, end to end | 313 ms |

Best-of-N on a Ryzen 3 5300U under Python 3.14. Timing `import dotenv` on its own gives ~70 ms, which is misleading: `-X importtime` puts 48 ms of that in `logging` and 13 ms in `tempfile`, both of which labmon imports anyway, and stubbing dotenv out of `labmon.cli.main` moves it only from 155 ms to 150 ms. Parsing is linear in assignments at ~150 µs each, so the cost only becomes interesting past ~100 of them.

The `no auth token` message now says what is actually wrong:

```
# no .env in this directory
reason="INFLUXDB3_AUTH_TOKEN is not set, and there is no .env in this directory. .env is read by Docker Compose rather than by your shell, so run labmon where that file is, or export it first with: set -a; . ./.env; set +a"

# a .env that does not define it
reason="INFLUXDB3_AUTH_TOKEN is not set, and the .env in this directory does not define it either"
```

The suite now runs each test in its own directory. Without that it would read the developer's own `.env` and pass or fail according to whose machine it ran on — the sharpest form of the problem `conftest.py` exists to prevent.

## The README used `labmon` before installing it (#187)

`uv tool install --editable '.[tui]'` now opens **Getting the data out**, and the duplicate under *Tab completion* is gone. `pip install 'labmon[tui]'` is replaced in the README and `docs/monitor.md`: it is the wrong environment for a uv-tool install, and the obvious correction — `uv pip install` — is wrong a second way, installing into the project venv while the `labmon` on the PATH stays as it was. Installing the extra once, up front, removes both. `docs/export.md` gained the extra to match.

## Test plan

- [x] `uv run pytest --cov=src --cov-fail-under=100` — 990 passed, 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright`, `typos`
- [x] by hand against the running stack, in a scratch directory: no `.env` gives the Compose explanation; a `.env` without a token gives the other message; a `.env` with one runs the query and logs `applied=1` with the file's path
- [x] a `.env` in the parent is not read; a directory named `.env` is not read; a variable already exported is not overwritten
- [x] startup cost measured, as above
- [x] CI

One note for review: `S105` fires on a fake token compared as a literal in the new tests, so the two values are named constants instead. Adding `S105` to the tests' per-file ignores would have silenced a rule worth keeping — it cannot tell a fixture from a real token, which is the point of it.


