### PR TITLE
Close the CI gaps in #85: concurrency, the two unchecked files, and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ on:
   push:
     branches: [main]
 
+# Superseded runs are work nobody will read: pushing three times to a PR
+# leaves the first two grinding on, and `smoke` has a 20-minute budget to
+# grind through. Cancelling on the same ref reclaims that.
+#
+# Only for `pull_request`, though. A push to `main` is what the branch's
+# status badge reflects and what a bisect later reads back, so those runs
+# finish even when the next push has already landed on top of them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Every job here only reads the repository; Codecov uploads with its own
 # token rather than GITHUB_TOKEN. Setting this at the top means a job added
 # later starts read-only unless it says otherwise.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           version: "0.12.5"
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - run: uv run --locked pytest --cov=src --cov-report=xml --cov-fail-under=100
+      - run: uv run --locked pytest --cov --cov-report=xml --cov-fail-under=100
       - if: matrix.python-version == '3.14'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,23 @@ jobs:
             hadolint/hadolint@sha256:a1d49ae1a4e83c1dbad26b8c1ad7588c8bd1e04f4866b34ad3cac50335198552 \
             hadolint Dockerfile templates/custom-sensor/Dockerfile
 
+  # Pinned by digest, and run without uv, for the reasons given on the
+  # job above.
+  workflows:
+    name: workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # A mistake in a workflow otherwise surfaces when the workflow runs,
+      # which for anything behind a `push: branches: [main]` filter can
+      # mean after merge. actionlint checks the expressions statically and
+      # runs shellcheck over every `run:` block, which is where most of
+      # smoke.yml lives.
+      - run: |
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -color
+
   test:
     name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,28 @@ jobs:
           enable-cache: true
       - run: uv run --locked typos
 
+  # No uv here: this lints a Dockerfile, not Python, and pulling a small
+  # image beats provisioning an interpreter to do it. The image is pinned
+  # by digest for the same reason the actions above are — a tag on Docker
+  # Hub is mutable, and this runs arbitrary code on a runner holding a
+  # checkout of this repository.
+  dockerfiles:
+    name: dockerfiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # templates/custom-sensor/Dockerfile matters more than the root one:
+      # it exists to be copied into somebody else's project, so a bad
+      # instruction in it is a bad instruction reproduced by every user who
+      # follows docs/custom-sensor.md.
+      #
+      # .hadolint.yaml in the working directory is read automatically; it
+      # carries the one rule this repository turns off, with the reason.
+      - run: |
+          docker run --rm -v "$PWD:/repo" -w /repo \
+            hadolint/hadolint@sha256:a1d49ae1a4e83c1dbad26b8c1ad7588c8bd1e04f4866b34ad3cac50335198552 \
+            hadolint Dockerfile templates/custom-sensor/Dockerfile
+
   test:
     name: test (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,6 +13,17 @@ on:
   push:
     branches: [main]
 
+# Superseded runs are work nobody will read: pushing three times to a PR
+# leaves the first two grinding on, and `smoke` has a 20-minute budget to
+# grind through. Cancelling on the same ref reclaims that.
+#
+# Only for `pull_request`, though. A push to `main` is what the branch's
+# status badge reflects and what a bisect later reads back, so those runs
+# finish even when the next push has already landed on top of them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,6 +36,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # First, because it costs 0.4s and the rest of this job costs
+      # minutes. The pre-commit hook of the same name runs the same script
+      # locally, but skips itself when the Docker daemon is down and is
+      # skipped wholesale by `--no-verify` or by never having run
+      # `pre-commit install` — so until now its claim to be backed by CI
+      # was not true of any workflow.
+      #
+      # docker-compose.client.yml is the file that needs this. The server
+      # file is parsed as a side effect of `up` a few steps down; the
+      # client file is started by nothing here, so an error in it would
+      # ship and surface on somebody's sensor machine.
+      - name: Both compose files parse
+        run: ./scripts/hooks/compose-config.sh
+
       # Deliberately the README's quickstart, command for command. A fresh
       # runner is the closest thing CI has to somebody cloning the repo, and
       # the bugs this job exists to catch only happen on the first run.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,9 +58,45 @@ jobs:
           cp .env.example .env
           sed -i 's/^INFLUXDB_NODE_ID=.*/INFLUXDB_NODE_ID=ci/' .env
 
-      - name: Start InfluxDB and mint an admin token
+      # The shape docs/deployment.md recommends for a real server is
+      # COMPOSE_PROFILES left unset. Every other start in this job carries
+      # `demo`, which left the recommended configuration as the one shape
+      # nobody ever started.
+      #
+      # An empty COMPOSE_PROFILES overrides the `demo` that .env.example
+      # sets rather than falling back to it, so this needs no second .env.
+      # The environment wins over the file even when what it says is
+      # nothing, which is the whole trick.
+      #
+      # It replaces the bare `up --wait influxdb` that used to open this
+      # step rather than adding a start, so it costs one extra container:
+      # InfluxDB has to be up before a token can be minted anyway, and the
+      # demo sensors join this same stack further down.
+      #
+      # Grafana therefore starts before the token exists, holding an empty
+      # INFLUXDB3_AUTH_TOKEN. The `up` that follows the minting step
+      # recreates it, because compose hashes a service's environment into
+      # the container config and a changed value is a changed service.
+      # Were that not so, every dashboard check below would query through
+      # a Grafana whose datasource had no credential.
+      - name: The server shape starts InfluxDB and Grafana, and nothing else
         run: |
-          docker compose up -d --wait influxdb
+          # Quoted empty rather than bare `COMPOSE_PROFILES=`, which
+          # SC1007 reads as a value accidentally left off.
+          COMPOSE_PROFILES='' docker compose up -d --wait
+          # Asked with every profile enabled, so a service that should
+          # have stayed down shows up here rather than being filtered out
+          # of the answer that was meant to catch it.
+          running="$(COMPOSE_PROFILES=demo,logs,tls docker compose ps \
+            --status running --format '{{.Service}}' | sort | xargs)"
+          echo "running: $running"
+          if [ "$running" != "grafana influxdb" ]; then
+            echo "wanted exactly grafana and influxdb, got: $running" >&2
+            exit 1
+          fi
+
+      - name: Mint an admin token
+        run: |
           token="$(docker compose exec -T influxdb influxdb3 create token --admin \
             | grep -oE 'apiv3_[A-Za-z0-9_-]+' | head -1)"
           if [ -z "$token" ]; then

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,12 @@
+# hadolint's defaults, minus one rule.
+#
+# DL3066 objects to `USER labmon` on the grounds that a name may not
+# resolve outside the container. It is aimed at images that adopt a name
+# from the base image without knowing its number; both Dockerfiles here
+# create the account themselves, three lines above the USER, pinned to
+# uid/gid 10001. Nothing is left to resolve, and `USER 10001` would cost
+# the reader the one word that says who this is.
+#
+# The threshold stays at hadolint's default, so a warning fails the job.
+ignored:
+  - DL3066

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
 
       - id: pytest
         name: pytest
-        entry: uv run --locked pytest --cov=src --cov-fail-under=100
+        entry: uv run --locked pytest --cov --cov-fail-under=100
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
 [dependency-groups]
 dev = [
     "basedpyright>=1.39.10",
+    # A CA bundle at a known path, for the two tests that check `--cacert`
+    # is actually loaded. Already present through influxdb3-python; named
+    # here because a test depends on it, and because
+    # `ssl.get_default_verify_paths()` answers None on a CI runner while
+    # typeshed declares it a str.
+    "certifi>=2026.7.22",
     "h5netcdf>=1.8.1",
     "h5py>=3.16.0",
     "pandas>=3.0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,17 @@ stubPath = "typings"
 testpaths = ["tests"]
 
 [tool.coverage.run]
-source = ["src"]
+# Everything that ships, not just the package. `demo/`, `scripts/` and
+# `templates/` are three trees a user meets early — the demo stack
+# acquires from one, CI's own gates are two files in another, and the
+# third exists to be copied into somebody else's project — and none of
+# them was measured. That is the same blind spot #82 closed for
+# basedpyright, in the test dimension.
+#
+# Spelled here rather than as `--cov=` flags so the pre-commit hook, the
+# CI job and a bare `pytest --cov` all measure the same four trees, and
+# adding a fifth is one edit rather than three.
+source = ["src", "demo", "scripts", "templates"]
 
 [tool.typos.default.extend-identifiers]
 # Misspelled in the D3 Gauge panel plugin's own options schema, so the

--- a/templates/custom-sensor/Dockerfile
+++ b/templates/custom-sensor/Dockerfile
@@ -20,6 +20,11 @@
 #
 # The `.` is the build context — the directory COPY can reach. A wheel
 # from your vendor has to sit next to this file; COPY cannot climb out.
+
+# `latest` on purpose, and the one place in this repo where it is right:
+# this is not a tag on a registry but the image `docker compose build`
+# leaves on your own machine, so there is no version here to pin to.
+# hadolint ignore=DL3007
 FROM labmon:latest
 
 # The base image ends as the unprivileged `labmon` user, so anything that

--- a/tests/loader.py
+++ b/tests/loader.py
@@ -1,0 +1,202 @@
+"""Import the files that ship to be executed, with a declared surface.
+
+`demo/`, `scripts/` and `templates/` hold code that is measured like any
+other and that no `import` statement can reach: nothing there is inside a
+package, and one directory has a hyphen in its name. Both halves of that
+are a path problem, so both are solved with a path.
+
+Loading by path costs the type checker everything it knows, and an
+untyped module leaks `Any` through every assertion that touches it. The
+protocols below are the fix, and they earn their length twice: the tests
+stay fully checked, and each one is a written-down statement of the
+surface a shipped script is expected to have, so renaming a function out
+from under its tests fails the type check rather than the run.
+
+Not named `test_*`, so pytest does not collect it.
+"""
+
+import importlib.util
+import logging
+import runpy
+import ssl
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, cast
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def path_to(relative: str) -> Path:
+    """One shipped script, by its path from the repository root."""
+    return _ROOT / relative
+
+
+def _load(relative: str) -> object:
+    """The script at `relative`, imported under a name of its own.
+
+    Cached the way `import` caches, so a module holding state built at
+    import time — `demo/adc_feeder.py` builds its channel list once —
+    behaves across tests the way it behaves in the process that runs it.
+
+    Returned as `object` rather than `ModuleType` so each accessor below
+    can name the surface it expects. A module and a protocol do not
+    overlap as far as the checker is concerned, and widening here is what
+    makes those casts a claim about the script rather than a mistake.
+    """
+    path = path_to(relative)
+    name = f"_shipped_{path.stem}"
+    cached = sys.modules.get(name)
+    if cached is not None:
+        return cached
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - unreachable
+        raise ImportError(f"no import machinery for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_as_main(relative: str) -> dict[str, object]:
+    """Execute the script the way the shell does, guard block included.
+
+    `if __name__ == "__main__":` is not boilerplate in these files: it is
+    where the sensor templates choose their identifiers and where the
+    feeder installs the log format the demo is read through. Running it
+    is the only way to check it, and the only way it is measured.
+
+    Every dependency it reaches for has to be replaced first — each of
+    these blocks otherwise opens a socket or writes to InfluxDB.
+    """
+    return cast(
+        dict[str, object], runpy.run_path(str(path_to(relative)), run_name="__main__")
+    )
+
+
+# --------------------------------------------------------------------------
+# templates/custom-sensor/
+# --------------------------------------------------------------------------
+
+SENSOR_CONTINUOUS = "templates/custom-sensor/sensor_continuous.py"
+SENSOR_TRIGGERED = "templates/custom-sensor/sensor_triggered.py"
+
+
+class SensorTemplate(Protocol):
+    """What both copy-me templates expose before anyone edits them."""
+
+    read_value: Callable[[], float | None]
+
+
+def sensor_template(relative: str) -> SensorTemplate:
+    return cast(SensorTemplate, _load(relative))
+
+
+# --------------------------------------------------------------------------
+# demo/adc_feeder.py
+# --------------------------------------------------------------------------
+
+ADC_FEEDER = "demo/adc_feeder.py"
+
+
+class Signal(Protocol):
+    """One analog input, as the feeder's own `Signal` protocol has it."""
+
+    name: str
+
+    def volts_at(self, elapsed: float, /) -> float: ...
+
+
+class Periodic(Signal, Protocol):
+    """A `Channel`: slow drift plus noise, staggered by a random phase."""
+
+    _phase: float
+
+
+class Walk(Signal, Protocol):
+    """A `Wander`: a mean-reverting random walk holding its own position."""
+
+    _volts: float
+
+
+class AdcFeeder(Protocol):
+    """The demo's stand-in for an ADC board."""
+
+    VREF: float
+    FULL_SCALE: int
+    SAMPLE_INTERVAL_SECONDS: float
+    CHANNELS: tuple[Signal, ...]
+
+    _counts: Callable[[float], float]
+    Channel: Callable[..., Periodic]
+    Wander: Callable[..., Walk]
+    serve: Callable[..., None]
+    _UtcMilliseconds: Callable[[], logging.Formatter]
+
+
+def adc_feeder() -> AdcFeeder:
+    return cast(AdcFeeder, _load(ADC_FEEDER))
+
+
+# --------------------------------------------------------------------------
+# scripts/
+# --------------------------------------------------------------------------
+
+SMOKE_LOGS = "scripts/smoke_logs.py"
+SMOKE_DASHBOARD = "scripts/smoke_dashboard.py"
+
+
+class SmokeLogs(Protocol):
+    """The check that Loki has a line from every running container."""
+
+    _Rejected: type[Exception]
+    _running_containers: Callable[[], set[str]]
+    _tls_context: Callable[[str | None], ssl.SSLContext | None]
+    _collected_containers: Callable[[str, str, ssl.SSLContext | None], set[str]]
+    main: Callable[[], int]
+
+
+def smoke_logs() -> SmokeLogs:
+    return cast(SmokeLogs, _load(SMOKE_LOGS))
+
+
+class Query(Protocol):
+    """One panel target, ready to send and to report on."""
+
+    label: str
+    payload: dict[str, object]
+    may_be_empty: bool
+
+
+class SmokeDashboard(Protocol):
+    """The check that every dashboard panel still returns rows."""
+
+    _Rejected: type[Exception]
+    _Query: Callable[..., Query]
+    _LOG_LINE_LIMIT: int
+    _DASHBOARD_DIR: Path
+
+    _mapping: Callable[[object], dict[str, object]]
+    _mappings: Callable[[object], list[dict[str, object]]]
+    _values_of: Callable[[dict[str, object]], list[str]]
+    _interpolate: Callable[[str, dict[str, list[str]]], str]
+    _child: Callable[[object, str], object]
+    _first: Callable[[object], object]
+    _row_count: Callable[[object], int]
+    _payload: Callable[
+        [str, dict[str, object], dict[str, list[str]]], dict[str, object]
+    ]
+    _load_queries: Callable[[Path, dict[str, object]], list[Query]]
+    _selected: Callable[[list[str] | None], list[Path]]
+    _tls_context: Callable[[str | None], ssl.SSLContext | None]
+    _post: Callable[
+        [dict[str, object], str, str, ssl.SSLContext | None], dict[str, object]
+    ]
+    _attempt: Callable[..., list[tuple[str, str]]]
+    _report: Callable[[list[tuple[str, str]], list[Query], float, int], None]
+    main: Callable[[], int]
+
+
+def smoke_dashboard() -> SmokeDashboard:
+    return cast(SmokeDashboard, _load(SMOKE_DASHBOARD))

--- a/tests/test_adc_feeder.py
+++ b/tests/test_adc_feeder.py
@@ -1,0 +1,356 @@
+"""The demo's stand-in for an ADC board.
+
+`demo/adc_feeder.py` is not part of the package and never runs in a real
+lab, but it is what the demo stack acquires from: every reading anyone
+sees on a first run of the quickstart came out of this file, through the
+same parsing and calibration path a real board's would. A channel that
+stops matching `demo/calibration.demo.toml`, or a voltage that leaves
+the board's range, is a demo that shows wrong physics convincingly.
+"""
+
+import logging
+import math
+import socket
+import threading
+import time
+import tomllib
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+
+from tests.loader import ADC_FEEDER, adc_feeder, path_to, run_as_main
+
+_CALIBRATION = "demo/calibration.demo.toml"
+
+feeder = adc_feeder()
+
+# Bound once rather than suppressed at each of the five call sites, the
+# way tests/test_influx.py takes `_setting`.
+_counts = feeder._counts  # pyright: ignore[reportPrivateUsage]
+_UtcMilliseconds = feeder._UtcMilliseconds  # pyright: ignore[reportPrivateUsage]
+
+
+def _free_port() -> int:
+    """A port the kernel has just confirmed is free.
+
+    Racy in principle and not in practice: nothing else on the machine is
+    handing out ports in the microseconds between the close and the bind,
+    and the alternative — a fixed port — collides with a developer who
+    happens to have the demo stack up.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return cast(tuple[str, int], probe.getsockname())[1]
+
+
+@pytest.fixture
+def _restored_level_names() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Undo the feeder's global rename of every logging level.
+
+    `addLevelName` is process-wide and permanent, so without this the
+    first test to run the main block leaves every later assertion on a
+    level name reading `warning` where the stdlib says `WARNING`.
+    """
+    names = {value: logging.getLevelName(value) for value in (10, 20, 30, 40)}
+    yield
+    for value, name in names.items():
+        logging.addLevelName(value, name)
+
+
+class TestCounts:
+    """Volts in, the count the board would report out."""
+
+    def test_zero_volts_is_zero_counts(self) -> None:
+        assert _counts(0.0) == 0.0
+
+    def test_full_scale_is_the_top_code(self) -> None:
+        """3.3 V reads 4095, the largest value 12 bits can hold."""
+        assert _counts(feeder.VREF) == float(feeder.FULL_SCALE)
+        assert feeder.FULL_SCALE == 4095
+
+    def test_midscale_is_half_the_range(self) -> None:
+        assert _counts(feeder.VREF / 2) == pytest.approx(2047.5, abs=0.01)
+
+    @pytest.mark.parametrize(
+        ("volts", "expected"), [(-1.0, 0.0), (99.0, 4095.0)], ids=["under", "over"]
+    )
+    def test_out_of_range_volts_clamp(self, volts: float, expected: float) -> None:
+        """A real ADC saturates; it does not report a negative code.
+
+        Without the clamp a noisy excursion past the rail would send a
+        count the parser accepts and the calibration then maps to a
+        temperature no thermometer has ever read.
+        """
+        assert _counts(volts) == expected
+
+    def test_counts_carry_two_decimals(self) -> None:
+        """The sketch averages a burst, so counts are fractional.
+
+        Rounding to two places is what the firmware sends, and the
+        parser on the other end is written against that.
+        """
+        rendered = f"{_counts(1.23456):.10f}".rstrip("0")
+        assert len(rendered.split(".")[1]) <= 2
+
+
+class TestSignals:
+    """The two shapes a channel's voltage can take."""
+
+    def test_channel_oscillates_around_its_centre(self) -> None:
+        """A full period comes back to where it started, within noise."""
+        channel = feeder.Channel(
+            "T", centre=1.2, swing=0.5, period_seconds=100.0, noise=0.0
+        )
+        samples = [channel.volts_at(t) for t in range(100)]
+
+        assert max(samples) == pytest.approx(1.2 + 0.5, abs=0.02)
+        assert min(samples) == pytest.approx(1.2 - 0.5, abs=0.02)
+        assert sum(samples) / len(samples) == pytest.approx(1.2, abs=0.02)
+
+    def test_channels_do_not_all_peak_together(self) -> None:
+        """The random phase is what stops six synchronised sine waves.
+
+        Six channels rising and falling as one is the tell that a demo is
+        simulated, and the panels are read side by side.
+        """
+        phases = {
+            feeder.Channel("T", 1.0, 0.1, 60.0, 0.0)._phase  # pyright: ignore[reportPrivateUsage]
+            for _ in range(20)
+        }
+        assert len(phases) == 20
+        assert all(0 <= phase <= 2 * math.pi for phase in phases)
+
+    def test_wander_is_pulled_back_towards_centre(self) -> None:
+        """Displaced and left alone, it decays rather than walking off.
+
+        This is the property that keeps the beam inside the calibration's
+        linear range: a plain random walk has no stationary spread and
+        leaves the ADC's range for good.
+        """
+        wander = feeder.Wander("Q", centre=1.65, noise=0.0, pull=0.05)
+        wander._volts = 2.65  # pyright: ignore[reportPrivateUsage]
+
+        after_one = wander.volts_at(0.0)
+        assert after_one == pytest.approx(2.65 - 1.0 * 0.05)
+
+        for _ in range(200):
+            _ = wander.volts_at(0.0)
+        assert wander._volts == pytest.approx(  # pyright: ignore[reportPrivateUsage]
+            1.65, abs=0.01
+        )
+
+    def test_wander_ignores_the_clock(self) -> None:
+        """Where it goes depends on where it has been, not on `elapsed`."""
+        first = feeder.Wander("Q", centre=1.0, noise=0.0, pull=0.1)
+        second = feeder.Wander("Q", centre=1.0, noise=0.0, pull=0.1)
+        first._volts = 2.0  # pyright: ignore[reportPrivateUsage]
+        second._volts = 2.0  # pyright: ignore[reportPrivateUsage]
+
+        assert first.volts_at(0.0) == second.volts_at(99999.0)
+
+    def test_wander_holds_a_stationary_spread(self) -> None:
+        """The noise terms are solved backwards from the spread wanted.
+
+        `noise / sqrt(2 * pull)` is the figure the channel comments quote
+        when they justify 0.0572 and 0.0677; if the update rule changed,
+        that arithmetic would stop describing this code.
+        """
+        wander = feeder.Wander("Q", centre=1.65, noise=0.0572, pull=0.05)
+        for _ in range(2000):
+            _ = wander.volts_at(0.0)
+        samples = [wander.volts_at(0.0) for _ in range(20000)]
+
+        mean = sum(samples) / len(samples)
+        spread = math.sqrt(sum((value - mean) ** 2 for value in samples) / len(samples))
+        predicted = 0.0572 / math.sqrt(2 * 0.05)
+        assert spread == pytest.approx(predicted, rel=0.1)
+
+
+class TestChannelWiring:
+    """The feeder and the calibration file have to agree."""
+
+    def test_every_channel_has_a_calibration(self) -> None:
+        """A channel with no entry is acquired and then never converted.
+
+        It reaches InfluxDB as raw counts under a name that looks like
+        every other sensor, which is the failure worth catching here:
+        the demo keeps working and starts lying.
+        """
+        with path_to(_CALIBRATION).open("rb") as handle:
+            calibration = tomllib.load(handle)
+
+        fed = {channel.name for channel in feeder.CHANNELS}
+        calibrated = set(cast(dict[str, object], calibration["channels"]))
+        assert fed == calibrated
+
+    def test_every_channel_stays_inside_the_board_range(self) -> None:
+        """Nothing should sit near a rail, where the clamp would flatten it.
+
+        Checked over an hour of simulated time rather than at t=0, since
+        the slow drift is what takes a channel towards a rail.
+        """
+        for channel in feeder.CHANNELS:
+            samples = [channel.volts_at(float(t)) for t in range(0, 3600, 7)]
+            assert min(samples) > 0.05, channel.name
+            assert max(samples) < feeder.VREF - 0.05, channel.name
+
+
+class TestServe:
+    """One client at a time, streaming until it leaves."""
+
+    @staticmethod
+    def _serve_in_background(port: int) -> threading.Thread:
+        """Run `serve` on a daemon thread, swallowing the teardown error.
+
+        `serve` has no stop: it is a `while True` around `accept()`, which
+        is right for a container whose lifetime is the demo's. The thread
+        is therefore left blocked in `accept()` when the test ends, and
+        dies with the interpreter.
+        """
+
+        def run() -> None:
+            try:
+                feeder.serve(host="127.0.0.1", port=port)
+            except OSError:  # pragma: no cover - only on interpreter teardown
+                pass
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        return thread
+
+    @staticmethod
+    def _connect(port: int) -> socket.socket:
+        """Connect once the background thread has actually bound the port.
+
+        `serve` binds and listens on the thread, so connecting straight
+        after `start()` races it and is refused perhaps one run in eight.
+        Retrying is the fix rather than sleeping: a sleep long enough to
+        be safe on a loaded runner is a sleep every run pays.
+        """
+        deadline = time.monotonic() + 10.0
+        while True:
+            try:
+                return socket.create_connection(("127.0.0.1", port), timeout=10)
+            except ConnectionRefusedError:
+                if time.monotonic() >= deadline:  # pragma: no cover - wedged host
+                    raise
+                time.sleep(0.01)
+
+    @staticmethod
+    def _read_lines(client: socket.socket, wanted: int) -> list[str]:
+        """Read until `wanted` complete CRLF-terminated lines have arrived."""
+        buffer = b""
+        while buffer.count(b"\r\n") < wanted:
+            chunk = client.recv(4096)
+            assert chunk, "the feeder closed the connection early"
+            buffer += chunk
+        return buffer.decode().split("\r\n")[:wanted]
+
+    def test_streams_every_channel_in_the_firmware_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`<channel>,<count>\\r\\n`, one line per channel per tick.
+
+        The format is the contract with `serial-sensor`'s parser, and the
+        one-line-per-channel part is what makes a tick a complete set of
+        readings rather than six that drift apart.
+        """
+        monkeypatch.setattr(feeder, "SAMPLE_INTERVAL_SECONDS", 0.01)
+        port = _free_port()
+        _ = self._serve_in_background(port)
+
+        with self._connect(port) as client:
+            lines = self._read_lines(client, len(feeder.CHANNELS))
+
+        names = [line.split(",")[0] for line in lines]
+        assert names == [channel.name for channel in feeder.CHANNELS]
+        for line in lines:
+            _, rendered = line.split(",")
+            assert 0.0 <= float(rendered) <= float(feeder.FULL_SCALE)
+
+    def test_a_client_leaving_is_not_a_crash(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """serial-sensor restarts; the feeder waits and takes it back.
+
+        Without the handler the container exits on the first restart and
+        the demo goes quiet, which reads as an acquisition fault rather
+        than as the ordinary event it is.
+        """
+        monkeypatch.setattr(feeder, "SAMPLE_INTERVAL_SECONDS", 0.01)
+        port = _free_port()
+        _ = self._serve_in_background(port)
+
+        with caplog.at_level(logging.INFO, logger="adc-feeder"):
+            first = self._connect(port)
+            _ = self._read_lines(first, len(feeder.CHANNELS))
+            # Abort rather than close: a FIN is read as end-of-stream and
+            # the next send succeeds into the void, while an RST is what
+            # actually raises the error being checked here.
+            first.setsockopt(
+                socket.SOL_SOCKET, socket.SO_LINGER, b"\x01\x00\x00\x00\x00\x00\x00\x00"
+            )
+            first.close()
+
+            with self._connect(port) as second:
+                lines = self._read_lines(second, len(feeder.CHANNELS))
+
+        assert len(lines) == len(feeder.CHANNELS)
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("client gone, waiting" in message for message in messages)
+        assert sum("client connected" in message for message in messages) == 2
+
+
+class TestLogFormat:
+    """The feeder's lines have to sort against the sensors'."""
+
+    def test_timestamps_are_utc_with_milliseconds(self) -> None:
+        """Local time, or whole seconds, and a joint query reads wrong.
+
+        The Logs dashboard interleaves this file's lines with the
+        package's, and two clocks or two resolutions put them in an order
+        neither process was in.
+        """
+        record = logging.LogRecord(
+            "adc-feeder", logging.INFO, __file__, 1, "msg=x", None, None
+        )
+        record.created = 1_700_000_000.123456
+
+        stamped = _UtcMilliseconds().formatTime(record)
+
+        assert stamped == datetime.fromtimestamp(1_700_000_000.123456, UTC).isoformat(
+            timespec="milliseconds"
+        )
+        assert stamped.endswith("+00:00")
+        assert ".123" in stamped
+
+    def test_main_lowercases_the_levels_and_exits_quietly(
+        self, monkeypatch: pytest.MonkeyPatch, _restored_level_names: None
+    ) -> None:
+        """Ctrl-C is how the demo container stops, and it is not an error.
+
+        `socket.socket` is what raises here because it is the first thing
+        `serve` reaches for, which makes this the shortest path through
+        the main block that does not open a port.
+
+        The handler the block installs is not asserted on: `basicConfig`
+        does nothing when the root logger already has handlers, and under
+        pytest it always does. The rename is global and survives, so that
+        is what is checked, and the formatter itself is covered directly
+        by the test above.
+        """
+
+        def interrupted(*_args: object, **_kwargs: object) -> object:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(socket, "socket", interrupted)
+        assert logging.getLevelName(logging.WARNING) == "WARNING"
+
+        with pytest.raises(SystemExit) as exited:
+            _ = run_as_main(ADC_FEEDER)
+
+        assert exited.value.code == 0
+        assert logging.getLevelName(logging.WARNING) == "warning"
+        assert logging.getLevelName(logging.DEBUG) == "debug"

--- a/tests/test_sensor_templates.py
+++ b/tests/test_sensor_templates.py
@@ -1,0 +1,156 @@
+"""The two files docs/custom-sensor.md tells people to copy.
+
+They are the only code here that is meant to be edited rather than run
+as shipped, which makes their defaults load-bearing: a template that
+polls the wrong function, or exits non-zero when the instrument simply
+had nothing to say, is a bug reproduced by everyone who follows the
+page. Both are checked as shipped — the `read_value` stub included,
+since it is what makes the template run before any vendor code exists.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import cast
+
+import pytest
+
+from tests.loader import (
+    SENSOR_CONTINUOUS,
+    SENSOR_TRIGGERED,
+    run_as_main,
+    sensor_template,
+)
+
+
+class _Recorder:
+    """Stands in for `poll` or `write_reading`, keeping what it was sent."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        self.calls.append((args, kwargs))
+
+    @property
+    def kwargs(self) -> dict[str, object]:
+        """The keyword arguments of the single call made."""
+        assert len(self.calls) == 1, f"wanted one call, got {len(self.calls)}"
+        return self.calls[0][1]
+
+
+def _returning(value: float | None) -> Callable[..., float | None]:
+    """A stand-in for `random.normalvariate` with a decided answer."""
+
+    def answer(*_args: object, **_kwargs: object) -> float | None:
+        return value
+
+    return answer
+
+
+@pytest.fixture
+def _quiet_logging(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stop `logs.configure()` reconfiguring the suite's own logging.
+
+    Both templates call it at the top of their main block, and it
+    installs a root handler; left alone, the first template to run
+    changes how every later test's output is formatted.
+    """
+
+    def configured(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr("labmon.logs.configure", configured)
+
+
+@pytest.mark.parametrize(
+    "relative", [SENSOR_CONTINUOUS, SENSOR_TRIGGERED], ids=["continuous", "triggered"]
+)
+def test_read_value_stub_returns_a_reading(relative: str) -> None:
+    """The shipped stub answers, so the template runs before any SDK does.
+
+    That is the property the docstring promises and the reason to start
+    the container before touching vendor code: if readings appear in
+    Grafana, the plumbing is right and anything that breaks afterwards
+    is the instrument.
+    """
+    read_value = sensor_template(relative).read_value
+    values = [read_value() for _ in range(50)]
+
+    assert all(isinstance(value, float) for value in values)
+    # Simulated around 21 degC with a 0.1 spread; a hundredth of that
+    # either way is far outside anything the generator produces, so this
+    # catches a stub rewired to return counts or millivolts.
+    assert all(value is not None and 20.0 < value < 22.0 for value in values)
+    assert len(set(values)) > 1, "a constant stub would hide a dead poll loop"
+
+
+def test_continuous_polls_with_the_identifiers_it_documents(
+    monkeypatch: pytest.MonkeyPatch, _quiet_logging: None
+) -> None:
+    """The main block hands `poll` the stub and the placeholder id.
+
+    `CHANGE-ME` is deliberate and checked: the template is wrong if it
+    ships an id that looks like a real sensor, because the copy that is
+    never edited then writes under a plausible name.
+    """
+    recorder = _Recorder()
+    monkeypatch.setattr("labmon.sensors.polling.poll", recorder)
+
+    namespace = run_as_main(SENSOR_CONTINUOUS)
+
+    positional, kwargs = recorder.calls[0]
+    assert positional == (namespace["read_value"],)
+    assert kwargs == {
+        "sensor_id": "CHANGE-ME",
+        "measurement": "temperature",
+        "unit": "degC",
+        "interval": 5.0,
+    }
+
+
+def test_triggered_writes_one_reading_and_stops(
+    monkeypatch: pytest.MonkeyPatch, _quiet_logging: None
+) -> None:
+    """One reading, written synchronously, with no loop around it."""
+    recorder = _Recorder()
+    monkeypatch.setattr("labmon.sensors.polling.write_reading", recorder)
+    monkeypatch.setattr("random.normalvariate", _returning(20.5))
+
+    _ = run_as_main(SENSOR_TRIGGERED)
+
+    positional, kwargs = recorder.calls[0]
+    assert positional == (20.5,)
+    assert kwargs == {
+        "sensor_id": "CHANGE-ME",
+        "measurement": "temperature",
+        "unit": "degC",
+    }
+
+
+def test_triggered_exits_zero_when_there_is_no_reading(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _quiet_logging: None,
+) -> None:
+    """No reading is not a failure, and a timer must not be told it is.
+
+    systemd reports a unit that exits non-zero as failed, so returning 1
+    here would turn an instrument that was merely warming up into a red
+    unit somebody has to go and clear.
+    """
+    recorder = _Recorder()
+    monkeypatch.setattr("labmon.sensors.polling.write_reading", recorder)
+    monkeypatch.setattr("random.normalvariate", _returning(None))
+
+    with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as exited:
+        _ = run_as_main(SENSOR_TRIGGERED)
+
+    assert exited.value.code == 0
+    assert recorder.calls == []
+    record = caplog.records[-1]
+    assert record.message == "no reading available; nothing written"
+    # The identifier travels in `extra=`, not inside the message, which is
+    # what lets a Loki query filter on it.
+    assert cast(str, record.sensor_id) == "CHANGE-ME"  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/test_smoke_dashboard.py
+++ b/tests/test_smoke_dashboard.py
@@ -24,6 +24,7 @@ from email.message import Message
 from pathlib import Path
 from typing import Self, cast
 
+import certifi
 import pytest
 
 from tests.loader import (
@@ -384,11 +385,15 @@ class TestTlsContext:
             _ = tls_context(str(tmp_path / "absent.crt"))
 
     def test_a_real_ca_is_loaded(self, tmp_path: Path) -> None:
-        bundle = Path(ssl.get_default_verify_paths().cafile)
-        if not bundle.is_file():  # pragma: no cover - host without a CA bundle
-            pytest.skip("no system CA bundle to borrow")
+        """The exported CA has to be trusted, not merely found.
+
+        certifi's bundle is borrowed rather than a certificate minted,
+        which would pull in `cryptography` for one assertion. Not
+        `ssl.get_default_verify_paths()`: typeshed declares its `cafile`
+        a `str`, and on a CI runner it is None.
+        """
         certificate = tmp_path / "ca.crt"
-        _ = certificate.write_bytes(bundle.read_bytes())
+        _ = certificate.write_bytes(Path(certifi.where()).read_bytes())
 
         context = tls_context(str(certificate))
 

--- a/tests/test_smoke_dashboard.py
+++ b/tests/test_smoke_dashboard.py
@@ -1,0 +1,629 @@
+"""The check that every dashboard panel still returns rows.
+
+`tests/test_dashboard.py` checks each dashboard's shape. This file
+checks the script that checks it *works* — the one that interpolates the
+dashboard variables the way Grafana's frontend would and sends every
+target through Grafana's own query endpoint.
+
+That script runs against a live stack in CI, so its happy path is well
+covered and its failure paths are not: a run where a panel returns
+nothing, or where the credentials are refused, is not a run CI can be
+asked to have. Those are what is checked here. The interpolation and
+loading halves are exercised against the real dashboards in
+`grafana/dashboards/`, since a fixture of a dashboard would drift from
+the file that ships.
+"""
+
+import io
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from email.message import Message
+from pathlib import Path
+from typing import Self, cast
+
+import pytest
+
+from tests.loader import (
+    SMOKE_DASHBOARD,
+    Query,
+    path_to,
+    run_as_main,
+    smoke_dashboard,
+)
+
+smoke = smoke_dashboard()
+
+# Bound once rather than suppressed at each call site, the way
+# tests/test_influx.py takes `_setting`.
+Rejected = smoke._Rejected  # pyright: ignore[reportPrivateUsage]
+make_query = smoke._Query  # pyright: ignore[reportPrivateUsage]
+LOG_LINE_LIMIT = smoke._LOG_LINE_LIMIT  # pyright: ignore[reportPrivateUsage]
+mapping = smoke._mapping  # pyright: ignore[reportPrivateUsage]
+mappings = smoke._mappings  # pyright: ignore[reportPrivateUsage]
+values_of = smoke._values_of  # pyright: ignore[reportPrivateUsage]
+interpolate = smoke._interpolate  # pyright: ignore[reportPrivateUsage]
+child = smoke._child  # pyright: ignore[reportPrivateUsage]
+first = smoke._first  # pyright: ignore[reportPrivateUsage]
+row_count = smoke._row_count  # pyright: ignore[reportPrivateUsage]
+payload_for = smoke._payload  # pyright: ignore[reportPrivateUsage]
+load_queries = smoke._load_queries  # pyright: ignore[reportPrivateUsage]
+select_dashboards = smoke._selected  # pyright: ignore[reportPrivateUsage]
+tls_context = smoke._tls_context  # pyright: ignore[reportPrivateUsage]
+post = smoke._post  # pyright: ignore[reportPrivateUsage]
+report = smoke._report  # pyright: ignore[reportPrivateUsage]
+
+_DASHBOARDS = path_to("grafana/dashboards")
+
+
+class _Clock:
+    """A monotonic clock the test advances, so no test waits five seconds."""
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _response(payload: object) -> object:
+    """Something `urlopen` could have returned: a context manager that reads."""
+    body = json.dumps(payload).encode()
+
+    class _Response:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return body
+
+    return _Response()
+
+
+def _http_error(code: int, body: bytes = b"column not found") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "http://127.0.0.1:3000", code, "nope", Message(), io.BytesIO(body)
+    )
+
+
+def _query(label: str, *, may_be_empty: bool = False) -> Query:
+    return make_query(
+        label=label,
+        payload={"refId": "A", "rawSql": "SELECT 1"},
+        may_be_empty=may_be_empty,
+    )
+
+
+def _frames(*column_lengths: int) -> dict[str, object]:
+    """A Grafana result holding one frame per length given."""
+    return {
+        "frames": [
+            {"data": {"values": [list(range(length))]}} for length in column_lengths
+        ]
+    }
+
+
+class TestNarrowing:
+    """The two JSON helpers, which exist so the rest can stay typed."""
+
+    def test_a_mapping_passes_through(self) -> None:
+        assert mapping({"a": 1}) == {"a": 1}
+
+    def test_a_non_mapping_names_what_it_got(self) -> None:
+        with pytest.raises(TypeError, match="expected an object, got int"):
+            _ = mapping(3)
+
+    def test_a_list_of_mappings_passes_through(self) -> None:
+        assert mappings([{"a": 1}]) == [{"a": 1}]
+
+    def test_a_non_list_names_what_it_got(self) -> None:
+        with pytest.raises(TypeError, match="expected a list, got str"):
+            _ = mappings("nope")
+
+
+class TestVariableValues:
+    """What the frontend would put in place of each dashboard variable."""
+
+    def test_a_custom_variable_yields_every_value(self) -> None:
+        """All of them, because `${room:singlequote}` reaches `IN (...)`.
+
+        Taking the first would quietly narrow a multi-select to one room
+        and the panel would still draw.
+        """
+        variable: dict[str, object] = {
+            "type": "custom",
+            "query": "room-1, room-2 ,, room-3",
+        }
+        assert values_of(variable) == ["room-1", "room-2", "room-3"]
+
+    def test_a_custom_variable_with_no_string_query_yields_nothing(self) -> None:
+        variable: dict[str, object] = {"type": "custom", "query": None}
+        assert values_of(variable) == []
+
+    def test_a_single_valued_variable_uses_its_current_value(self) -> None:
+        variable: dict[str, object] = {
+            "type": "query",
+            "current": {"value": "influxdb"},
+        }
+        assert values_of(variable) == ["influxdb"]
+
+    def test_a_multi_valued_variable_uses_all_of_them(self) -> None:
+        variable: dict[str, object] = {
+            "type": "query",
+            "current": {"value": ["a", "b"]},
+        }
+        assert values_of(variable) == ["a", "b"]
+
+    def test_all_selected_interpolates_the_declared_all_value(self) -> None:
+        """What a browser sends on load, which resolves it without a round trip."""
+        variable: dict[str, object] = {
+            "type": "query",
+            "current": {"value": ["$__all"]},
+            "allValue": ".+",
+        }
+        assert values_of(variable) == [".+"]
+
+    def test_all_selected_with_no_all_value_cannot_be_resolved(self) -> None:
+        """Guessing would send a query that differs from the shipped panel's."""
+        variable: dict[str, object] = {
+            "name": "container",
+            "type": "query",
+            "current": {"value": "$__all"},
+        }
+        with pytest.raises(SystemExit, match="declares no allValue"):
+            _ = values_of(variable)
+
+
+# Two variables of the shape the real dashboards carry: one multi-valued
+# selector reaching an `IN (...)`, one single-valued.
+_VARIABLES: dict[str, list[str]] = {
+    "room": ["room-1", "room-2"],
+    "channel": ["cryo-diode"],
+}
+
+
+class TestInterpolation:
+    """Substitution, which has to match the frontend or the check is fiction."""
+
+    def test_singlequote_quotes_and_joins_every_value(self) -> None:
+        rendered = interpolate("WHERE room IN (${room:singlequote})", _VARIABLES)
+        assert rendered == "WHERE room IN ('room-1','room-2')"
+
+    def test_another_format_joins_without_quoting(self) -> None:
+        rendered = interpolate("${room:csv}", _VARIABLES)
+        assert rendered == "room-1,room-2"
+
+    def test_a_bare_variable_takes_the_first_value(self) -> None:
+        assert interpolate("$channel and $room", _VARIABLES) == (
+            "cryo-diode and room-1"
+        )
+
+    def test_a_braced_variable_takes_the_first_value(self) -> None:
+        assert interpolate("${channel}", _VARIABLES) == "cryo-diode"
+
+    def test_grafana_macros_are_left_for_the_backend(self) -> None:
+        """`$__timeFrom()` and `$__auto` are expanded server-side.
+
+        Substituting them here would send the backend something it has
+        no macro for, and the panel would fail for a reason invented by
+        this script rather than by the dashboard.
+        """
+        sql = "WHERE time >= $__timeFrom() AND x = $__auto"
+        assert interpolate(sql, _VARIABLES) == sql
+
+    def test_an_unknown_variable_is_left_alone(self) -> None:
+        """Both spellings, so an unresolved name reaches the backend intact."""
+        assert interpolate("$nope ${nope} ${nope:singlequote}", {}) == (
+            "$nope ${nope} ${nope:singlequote}"
+        )
+
+    def test_a_variable_with_no_values_is_left_alone(self) -> None:
+        assert interpolate("$empty", {"empty": []}) == "$empty"
+
+
+class TestResultWalking:
+    """Grafana's response is nested five levels deep and typed as `object`."""
+
+    def test_a_child_of_a_mapping_is_returned(self) -> None:
+        assert child({"a": 1}, "a") == 1
+
+    def test_a_child_of_anything_else_is_none(self) -> None:
+        assert child(["a"], "a") is None
+
+    def test_the_first_item_of_a_list(self) -> None:
+        assert first([1, 2]) == 1
+
+    @pytest.mark.parametrize("value", [[], "no", None], ids=["empty", "str", "none"])
+    def test_no_first_item(self, value: object) -> None:
+        assert first(value) is None
+
+    def test_rows_are_counted_across_every_frame(self) -> None:
+        """One frame per stream for Loki, and the first can be empty.
+
+        Counting only the first frame would read a working multi-stream
+        query as a dead one.
+        """
+        assert row_count(_frames(0, 3, 2)) == 5
+
+    def test_a_result_with_no_frames_counts_nothing(self) -> None:
+        assert row_count({"frames": "not a list"}) == 0
+
+    def test_a_frame_with_no_columns_counts_nothing(self) -> None:
+        empty: dict[str, object] = {"frames": [{"data": {"values": []}}]}
+        assert row_count(empty) == 0
+
+
+class TestPayload:
+    """Each backend wants its query under a different key, with different extras."""
+
+    def test_an_influxdb_target_carries_sql_and_a_format(self) -> None:
+        target: dict[str, object] = {
+            "refId": "A",
+            "datasource": {"type": "influxdb"},
+            "rawSql": "SELECT 1",
+        }
+        payload = payload_for("influxdb", target, {})
+
+        assert payload["rawSql"] == "SELECT 1"
+        assert payload["format"] == "time_series"
+        assert "maxLines" not in payload
+
+    def test_a_loki_target_carries_an_expression_and_a_line_limit(self) -> None:
+        """`queryType` decides range against instant; sending neither is empty."""
+        target: dict[str, object] = {
+            "refId": "B",
+            "datasource": {"type": "loki"},
+            "expr": '{container=~".+"}',
+            "queryType": "instant",
+        }
+        payload = payload_for("loki", target, {})
+
+        assert payload["expr"] == '{container=~".+"}'
+        assert payload["queryType"] == "instant"
+        assert payload["maxLines"] == LOG_LINE_LIMIT
+        assert "format" not in payload
+
+    def test_a_loki_target_defaults_to_a_range_query(self) -> None:
+        target: dict[str, object] = {
+            "refId": "B",
+            "datasource": {"type": "loki"},
+            "expr": '{a="b"}',
+        }
+        payload = payload_for("loki", target, {})
+        assert payload["queryType"] == "range"
+
+
+class TestLoadingTheRealDashboards:
+    """Against the files that ship, so a fixture cannot drift from them."""
+
+    @pytest.mark.parametrize(
+        "stem", [path.stem for path in sorted(_DASHBOARDS.glob("*.json"))]
+    )
+    def test_every_panel_target_becomes_a_query(self, stem: str) -> None:
+        path = _DASHBOARDS / f"{stem}.json"
+        parsed = cast(dict[str, object], json.loads(path.read_text("utf-8")))
+
+        queries = load_queries(path, parsed)
+
+        assert queries, f"{stem} produced no queries at all"
+        for query in queries:
+            assert query.label.startswith(f"{stem}/")
+            field = "expr" if "expr" in query.payload else "rawSql"
+            rendered = str(query.payload[field])
+            # A variable left unsubstituted is the failure this script
+            # exists to avoid making itself: it would reach the backend
+            # as a literal `$room` and fail for the wrong reason.
+            assert "${" not in rendered
+            for token in rendered.split("$")[1:]:
+                assert token.startswith("__"), f"{query.label} left ${token[:12]}"
+
+    def test_an_unknown_datasource_type_is_an_error_not_a_skip(self) -> None:
+        """Adding a backend must not silently switch a dashboard's check off."""
+        dashboard: dict[str, object] = {
+            "templating": {"list": []},
+            "panels": [
+                {
+                    "title": "Prometheus panel",
+                    "targets": [{"refId": "A", "datasource": {"type": "prometheus"}}],
+                }
+            ],
+        }
+        with pytest.raises(SystemExit, match="whose query field this script does not"):
+            _ = load_queries(Path("made-up.json"), dashboard)
+
+
+class TestSelection:
+    """`--dashboard`, and the rule that an unknown name is an error."""
+
+    def test_no_argument_takes_every_dashboard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(smoke, "_DASHBOARD_DIR", _DASHBOARDS)
+        selected = select_dashboards(None)
+        assert [path.stem for path in selected] == ["lab-overview", "logs"]
+
+    def test_a_named_subset_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(smoke, "_DASHBOARD_DIR", _DASHBOARDS)
+        selected = select_dashboards(["logs"])
+        assert [path.stem for path in selected] == ["logs"]
+
+    def test_an_unknown_name_lists_what_there_is(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A typo would otherwise report success having checked nothing."""
+        monkeypatch.setattr(smoke, "_DASHBOARD_DIR", _DASHBOARDS)
+        with pytest.raises(SystemExit, match="no dashboard named lgos"):
+            _ = select_dashboards(["lgos"])
+
+    def test_an_empty_directory_is_an_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(smoke, "_DASHBOARD_DIR", tmp_path)
+        with pytest.raises(SystemExit, match="no dashboards found"):
+            _ = select_dashboards(None)
+
+
+class TestTlsContext:
+    """`--cacert`, which is what makes the tls route reachable at all."""
+
+    def test_no_cacert_means_the_system_store(self) -> None:
+        assert tls_context(None) is None
+
+    def test_a_cacert_that_is_not_a_file_stops_the_run(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit, match="which is not a file"):
+            _ = tls_context(str(tmp_path / "absent.crt"))
+
+    def test_a_real_ca_is_loaded(self, tmp_path: Path) -> None:
+        bundle = Path(ssl.get_default_verify_paths().cafile)
+        if not bundle.is_file():  # pragma: no cover - host without a CA bundle
+            pytest.skip("no system CA bundle to borrow")
+        certificate = tmp_path / "ca.crt"
+        _ = certificate.write_bytes(bundle.read_bytes())
+
+        context = tls_context(str(certificate))
+
+        assert isinstance(context, ssl.SSLContext)
+        assert context.get_ca_certs(), "the file was accepted but loaded nothing"
+
+
+class TestPost:
+    """The one network call, and the credentials it carries."""
+
+    def test_the_request_is_authenticated_json(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[urllib.request.Request] = []
+
+        def opened(request: urllib.request.Request, **_kwargs: object) -> object:
+            seen.append(request)
+            return _response({"results": {}})
+
+        monkeypatch.setattr("urllib.request.urlopen", opened)
+
+        answer = post({"queries": []}, "hunter2", "http://x/api", None)
+
+        assert answer == {"results": {}}
+        request = seen[0]
+        assert request.full_url == "http://x/api"
+        assert request.get_header("Content-type") == "application/json"
+        authorization = request.get_header("Authorization")
+        assert authorization is not None and authorization.startswith("Basic ")
+        assert json.loads(cast(bytes, request.data)) == {"queries": []}
+
+
+class TestAttempt:
+    """One pass over every query, and which failures are worth retrying."""
+
+    @staticmethod
+    def _run(
+        monkeypatch: pytest.MonkeyPatch,
+        answer: object,
+        queries: list[Query] | None = None,
+    ) -> list[tuple[str, str]]:
+        def posted(*_args: object, **_kwargs: object) -> object:
+            if isinstance(answer, BaseException):
+                raise answer
+            return answer
+
+        monkeypatch.setattr(smoke, "_post", posted)
+        return smoke._attempt(  # pyright: ignore[reportPrivateUsage]
+            queries or [_query("d/Panel")],
+            {"from": "now-15m", "to": "now"},
+            "pw",
+            "u",
+            None,
+        )
+
+    def test_a_query_returning_rows_is_not_a_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answer = {"results": {"A": _frames(3)}}
+        assert self._run(monkeypatch, answer) == []
+
+    def test_a_query_returning_nothing_is_a_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The case nothing else catches: valid LogQL that matches nothing."""
+        answer = {"results": {"A": _frames(0)}}
+        assert self._run(monkeypatch, answer) == [
+            ("d/Panel", "query succeeded but returned no rows")
+        ]
+
+    def test_a_panel_allowed_to_be_empty_is_left_alone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run where nothing logged a warning is a good run."""
+        answer = {"results": {"A": _frames(0)}}
+        queries = [_query("logs/Warnings", may_be_empty=True)]
+        assert self._run(monkeypatch, answer, queries=queries) == []
+
+    def test_a_datasource_error_is_reported_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answer = {"results": {"A": {"error": "table not found: temperature"}}}
+        failures = self._run(monkeypatch, answer)
+        assert failures == [("d/Panel", "table not found: temperature")]
+
+    def test_an_http_error_carries_the_body_not_just_the_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad column and a bad token are both "400 Bad Request"."""
+        failures = self._run(monkeypatch, _http_error(400))
+        assert "column not found" in failures[0][1]
+
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_refused_credentials_stop_the_retry_loop(
+        self, monkeypatch: pytest.MonkeyPatch, code: int
+    ) -> None:
+        with pytest.raises(Rejected):
+            _ = self._run(monkeypatch, _http_error(code))
+
+    def test_an_unreachable_grafana_is_a_retryable_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        failures = self._run(monkeypatch, urllib.error.URLError("refused"))
+        assert "refused" in failures[0][1]
+
+
+class TestReport:
+    """Grouping, so one broken panel is not buried under twenty copies."""
+
+    def test_failures_are_grouped_by_reason(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        queries = [_query("a/One"), _query("a/Two"), _query("b/Three")]
+        failures = [("a/One", "same"), ("a/Two", "same"), ("b/Three", "other")]
+
+        report(failures, queries, 60.0, 3)
+
+        errors = capsys.readouterr().err
+        assert "3 of 3 dashboard queries still failing after 60s (3 attempts)" in errors
+        assert "  - a/One, a/Two: same" in errors
+        assert "  - b/Three: other" in errors
+
+    def test_a_whole_dashboard_down_gets_the_profile_hint(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Every query on one dashboard failing usually means its profile is off."""
+        queries = [_query("logs/One"), _query("lab/Two")]
+        report([("logs/One", "no such datasource")], queries, 60.0, 1)
+
+        assert "the profile behind" in capsys.readouterr().err
+
+    def test_one_broken_panel_among_working_ones_gets_no_hint(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """It would point at the wrong thing, which is worse than silence."""
+        queries = [_query("logs/One"), _query("logs/Two")]
+        report([("logs/One", "no rows")], queries, 60.0, 1)
+
+        assert "the profile behind" not in capsys.readouterr().err
+
+
+class TestMain:
+    """The loop, run against the real dashboards with only the network faked."""
+
+    @staticmethod
+    def _run(
+        monkeypatch: pytest.MonkeyPatch,
+        attempts: list[object],
+        argv: list[str] | None = None,
+    ) -> tuple[int, _Clock]:
+        clock = _Clock()
+        monkeypatch.setattr(smoke, "time", clock)
+        monkeypatch.setattr(smoke, "_DASHBOARD_DIR", _DASHBOARDS)
+        monkeypatch.setattr(sys, "argv", ["smoke_dashboard.py", *(argv or [])])
+
+        remaining = list(attempts)
+
+        def attempt(*_args: object, **_kwargs: object) -> object:
+            answer = remaining.pop(0) if len(remaining) > 1 else remaining[0]
+            if isinstance(answer, BaseException):
+                raise answer
+            return answer
+
+        monkeypatch.setattr(smoke, "_attempt", attempt)
+        return smoke.main(), clock
+
+    def test_every_query_returning_rows_passes(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, clock = self._run(monkeypatch, [[]])
+
+        output = capsys.readouterr().out
+        assert status == 0
+        assert clock.slept == []
+        assert "across 2 dashboards returned rows" in output
+        assert "not counting 3 allowed to be empty" in output
+
+    def test_a_single_dashboard_reads_singular(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, _ = self._run(monkeypatch, [[]], argv=["--dashboard", "lab-overview"])
+
+        output = capsys.readouterr().out
+        assert status == 0
+        assert "across 1 dashboard returned rows" in output
+        # lab-overview has no panel on the may-be-empty list, so the
+        # note is absent rather than reading "not counting 0".
+        assert "not counting" not in output
+
+    def test_a_slow_stack_is_waited_for(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The sensors need a moment to fill the dashboard's window."""
+        status, clock = self._run(monkeypatch, [[("logs/Rate", "no rows")], []])
+
+        assert status == 0
+        assert clock.slept == [5]
+        assert "1 not ready yet, retrying" in capsys.readouterr().out
+
+    def test_a_query_that_never_recovers_fails_with_a_report(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, clock = self._run(
+            monkeypatch, [[("logs/Rate", "no rows")]], argv=["--timeout", "10"]
+        )
+
+        assert status == 1
+        assert clock.slept == [5, 5]
+        assert "1 of" in capsys.readouterr().err
+
+    def test_refused_credentials_end_the_run(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, clock = self._run(monkeypatch, [Rejected("401 on logs/Rate")])
+
+        assert status == 1
+        assert clock.slept == []
+        assert "Grafana rejected the credentials" in capsys.readouterr().err
+
+
+def test_running_it_as_a_script_exits_with_its_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard block, which is how CI actually invokes this file."""
+    monkeypatch.setattr(sys, "argv", ["smoke_dashboard.py", "--dashboard", "logs"])
+
+    def opened(request: urllib.request.Request, **_kwargs: object) -> object:
+        """Answer whatever refId the script asked about, with one row."""
+        sent = cast(dict[str, object], json.loads(cast(bytes, request.data)))
+        asked = cast(list[dict[str, object]], sent["queries"])
+        return _response({"results": {str(asked[0]["refId"]): _frames(1)}})
+
+    monkeypatch.setattr("urllib.request.urlopen", opened)
+
+    with pytest.raises(SystemExit) as exited:
+        _ = run_as_main(SMOKE_DASHBOARD)
+
+    assert exited.value.code == 0

--- a/tests/test_smoke_logs.py
+++ b/tests/test_smoke_logs.py
@@ -1,0 +1,373 @@
+"""The check that log collection is actually collecting.
+
+`scripts/smoke_logs.py` is the only thing that would notice the `logs`
+profile going quiet: Alloy failing to parse its config, Loki refusing
+pushes and a container buffering its output all look identical from
+outside, and all of them look like a quiet lab. It runs against a live
+stack in CI, which proves it works but cannot reach its failure paths —
+a run where the credentials are refused, or where one container of
+twelve is missing, is not a run anybody wants CI to have.
+
+Those are what is checked here: the reporting and the give-up rules,
+against a stack that is fabricated rather than started.
+"""
+
+import io
+import ssl
+import subprocess
+import sys
+import urllib.error
+from collections.abc import Callable
+from email.message import Message
+from pathlib import Path
+from typing import Self, cast
+
+import pytest
+
+from tests.loader import SMOKE_LOGS, run_as_main, smoke_logs
+
+smoke = smoke_logs()
+
+# Bound once rather than suppressed at each call site, the way
+# tests/test_influx.py takes `_setting`.
+Rejected = smoke._Rejected  # pyright: ignore[reportPrivateUsage]
+running_containers = smoke._running_containers  # pyright: ignore[reportPrivateUsage]
+tls_context = smoke._tls_context  # pyright: ignore[reportPrivateUsage]
+collected_containers = smoke._collected_containers  # pyright: ignore[reportPrivateUsage]
+
+
+class _Clock:
+    """A monotonic clock the test advances, so no test waits five seconds.
+
+    The retry loop sleeps between attempts and gives up on a deadline;
+    both are read through this, so a run that would take three minutes of
+    wall clock takes none.
+    """
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _response(payload: bytes) -> object:
+    """Something `urlopen` could have returned: a context manager that reads."""
+
+    class _Response:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return payload
+
+    return _Response()
+
+
+def _completing(stdout: str) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """A `subprocess.run` that reports what Compose would have said."""
+
+    def ran(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=stdout, stderr=""
+        )
+
+    return ran
+
+
+def _answering(payload: bytes) -> Callable[..., object]:
+    """A `urlopen` that always hands back the same body."""
+
+    def opened(*_args: object, **_kwargs: object) -> object:
+        return _response(payload)
+
+    return opened
+
+
+def _http_error(code: int, body: bytes = b"denied") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "http://127.0.0.1:3000", code, "nope", Message(), io.BytesIO(body)
+    )
+
+
+class TestRunningContainers:
+    """What Compose says is up, which is the list everything is judged against."""
+
+    def test_names_are_read_from_compose(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Blank lines are dropped; the rest come back as a set."""
+        monkeypatch.setattr(subprocess, "run", _completing("influxdb\ngrafana\n\n"))
+        assert running_containers() == {"influxdb", "grafana"}
+
+    def test_missing_docker_is_not_worth_retrying(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def absent(*_args: object, **_kwargs: object) -> object:
+            raise FileNotFoundError
+
+        monkeypatch.setattr(subprocess, "run", absent)
+        with pytest.raises(Rejected, match="docker is not on PATH"):
+            _ = running_containers()
+
+    def test_a_failed_compose_call_carries_its_stderr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Usually "run from outside the repo", and the message should say so."""
+
+        def failed(*_args: object, **_kwargs: object) -> object:
+            raise subprocess.CalledProcessError(
+                1, "docker", stderr="no configuration file provided\n"
+            )
+
+        monkeypatch.setattr(subprocess, "run", failed)
+        with pytest.raises(Rejected, match="no configuration file provided"):
+            _ = running_containers()
+
+
+class TestTlsContext:
+    """`--cacert`, which is what makes the tls route reachable at all."""
+
+    def test_no_cacert_means_the_system_store(self) -> None:
+        assert tls_context(None) is None
+
+    def test_a_cacert_that_is_not_a_file_stops_the_run(self, tmp_path: Path) -> None:
+        """Named and quoted, because the usual cause is a typo in a path."""
+        missing = str(tmp_path / "absent.crt")
+        with pytest.raises(SystemExit, match="which is not a file"):
+            _ = tls_context(missing)
+
+    def test_a_real_ca_is_loaded(self, tmp_path: Path) -> None:
+        """The exported CA has to be trusted, not merely found.
+
+        Built from the trust store the interpreter already ships rather
+        than by minting a certificate, which would pull in `cryptography`
+        for one assertion.
+        """
+        bundle = Path(ssl.get_default_verify_paths().cafile)
+        if not bundle.is_file():  # pragma: no cover - host without a CA bundle
+            pytest.skip("no system CA bundle to borrow")
+        certificate = tmp_path / "ca.crt"
+        _ = certificate.write_bytes(bundle.read_bytes())
+
+        context = tls_context(str(certificate))
+
+        assert isinstance(context, ssl.SSLContext)
+        assert context.get_ca_certs(), "the file was accepted but loaded nothing"
+
+
+class TestCollectedContainers:
+    """What Loki answers, and which answers are worth retrying."""
+
+    @staticmethod
+    def _patch(monkeypatch: pytest.MonkeyPatch, result: object) -> None:
+        def opened(*_args: object, **_kwargs: object) -> object:
+            if isinstance(result, BaseException):
+                raise result
+            return result
+
+        monkeypatch.setattr("urllib.request.urlopen", opened)
+
+    def test_label_values_become_the_collected_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch(monkeypatch, _response(b'{"data": ["influxdb", "grafana"]}'))
+        collected = collected_containers("pw", "http://x", None)
+        assert collected == {"influxdb", "grafana"}
+
+    def test_a_body_with_no_data_list_is_empty_rather_than_an_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loki answers this while it is still starting, and it will pass."""
+        self._patch(monkeypatch, _response(b'{"status": "success"}'))
+        assert collected_containers("pw", "http://x", None) == set()
+
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_refused_credentials_are_terminal(
+        self, monkeypatch: pytest.MonkeyPatch, code: int
+    ) -> None:
+        """Retrying would lock the admin out after five attempts.
+
+        Grafana blocks an account on consecutive failures, so a retry
+        loop against a wrong password does more damage than the failure
+        it is trying to ride out.
+        """
+        self._patch(monkeypatch, _http_error(code))
+        with pytest.raises(Rejected):
+            _ = collected_containers("pw", "http://x", None)
+
+    def test_other_http_errors_stay_retryable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 502 while Grafana starts is exactly what the loop is for."""
+        self._patch(monkeypatch, _http_error(502))
+        with pytest.raises(urllib.error.HTTPError):
+            _ = collected_containers("pw", "http://x", None)
+
+
+class TestMain:
+    """The loop: what it waits for, what it gives up on, what it prints."""
+
+    @staticmethod
+    def _run(
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        running: object,
+        collected: list[object],
+        argv: list[str] | None = None,
+    ) -> tuple[int, _Clock]:
+        clock = _Clock()
+        monkeypatch.setattr(smoke, "time", clock)
+        monkeypatch.setattr(sys, "argv", ["smoke_logs.py", *(argv or [])])
+
+        def containers() -> set[str]:
+            if isinstance(running, BaseException):
+                raise running
+            return cast(set[str], running)
+
+        answers = list(collected)
+
+        def collect(*_args: object, **_kwargs: object) -> set[str]:
+            answer = answers.pop(0) if len(answers) > 1 else answers[0]
+            if isinstance(answer, BaseException):
+                raise answer
+            return cast(set[str], answer)
+
+        monkeypatch.setattr(smoke, "_running_containers", containers)
+        monkeypatch.setattr(smoke, "_collected_containers", collect)
+        return smoke.main(), clock
+
+    def test_every_container_collected_passes_first_time(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, clock = self._run(
+            monkeypatch,
+            running={"influxdb", "grafana"},
+            collected=[{"influxdb", "grafana"}],
+        )
+
+        assert status == 0
+        assert clock.slept == []
+        assert "all 2 running containers have logs in Loki" in capsys.readouterr().out
+
+    def test_loki_is_excused_and_said_to_be(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Loki runs at log_level=warn so that it has nothing to say.
+
+        Naming it in the success line is what stops the exemption being
+        invisible: a reader counting containers would otherwise find one
+        missing and no explanation.
+        """
+        status, _ = self._run(
+            monkeypatch,
+            running={"influxdb", "grafana", "loki"},
+            collected=[{"influxdb", "grafana"}],
+        )
+
+        output = capsys.readouterr().out
+        assert status == 0
+        assert "all 2 running containers" in output
+        assert "not counting loki" in output
+
+    def test_a_container_arriving_late_is_waited_for(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Alloy discovers containers a moment after they start."""
+        status, clock = self._run(
+            monkeypatch,
+            running={"influxdb", "grafana"},
+            collected=[{"influxdb"}, {"influxdb", "grafana"}],
+        )
+
+        assert status == 0
+        assert clock.slept == [5]
+        assert "1 not collected yet, retrying" in capsys.readouterr().out
+
+    def test_an_unreachable_loki_is_retried_not_failed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Loki has no healthcheck, so early attempts land before it listens."""
+        status, _ = self._run(
+            monkeypatch,
+            running={"influxdb"},
+            collected=[urllib.error.URLError("connection refused"), {"influxdb"}],
+        )
+
+        assert status == 0
+        assert "not ready yet" in capsys.readouterr().out
+
+    def test_a_container_that_never_arrives_fails_with_its_name(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The single missing container is the failure worth reporting.
+
+        A non-empty check would pass here, which is the whole reason this
+        compares against the running set.
+        """
+        status, clock = self._run(
+            monkeypatch,
+            running={"influxdb", "mock-cryo-4k"},
+            collected=[{"influxdb"}],
+            argv=["--timeout", "12"],
+        )
+
+        assert status == 1
+        assert clock.slept == [5, 5, 5]
+        errors = capsys.readouterr().err
+        assert "1 of 2 containers have no logs in Loki after 12s" in errors
+        assert "  - mock-cryo-4k" in errors
+        assert "usually buffering rather than a collection fault" in errors
+
+    def test_a_stack_that_is_not_up_says_so(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, _ = self._run(monkeypatch, running=set[str](), collected=[set[str]()])
+
+        assert status == 1
+        assert "no running containers" in capsys.readouterr().err
+
+    def test_compose_being_unusable_is_reported_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, _ = self._run(
+            monkeypatch,
+            running=Rejected("docker is not on PATH"),
+            collected=[set()],
+        )
+
+        assert status == 1
+        assert "cannot list the stack's containers" in capsys.readouterr().err
+
+    def test_refused_credentials_end_the_run(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        status, clock = self._run(
+            monkeypatch,
+            running={"influxdb"},
+            collected=[Rejected("401")],
+        )
+
+        assert status == 1
+        assert clock.slept == []
+        assert "Grafana rejected the credentials" in capsys.readouterr().err
+
+
+def test_running_it_as_a_script_exits_with_its_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard block, which is how CI actually invokes this file."""
+    monkeypatch.setattr(sys, "argv", ["smoke_logs.py"])
+    monkeypatch.setattr(subprocess, "run", _completing("influxdb\n"))
+    monkeypatch.setattr("urllib.request.urlopen", _answering(b'{"data": ["influxdb"]}'))
+
+    with pytest.raises(SystemExit) as exited:
+        _ = run_as_main(SMOKE_LOGS)
+
+    assert exited.value.code == 0

--- a/tests/test_smoke_logs.py
+++ b/tests/test_smoke_logs.py
@@ -22,6 +22,7 @@ from email.message import Message
 from pathlib import Path
 from typing import Self, cast
 
+import certifi
 import pytest
 
 from tests.loader import SMOKE_LOGS, run_as_main, smoke_logs
@@ -146,15 +147,13 @@ class TestTlsContext:
     def test_a_real_ca_is_loaded(self, tmp_path: Path) -> None:
         """The exported CA has to be trusted, not merely found.
 
-        Built from the trust store the interpreter already ships rather
-        than by minting a certificate, which would pull in `cryptography`
-        for one assertion.
+        certifi's bundle is borrowed rather than a certificate minted,
+        which would pull in `cryptography` for one assertion. Not
+        `ssl.get_default_verify_paths()`: typeshed declares its `cafile`
+        a `str`, and on a CI runner it is None.
         """
-        bundle = Path(ssl.get_default_verify_paths().cafile)
-        if not bundle.is_file():  # pragma: no cover - host without a CA bundle
-            pytest.skip("no system CA bundle to borrow")
         certificate = tmp_path / "ca.crt"
-        _ = certificate.write_bytes(bundle.read_bytes())
+        _ = certificate.write_bytes(Path(certifi.where()).read_bytes())
 
         context = tls_context(str(certificate))
 

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,7 @@ tui = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
+    { name = "certifi" },
     { name = "h5netcdf" },
     { name = "h5py" },
     { name = "pandas" },
@@ -332,6 +333,7 @@ provides-extras = ["spline", "netcdf", "tui"]
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.39.10" },
+    { name = "certifi", specifier = ">=2026.7.22" },
     { name = "h5netcdf", specifier = ">=1.8.1" },
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "pandas", specifier = ">=3.0.5" },


### PR DESCRIPTION
Closes #85, bar one point deliberately left undone.

Six commits, one per point: a concurrency group on both workflows; `scripts/hooks/compose-config.sh` promoted from pre-commit-only into the smoke job; an opening `up --wait` with `COMPOSE_PROFILES` empty, asserting the running set is exactly `grafana influxdb`; hadolint over both Dockerfiles; actionlint over both workflows; and coverage extended from `src` to `demo`, `scripts` and `templates` with the tests to carry all four to 100%.

**Point 6 I'm not doing.** Merging `lint`, `typecheck` and `typos` into one `static` job saves two runner startups and costs three independently named checks in the PR status list. One red X you have to open a log to interpret is worse value than thirty seconds of parallel runner time, so the three stay as they are.

Two things worth flagging.

The client compose file was not quite "validated by nothing" as I wrote in the issue — a pre-commit hook parses both files, and that hook's own comment claims CI runs the same check "with Docker guaranteed present". No workflow ran it. So the file was guarded by a gate that `--no-verify` skips, that a fresh clone never installs, and that skips itself when the daemon is down. The fix reuses the script rather than duplicating it, which makes the comment true.

actionlint justified itself before it was committed: run over the tree, it rejected the step I'd added two commits earlier, where `COMPOSE_PROFILES=` before a command trips SC1007. It then rejected the comment explaining the fix, because shellcheck reads a comment starting with its own name as a directive. Both are fixed in the commit that adds the linter.

Reordering the smoke job means Grafana now starts before the token is minted and depends on the later `up` recreating it once `INFLUXDB3_AUTH_TOKEN` is set. Compose hashes a service's environment into the container config, so it does. That was the one thing I couldn't rehearse locally — `container_name` is fixed, so a second project collides with a running stack — and `cold start` has now confirmed it, dashboards and Loki checks included.

Point 7's note that the coverage gap "probably belongs with #82" is now stale: #82 closed having fixed only the basedpyright half. It is done here instead. No CHANGELOG entry — this is all internal, and the file records no CI work.

## Test plan

- [x] `pytest --cov --cov-fail-under=100` — 1089 tests, 100% of 2883 statements across four trees
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `ruff check` / `ruff format --check` / `typos`
- [x] hadolint and actionlint run locally against the pinned digests, both clean
- [x] `smoke` green on this PR, including the new server-shape step and the Grafana recreation behind it
