### PR TITLE
Build every point through build_point()

### DIFF
--- a/docs/custom-sensor.md
+++ b/docs/custom-sensor.md
@@ -100,6 +100,19 @@ writer.write(
 Same tag conventions, so the readings sit alongside every other sensor's
 rather than in a shape of their own.
 
+For several numbers describing *one* reading — a value and the raw input
+it was derived from, say — add the extra field to the point rather than
+writing a second one:
+
+```python
+point = build_point(value, sensor_id="cryo-1", measurement="temperature", unit="K")
+writer.write(point.field("input_volts", volts))
+```
+
+`build_point()` returns the point for exactly this reason, so a sensor
+with more to record does not need the builder to grow a parameter for
+every shape. `labmon serial-sensor` records `input_volts` this way.
+
 </details>
 
 ## Prove the plumbing first

--- a/src/labmon/sensors/mock_sensor.py
+++ b/src/labmon/sensors/mock_sensor.py
@@ -12,13 +12,11 @@ import logging
 import math
 import random
 import time
-from datetime import UTC, datetime
-
-from influxdb_client_3 import Point
 
 from labmon.influx import influx_database
 from labmon.quantise import DEFAULT_SIGNIFICANT_DIGITS, quantise
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
+from labmon.sensors.polling import build_point
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -89,7 +87,6 @@ def run(
         },
     )
     while True:
-        reading_time = datetime.now(UTC)
         # Rounded here rather than inside the walk: quantising the walk's
         # own state would change how it reverts to the setpoint, and a
         # step coarser than the noise would freeze it outright. The gate
@@ -105,11 +102,16 @@ def run(
         # the rest of the iteration, so the pacing stays in one place and a
         # bad reading cannot turn the loop into a spin.
         if loop.admits(reading, sensor_id=sensor_id):
-            point = Point(measurement).tag("sensor_id", sensor_id)
-            if unit:
-                point = point.tag("unit", unit)
-            point = point.field(field, reading).time(reading_time, write_precision="ms")
-            loop.record(point, sensor_id)
+            loop.record(
+                build_point(
+                    reading,
+                    sensor_id=sensor_id,
+                    measurement=measurement,
+                    unit=unit,
+                    field=field,
+                ),
+                sensor_id,
+            )
             logger.debug(
                 "reading",
                 extra={"sensor_id": sensor_id, "value": f"{reading:.4g}", "unit": unit},

--- a/src/labmon/sensors/serial_sensor.py
+++ b/src/labmon/sensors/serial_sensor.py
@@ -6,9 +6,6 @@ that drives it is `labmon.cli.commands.serial_sensor`.
 """
 
 import logging
-from datetime import UTC, datetime
-
-from influxdb_client_3 import Point
 
 from labmon.calibration import (
     ADC_RESOLUTION_BITS,
@@ -21,6 +18,7 @@ from labmon.calibration import (
 from labmon.gate import RecordingGate
 from labmon.influx import influx_database
 from labmon.sensors.loop import DEFAULT_SUMMARY_INTERVAL_SECONDS, SensorLoop
+from labmon.sensors.polling import build_point
 from labmon.sensors.serial_source import (
     RawSource,
 )
@@ -193,16 +191,21 @@ def run(
                 # transition the gate logged is the evidence for the gap.
                 continue
 
-            # The board has no clock, so the host stamps the reading on
-            # arrival; serial transit is negligible next to sample rates here.
-            point = (
-                Point(calibration.measurement)
-                .tag("sensor_id", calibration.sensor_id)
-                .tag("unit", calibration.unit)
-                .tag(CALIBRATION_ID_TAG, calibration.calibration_id)
-                .field(FIELD_NAME, value.magnitude)
-                .time(datetime.now(UTC), write_precision="ms")
+            # `build_point` owns the tag conventions and stamps the point.
+            # The board has no clock, so the host stamps on arrival; serial
+            # transit is negligible next to sample rates here.
+            point = build_point(
+                value.magnitude,
+                sensor_id=calibration.sensor_id,
+                measurement=calibration.measurement,
+                unit=calibration.unit,
+                field=FIELD_NAME,
+                tags={CALIBRATION_ID_TAG: calibration.calibration_id},
             )
+            # The second field is added here rather than by `build_point`,
+            # which returns the point precisely so a caller with more to
+            # record can add it without the builder growing a parameter
+            # for every shape a sensor might have.
             if calibration.store_input:
                 # Keeping the conversion's input makes a wrong calibration
                 # correctable after the fact; without it, readings already

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,7 +1,9 @@
+import ast
 import logging
 import signal
 import time
 from collections.abc import Callable
+from pathlib import Path
 from types import FrameType
 from typing import override
 
@@ -126,6 +128,52 @@ def test_build_point_accepts_extra_tags_and_a_field_name() -> None:
 # --------------------------------------------------------------------------
 # write_reading — the one-shot path
 # --------------------------------------------------------------------------
+
+
+def test_build_point_is_the_only_place_a_point_is_constructed() -> None:
+    """No module may assemble a `Point` by hand.
+
+    `build_point` was extracted to own the tag conventions — the
+    `sensor_id` tag, the rule that an empty unit tag is not the same as
+    no unit tag, the millisecond write precision. A convention owned in
+    one place and applied in three is one that eventually differs in one
+    of them, and that failure is silent: it lands in stored data as two
+    series that look identical in a legend, and cannot be corrected
+    afterwards.
+
+    `mock_sensor` and `serial_sensor` each carried their own copy until
+    #117. A sensor with more to record than one field adds it to the
+    point `build_point` returns, the way `serial_sensor` adds
+    `input_volts` — so needing a second field is not a reason to open a
+    fourth copy.
+
+    Read with `ast` rather than by grepping, so a mention in a docstring
+    or a comment is not a finding.
+    """
+    root = Path(__file__).resolve().parent.parent / "src"
+    built_in: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text("utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            called = node.func
+            name = (
+                called.id
+                if isinstance(called, ast.Name)
+                else called.attr
+                if isinstance(called, ast.Attribute)
+                else ""
+            )
+            if name == "Point":
+                built_in.append(str(path.relative_to(root)))
+
+    # The file, not the line: pinning a line number would make this fail
+    # on any edit above it, which teaches people to update the number
+    # rather than to ask why it moved.
+    assert built_in == ["labmon/sensors/polling.py"], (
+        "a Point is constructed outside build_point, in " + ", ".join(built_in)
+    )
 
 
 def test_write_reading_writes_one_point(fake_client: FakeInfluxClient) -> None:

--- a/tests/test_serial_sensor.py
+++ b/tests/test_serial_sensor.py
@@ -147,6 +147,38 @@ def test_run_writes_a_calibrated_point(
     assert "input_volts=3.3" in line
 
 
+def test_run_writes_no_unit_tag_for_a_dimensionless_channel(
+    fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
+) -> None:
+    """A ratio has no unit, and an empty unit tag is not the same as none.
+
+    This is the convention `build_point` exists to own. `serial-sensor`
+    used to tag `unit` unconditionally, and only the client's habit of
+    dropping an empty tag kept the two spellings from splitting the
+    series in two — halves that would look identical in a legend. Pinned
+    here so the guarantee rests on this repository rather than on a
+    detail of influxdb_client_3.
+    """
+    source = FakeRawSource([RawReading(channel="A0", raw_count=4095)])
+    ratio = Calibration(
+        sensor_id="beam-ratio",
+        measurement="ratio",
+        conversion=LinearConversion(factor=ureg("0.3 / volt")),
+    )
+    assert ratio.unit == "", "a dimensionless conversion should carry no unit"
+
+    with pytest.raises(_StopLoop):
+        run(source=source, calibrations={"A0": ratio})
+    with pytest.raises(SystemExit):
+        registered_handlers[signal.SIGINT](signal.SIGINT, None)
+
+    [batch] = fake_client.batches
+    [point] = batch
+    line = point.to_line_protocol()
+    assert "sensor_id=beam-ratio" in line
+    assert "unit=" not in line
+
+
 def test_run_stores_the_conversion_input_by_default(
     fake_client: FakeInfluxClient, registered_handlers: dict[int, SignalHandler]
 ) -> None:


### PR DESCRIPTION
Closes #117. `mock_sensor` and `serial_sensor` no longer assemble points by hand; both go through `build_point()`, which is where the tag conventions were supposed to live.

`serial_sensor` turned out to need nothing added to `build_point()`. It already takes `tags`, which covers `calibration_id`, and the second field is chained onto the point it returns — something its own docstring already offered ("several fields from one device read, say"). So the builder keeps its four optional parameters rather than drifting towards the unreadable function I was worried about in the issue. `src/` is a net +26/−21.

I thought I'd found a live bug on the way and hadn't, which is worth recording. `Calibration.unit` renders as an empty string for a dimensionless conversion, and `serial_sensor` tagged `unit` unconditionally where `build_point()` omits an empty one — so a `value_unit = "dimensionless"` channel looked like it would split its series into two halves indistinguishable in a legend. It doesn't: influxdb_client_3 drops an empty tag before the wire, and both spellings produce identical line protocol. The guarantee was just resting on a third-party detail instead of on this repository. There's now a test holding it here.

The other new test is the one that matters for the concern in the issue comment — that an exemption is how the third copy gets justified later. It walks `src/` with `ast` and asserts `Point(...)` appears only in `polling.py`, so a fourth copy fails a test rather than passing review. I confirmed it fails by reintroducing a hand-rolled point in `mock_sensor` and watching it break.

One deliberate behaviour change: `mock_sensor` captured its timestamp before the walk step, and now stamps when the point is built. A few microseconds of arithmetic against a millisecond write precision, no test depended on it, and stamping on read is the convention `serial_sensor` documents.

All 1089 pre-existing tests passed against the refactor untouched, which is the substance of the claim that nothing else changed.

## Test plan

- [x] `pytest --cov --cov-fail-under=100` — 1091 tests, 100% of 2876 statements
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `ruff check` / `ruff format --check` / `typos`
- [x] the structural guard verified to fail on a reintroduced hand-rolled `Point`
- [x] `smoke` green — `serial-sensor` writes through the demo stack's ADC path, so the rewritten point construction is exercised against a real InfluxDB
