### PR TITLE
labmon init and labmon reset-database

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -95,18 +95,37 @@ jobs:
             exit 1
           fi
 
-      - name: Mint an admin token
+      # The README installs the CLI before setting the database up, because
+      # `labmon init` is what sets it up. Installed from the checkout, so
+      # this is the package under test rather than a published one.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - name: Install the command line the way the quickstart does
+        run: uv tool install --editable '.[tui]'
+
+      # The quickstart's own command. It issues the admin token, writes it
+      # into .env, and creates the database with a retention period —
+      # which is the only moment one can be set, since a database created
+      # by a write keeps readings for ever.
+      #
+      # Nothing here execs into a container. The token endpoint is HTTP
+      # like the rest, which is what lets a sensor machine across the lab
+      # run the same command; a job that kept the `docker compose exec`
+      # spelling would leave that claim untested.
+      - name: Set the instance up
         run: |
-          token="$(docker compose exec -T influxdb influxdb3 create token --admin \
-            | grep -oE 'apiv3_[A-Za-z0-9_-]+' | head -1)"
+          "$HOME/.local/bin/labmon" init --retention 1y
+          token="$(grep '^INFLUXDB3_AUTH_TOKEN=' .env | cut -d= -f2-)"
           if [ -z "$token" ]; then
-            echo "no token in the create-token output" >&2
+            echo "labmon init wrote no token into .env" >&2
             exit 1
           fi
+          # Masked as soon as it is read back. `labmon init` never prints
+          # it, but later steps pass it to commands that might, and this
+          # log is public.
           echo "::add-mask::$token"
-          grep -v '^INFLUXDB3_AUTH_TOKEN=' .env > .env.next
-          mv .env.next .env
-          printf 'INFLUXDB3_AUTH_TOKEN=%s\n' "$token" >> .env
 
       # Fails on its own if any service is unhealthy, which is what caught
       # nothing before this job existed.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,6 +58,22 @@ jobs:
           cp .env.example .env
           sed -i 's/^INFLUXDB_NODE_ID=.*/INFLUXDB_NODE_ID=ci/' .env
 
+      # The README installs the CLI before starting anything, because
+      # `labmon init` is what sets the database up. Installed from the
+      # checkout, so this is the package under test rather than a
+      # published one.
+      #
+      # Before the first `docker compose up`, and that ordering is load
+      # bearing rather than cosmetic: setup-uv's cache key globs the whole
+      # working directory, and once the stack has run, `.grafana/data` is
+      # owned by uid 472 and the scan dies on EACCES.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+          enable-cache: true
+      - name: Install the command line the way the quickstart does
+        run: uv tool install --editable '.[tui]'
+
       # The shape docs/deployment.md recommends for a real server is
       # COMPOSE_PROFILES left unset. Every other start in this job carries
       # `demo`, which left the recommended configuration as the one shape
@@ -94,16 +110,6 @@ jobs:
             echo "wanted exactly grafana and influxdb, got: $running" >&2
             exit 1
           fi
-
-      # The README installs the CLI before setting the database up, because
-      # `labmon init` is what sets it up. Installed from the checkout, so
-      # this is the package under test rather than a published one.
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          version: "0.12.5"
-          enable-cache: true
-      - name: Install the command line the way the quickstart does
-        run: uv tool install --editable '.[tui]'
 
       # The quickstart's own command. It issues the admin token, writes it
       # into .env, and creates the database with a retention period —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ so the sections below map onto commit types.
 - **Tab completion** for bash, zsh, fish and powershell, through
   `labmon --install-completion`.
   [#154](https://github.com/quentinmarolleau/labmon/pull/154)
+- **`labmon init`** — issues the instance's admin token, writes it into
+  `.env`, and creates the database. Replaces exec'ing into the container
+  and copying the token out of the terminal, and works from a machine
+  that has no container to exec into. `--retention` sets how long
+  readings are kept, which can only be decided when a database is
+  created.
+  [`docs/deployment.md`](docs/deployment.md#setting-up-and-starting-over)
+- **`labmon reset-database`** — empties the database and creates it
+  again, keeping its retention. The admin token is untouched, so clients
+  keep writing. `docker compose down -v` does not do this: InfluxDB's
+  data is a bind mount rather than a named volume.
+  [`docs/deployment.md`](docs/deployment.md#setting-up-and-starting-over)
 
 #### Elsewhere
 

--- a/README.md
+++ b/README.md
@@ -67,34 +67,84 @@ cd labmon
 cp .env.example .env
 ```
 
-**2. Ask InfluxDB for an auth token.**
+**2. Install the command line.**
+
+```bash
+uv tool install --editable '.[tui]'
+```
+
+**3. Start InfluxDB and set it up.**
 
 InfluxDB issues its own tokens, so it has to be running before it can give
 you one:
 
 ```bash
 docker compose up -d --wait influxdb
+labmon init --retention 1y
+```
+
+`labmon init` asks the server for its admin token, writes it into `.env`,
+and creates the database. `--retention` is optional; without it, readings
+are kept for ever.
+
+> [!IMPORTANT]
+> The token is shown once, and one admin token exists per instance.
+> `labmon init` saves it, so it is in `.env` — keep that file. If it is
+> lost, `influxdb3 create token --admin --regenerate` issues a new one and
+> invalidates the old, which means every client needs the new value.
+
+<details>
+<summary><b>What <code>labmon init</code> actually does</b></summary>
+
+<br>
+
+Three HTTP calls to InfluxDB, and one edit to a file:
+
+1. `POST /api/v3/configure/token/admin` — unauthenticated, because this is
+   the call that issues the credential everything else needs. The server
+   answers with the token once and keeps no copy it will hand back.
+2. The token is written into `.env` as `INFLUXDB3_AUTH_TOKEN=…`. An
+   existing assignment is replaced where it stands, so the comment above
+   it still describes the line beneath, and nothing else in the file is
+   touched — Compose reads this same file.
+3. `POST /api/v3/configure/database` — creates the database named by
+   `INFLUXDB_DATABASE`, with the retention you asked for.
+
+Running it again is safe, and does almost nothing: the server answers
+`409` to a second token and to a second database of the same name, and
+`init` reports both rather than failing. The one thing a re-run *will*
+change is the retention, if you pass `--retention` — that is a property of
+the database rather than of its creation, so it stays adjustable.
+
+Nothing here needs a container. The token endpoint is served over HTTP
+like everything else, so `labmon init` also works from a sensor machine
+across the lab, pointed at the server with `INFLUXDB_HOST`.
+
+</details>
+
+<details>
+<summary><b>Doing it without installing labmon</b></summary>
+
+<br>
+
+The same thing, from inside the container:
+
+```bash
 docker compose exec influxdb influxdb3 create token --admin
 ```
 
-Copy the token into `.env` as `INFLUXDB3_AUTH_TOKEN=…`.
+Then copy the token into `.env` as `INFLUXDB3_AUTH_TOKEN=…` yourself. The
+database is created by the first write, so there is nothing else to do —
+but it will keep readings for ever, since a retention period can only be
+set when the database is created. `labmon init --retention` exists for
+exactly that.
 
-> [!IMPORTANT]
-> The token is shown once, and one admin token exists per instance. Keep
-> it somewhere. If it is lost, `influxdb3 create token --admin
-> --regenerate` issues a new one and invalidates the old, which means
-> every client needs the new value.
+</details>
 
-**3. Start everything.**
+**4. Start everything.**
 
 ```bash
 docker compose up -d --wait
-```
-
-**4. Install the command line.**
-
-```bash
-uv tool install --editable '.[tui]'
 ```
 
 That is the whole setup. Data is already being recorded, so:
@@ -502,6 +552,24 @@ datasource and dashboards are provisioned from files in this repository.
 
 [`docs/configuration.md`](docs/configuration.md) is the index: every
 setting, what reads it, and where it lives.
+
+### Starting over
+
+`labmon reset-database` empties the database and creates it again, keeping
+its retention period. The admin token is untouched, so sensors on other
+machines keep writing without being visited.
+
+```bash
+labmon reset-database              # asks you to type the database name
+labmon reset-database --yes        # for a script that means it
+```
+
+It exists because `docker compose down -v` does not do this: InfluxDB's
+data is a bind mount rather than a named volume, so the alternative was
+`rm -rf .influxdb3/data` with the stack stopped.
+[`docs/deployment.md`](docs/deployment.md#setting-up-and-starting-over)
+covers what a reset does to the data on disk, and why there is no command
+to delete a narrower slice of it.
 
 ### Project structure
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,20 @@ describing hardware. Full description in
 | `--log-level` | `INFO` | `DEBUG` adds a line per reading |
 | `--summary-interval` | `30.0` | Seconds between "still writing" lines; `0` turns them off |
 
+### `labmon init` and `labmon reset-database`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--retention` | unset | How long to keep readings — `1y`, `90d`, `24h`. Unset keeps them for ever |
+| `--database`, `-d` | `$INFLUXDB_DATABASE`, then `lab` | Which database to create or reset |
+| `--hard` | off | `reset-database` only: reclaim the disk space now, rather than leaving a copy the server clears later |
+| `--yes`, `-y` | off | `reset-database` only: skip the confirmation prompt |
+
+`--retention` is accepted only by `init`, and applies whether the database
+is being created or already exists — it is the one thing a second `init`
+changes. See
+[`deployment.md`](deployment.md#setting-up-and-starting-over).
+
 ### `labmon export` and `labmon query`
 
 Both take the same selection flags. See

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -296,6 +296,87 @@ docker compose exec influxdb sh -c \
 Clients buffer while they cannot write (see [`latency.md`](latency.md)), so
 a rotation completed within the queue's depth loses nothing.
 
+## Setting up, and starting over
+
+Two commands cover the database's whole lifecycle.
+
+`labmon init` prepares a fresh instance: it asks for the admin token,
+writes it into `.env`, and creates the database. Run it once per instance,
+against a server that is already up.
+
+```bash
+docker compose up -d --wait influxdb
+labmon init --retention 1y
+```
+
+`--retention` is the reason the command exists at all. A database is
+created by the first write if nothing created it first, but one that
+appears that way keeps readings for ever, and a retention period can only
+be set when the database is created. Re-running `labmon init --retention
+30d` on a database that already exists changes it, which is the one thing
+a second run does.
+
+`labmon reset-database` empties it again:
+
+```bash
+labmon reset-database              # asks you to type the database name
+labmon reset-database --yes        # for a script that means it
+```
+
+> [!WARNING]
+> This deletes every reading. The retention period is read first and put
+> back, so a database that kept a year of readings still does — but the
+> readings themselves are gone.
+
+<details>
+<summary><b>What a reset actually does to the data</b></summary>
+
+<br>
+
+`DELETE /api/v3/configure/database`, then `POST` to create it again under
+the same name. Both succeed immediately, which is what lets the two be one
+command rather than two with a wait between them.
+
+The delete is *soft*, which is InfluxDB's own default. What is on disk is
+renamed to `<name>-<timestamp>` and reclaimed by the server in its own
+time, so a reset run by mistake is recoverable from that copy for a while
+— by hand, and by someone who knows what they are doing, but recoverable.
+It also means the disk space does not come back at once. `--hard` asks for
+it now instead, which is the answer when the reason for the reset is a
+full disk.
+
+Either way the catalogue keeps a record of the deletion, which
+`influxdb3 show databases` lists alongside the live ones.
+
+**The admin token is not touched.** A token belongs to the instance rather
+than to a database, so every sensor machine's `.env` keeps working across a
+reset and no client needs visiting. That is what makes this safe to run on
+a stack with clients on it — unlike rotating the token, above.
+
+</details>
+
+<details>
+<summary><b>Why there is no "delete these readings" command</b></summary>
+
+<br>
+
+Because InfluxDB 3 Core cannot do it. Its delete granularity is a
+database, a table, a cache, a trigger or a token — there is no
+`DELETE ... WHERE`, and the query API is read-only. So a bad afternoon, or
+one sensor's history, cannot be removed by predicate the way an SQL
+database would allow.
+
+What the engine offers instead is retention, which is why `--retention`
+sits on `labmon init`: it drops anything older than the period you set,
+automatically and for ever after.
+
+For anything narrower, the shape that works is to export what you want to
+keep, reset, and write it back — [`export.md`](export.md) already selects
+by measurement, sensor and time window. It is not atomic and it is not
+quick, but it is honest about what it is doing.
+
+</details>
+
 ## Two things in the logs that look wrong
 
 <details>

--- a/src/labmon/admin.py
+++ b/src/labmon/admin.py
@@ -1,0 +1,244 @@
+"""Set up an InfluxDB 3 instance: its admin token, and its database.
+
+Everything here talks to `/api/v3/configure/...` over plain HTTP rather
+than through `InfluxDBClient3`, for two reasons. The first is ordering:
+the token endpoint is what *issues* the credential every other call
+needs, so it has to work before there is a client to build. The second
+is weight — the client pulls in pyarrow and costs about 0.3s to import,
+which is a lot for a command whose whole job is three requests.
+
+Only the operations labmon actually offers are here. InfluxDB 3 Core can
+also create tables, caches and triggers; none of that is labmon's
+business, and wrapping it would mean maintaining a second, worse
+`influxdb3` CLI.
+
+What Core *cannot* do is delete rows: its delete granularity is a
+database, a table, a cache, a trigger or a token, and there is no
+`DELETE ... WHERE`. That is why there is no `--since`/`--sensor-id`
+option anywhere in this module, and why resetting means dropping the
+database rather than deleting what is in it.
+"""
+
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import cast
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Long enough for a server still opening its object store, short enough
+# that a wrong host fails while somebody is still watching.
+TIMEOUT_SECONDS = 30.0
+
+# An endpoint, not a credential — S105 matches the name, not the value.
+_ADMIN_TOKEN_PATH = "/api/v3/configure/token/admin"  # noqa: S105
+_DATABASE_PATH = "/api/v3/configure/database"
+_QUERY_PATH = "/api/v3/query_sql"
+
+# The database holding the server's own catalogue. `system.databases`
+# there is the only place a retention period can be read back: the
+# configure endpoint lists names and nothing else.
+_INTERNAL_DATABASE = "_internal"
+
+# Every database the server serves, with its retention. `deleted = false`
+# drops the tombstones a soft delete leaves behind, so a database dropped
+# and recreated under the same name is reported once.
+_RETENTION_QUERY = (
+    "SELECT database_name, retention_period_ns FROM system.databases"
+    " WHERE deleted = false"
+)
+
+_NANOSECONDS_PER_DAY = 86_400_000_000_000
+
+
+class AdminError(Exception):
+    """A request the server refused, in terms the reader can act on."""
+
+
+def _tls_context() -> ssl.SSLContext | None:
+    """Trust the stack's own CA when INFLUXDB_TLS_CA names it.
+
+    The same variable `labmon.influx.get_client` reads, so a deployment
+    behind the `tls` profile needs configuring once rather than twice. A
+    private root is in no system store, so without this the proxy is
+    unreachable rather than merely untrusted.
+    """
+    ca = os.environ.get("INFLUXDB_TLS_CA")
+    if not ca:
+        return None
+    if not Path(ca).is_file():
+        raise AdminError(
+            f"INFLUXDB_TLS_CA points at {ca!r}, which is not a file."
+            + " It should be the CA certificate exported from the server"
+            + " (see scripts/export-ca.sh)."
+        )
+    return ssl.create_default_context(cafile=ca)
+
+
+def _request(
+    method: str,
+    host: str,
+    path: str,
+    *,
+    token: str | None = None,
+    body: dict[str, object] | None = None,
+    query: dict[str, str] | None = None,
+) -> tuple[int, bytes]:
+    """One call to the configure API, returning its status and body.
+
+    A 4xx comes back as a value rather than an exception because the
+    statuses that matter here are ordinary outcomes: 409 means the thing
+    already exists, which is what a second `labmon init` should report
+    calmly rather than fail on.
+    """
+    url = f"{host.rstrip('/')}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(body).encode() if body is not None else None
+    # The URL is built from the configured host and this module's own
+    # constants, never from a response.
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)  # noqa: S310
+
+    try:
+        # urlopen resolves to `Any`; the handle and its read are pinned.
+        opened = urllib.request.urlopen(  # noqa: S310  # pyright: ignore[reportAny]
+            request, timeout=TIMEOUT_SECONDS, context=_tls_context()
+        )
+        with opened as response:  # pyright: ignore[reportAny]
+            return cast(int, response.status), cast(bytes, response.read())  # pyright: ignore[reportAny]
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+    except urllib.error.URLError as error:
+        raise AdminError(f"cannot reach {host}: {error.reason}") from error
+
+
+def _refuse(status: int, body: bytes, doing: str) -> None:
+    """Turn an unexpected status into a message naming what failed.
+
+    The server's own text is quoted: for a malformed retention it says
+    `invalid value: string "banana", expected a duration`, which is more
+    use than anything this module could invent.
+    """
+    detail = body.decode(errors="replace").strip() or f"HTTP {status}"
+    raise AdminError(f"{doing}: {detail}")
+
+
+def create_admin_token(host: str) -> str | None:
+    """Issue the instance's admin token, or None if it already has one.
+
+    Unauthenticated, because this is the call that bootstraps
+    authentication. It works exactly once per instance: the second
+    attempt is refused with 409 and the original token is not recoverable
+    from the server, which is why `labmon init` writes it to `.env`
+    rather than printing it and hoping.
+    """
+    status, body = _request("POST", host, _ADMIN_TOKEN_PATH)
+    if status == 409:
+        return None
+    if status not in (200, 201):
+        _refuse(status, body, "could not create an admin token")
+    payload = cast(dict[str, object], json.loads(body.decode()))
+    token = payload.get("token")
+    if not isinstance(token, str) or not token:
+        raise AdminError("the server issued a token with no value in it")
+    return token
+
+
+def create_database(host: str, token: str, name: str, retention: str | None) -> bool:
+    """Create `name`, returning False if it was already there.
+
+    `retention` is a duration the server parses — `1y`, `30d`, `24h` —
+    or None for unlimited, which is also what a database gets when a
+    write brings it into existence on its own.
+    """
+    body: dict[str, object] = {"db": name, "retention_period": retention}
+    status, response = _request("POST", host, _DATABASE_PATH, token=token, body=body)
+    if status == 409:
+        return False
+    if status not in (200, 201):
+        _refuse(status, response, f"could not create the database {name!r}")
+    return True
+
+
+def set_retention(host: str, token: str, name: str, retention: str | None) -> None:
+    """Change how long `name` keeps readings, on a database that exists."""
+    body: dict[str, object] = {"db": name, "retention_period": retention}
+    status, response = _request("PUT", host, _DATABASE_PATH, token=token, body=body)
+    if status not in (200, 201):
+        _refuse(status, response, f"could not set the retention on {name!r}")
+
+
+def delete_database(host: str, token: str, name: str, *, hard: bool = False) -> None:
+    """Delete `name` and everything in it.
+
+    Soft by default, which is the server's own default: the data stops
+    being queryable at once, and what is on disk is renamed to
+    `<name>-<timestamp>` and reclaimed later. The original name is free
+    immediately, so a database of the same name can be created straight
+    after — which is what lets a reset be a delete followed by a create
+    rather than two steps with a wait between them.
+
+    `hard` asks for that space back now rather than on the server's own
+    schedule. The renamed copy is a real safety net — an accidental reset
+    is recoverable from it until the server clears it — so this is a
+    deliberate request rather than the default, and it is the answer for
+    a disk that is actually full.
+
+    Either way the catalogue keeps a row for the deletion, which
+    `influxdb3 show databases` lists; `hard` shortens how long the data
+    behind it lives, not whether the record of it does.
+    """
+    query = {"db": name}
+    if hard:
+        query["hard_delete_at"] = "now"
+    status, response = _request(
+        "DELETE", host, _DATABASE_PATH, token=token, query=query
+    )
+    if status not in (200, 204):
+        _refuse(status, response, f"could not delete the database {name!r}")
+
+
+def read_retention(host: str, token: str, name: str) -> str | None:
+    """The retention `name` currently keeps, as a duration, or None.
+
+    Read so a reset can put back what was there. Without it, resetting a
+    database created with `--retention 1y` would quietly return it to
+    keeping everything for ever, and nothing would say so until the disk
+    filled.
+
+    Reported in whole days, which every value the server accepts from
+    labmon resolves to. `1y` is stored as 365.25 days and comes back as
+    `365d`; the quarter day is InfluxDB's own rounding of a year, not
+    something worth carrying through a reset.
+    """
+    query = {"db": _INTERNAL_DATABASE, "q": _RETENTION_QUERY, "format": "json"}
+    status, body = _request("GET", host, _QUERY_PATH, token=token, query=query)
+    if status != 200:
+        _refuse(status, body, "could not read the current retention")
+    rows = cast(list[dict[str, object]], json.loads(body.decode()))
+    for row in rows:
+        if row.get("database_name") != name:
+            continue
+        nanoseconds = row.get("retention_period_ns")
+        if not isinstance(nanoseconds, int):
+            return None
+        return f"{max(1, round(nanoseconds / _NANOSECONDS_PER_DAY))}d"
+    return None
+
+
+def database_exists(host: str, token: str, name: str) -> bool:
+    """Whether `name` is a database the server currently serves."""
+    query = {"db": _INTERNAL_DATABASE, "q": _RETENTION_QUERY, "format": "json"}
+    status, body = _request("GET", host, _QUERY_PATH, token=token, query=query)
+    if status != 200:
+        _refuse(status, body, "could not list the databases")
+    rows = cast(list[dict[str, object]], json.loads(body.decode()))
+    return any(row.get("database_name") == name for row in rows)

--- a/src/labmon/cli/commands/init.py
+++ b/src/labmon/cli/commands/init.py
@@ -1,0 +1,117 @@
+"""`labmon init` — issue the admin token and create the database.
+
+The step this replaces was `docker compose exec influxdb influxdb3
+create token --admin`, followed by copying the token out of the terminal
+and into `.env` by hand. That works on the machine running the stack and
+nowhere else: a sensor machine across the lab has no container to exec
+into. The token endpoint is served over HTTP like everything else, so
+there was never a reason for the container to be involved.
+"""
+
+import logging
+from typing import Annotated
+
+import typer
+
+from labmon import admin, env
+from labmon.cli.options import LogLevelOption
+from labmon.cli.runtime import REFUSED, configure
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+HELP = (
+    "Prepare a fresh InfluxDB instance, and write its token to"
+    + " [bold].env[/bold]."
+    + "\n\n"
+    + "Issues the instance's admin token, saves it, and creates the"
+    + " database. Safe to run twice: the server refuses a second token and"
+    + " a second database of the same name, so a re-run reports what is"
+    + " already there and changes only the retention, if you ask for one."
+    + "\n\n"
+    + "[bold]Examples[/bold]\n\n"
+    + "    labmon init\n"
+    + "    labmon init --retention 1y\n"
+    + "    labmon init --database rig-2 --retention 90d"
+)
+
+Retention = Annotated[
+    str | None,
+    typer.Option(
+        "--retention",
+        help="How long to keep readings, e.g. 1y, 90d, 24h. Left unset they"
+        + " are kept for ever, which is what a database created by a write"
+        + " gets",
+        metavar="DURATION",
+        show_default=False,
+    ),
+]
+
+Database = Annotated[
+    str | None,
+    typer.Option(
+        "--database",
+        "-d",
+        help="Database to create; defaults to INFLUXDB_DATABASE, then 'lab'",
+        metavar="NAME",
+        show_default=False,
+    ),
+]
+
+
+def init(
+    retention: Retention = None,
+    database: Database = None,
+    log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
+) -> None:
+    """Bootstrap the instance, then say what is now true of it."""
+    configure(log_level)
+    # Imported here, not at module scope: `labmon.influx` pulls in the
+    # InfluxDB client, and `test_the_command_line_loads_without_the_heavy_libraries`
+    # holds every `labmon --help` to not paying for it.
+    from labmon.influx import AUTH_TOKEN, auth_token, influx_database, influx_host
+
+    host = influx_host()
+    name = database or influx_database()
+
+    issued = admin.create_admin_token(host)
+    if issued is not None:
+        _ = env.write(AUTH_TOKEN, issued)
+        logger.info(
+            "issued an admin token and saved it",
+            extra={"host": host, "file": env.ENV_FILE},
+        )
+    else:
+        logger.info("instance already has an admin token", extra={"host": host})
+
+    token = issued or auth_token()
+    if token is None:
+        # The server issues the admin token once and keeps no copy it will
+        # hand back, so there is nothing to recover — only a machine that
+        # already has it, or a regeneration that costs every other client.
+        logger.error(
+            "this instance is initialised, but no token is configured here",
+            extra={
+                "reason": f"{AUTH_TOKEN} is unset and {env.ENV_FILE} does not"
+                + " define it. An admin token is shown once and cannot be read"
+                + " back, so copy it from a machine that has it. Regenerating"
+                + " it with `influxdb3 create token --admin --regenerate`"
+                + " invalidates every client's copy, including every sensor"
+            },
+        )
+        raise SystemExit(REFUSED)
+
+    if admin.create_database(host, token, name, retention):
+        logger.info(
+            "created the database",
+            extra={"database": name, "retention": retention or "unlimited"},
+        )
+        return
+
+    logger.info("database already exists", extra={"database": name})
+    if retention is None:
+        return
+    # The one thing a re-run is allowed to change. Creating is refused
+    # when the database is there, but the retention is a property of a
+    # database rather than of its creation, so it stays adjustable.
+    admin.set_retention(host, token, name, retention)
+    logger.info("set the retention", extra={"database": name, "retention": retention})

--- a/src/labmon/cli/commands/reset_database.py
+++ b/src/labmon/cli/commands/reset_database.py
@@ -1,0 +1,125 @@
+"""`labmon reset-database` — drop the database and create it again.
+
+The alternative, before this existed, was `rm -rf .influxdb3/data` in
+the repository root: InfluxDB's data is a bind mount rather than a named
+volume, so `docker compose down -v` leaves it untouched. A recursive
+delete against a hand-typed path is a poor thing to put in a document,
+and it needs the stack stopped. This goes through the API instead.
+
+The token is not touched. Tokens belong to the instance rather than to a
+database, so every sensor machine's `.env` keeps working across a reset
+— which is what makes this safe to run on a stack with clients on it.
+"""
+
+import logging
+from typing import Annotated, cast
+
+import typer
+
+from labmon import admin
+from labmon.cli.commands.init import Database
+from labmon.cli.options import LogLevelOption
+from labmon.cli.runtime import REFUSED, configure
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+HELP = (
+    "Delete every reading in the database, and create it again empty."
+    + "\n\n"
+    + "[bold]This cannot be undone.[/bold] Confirm by typing the database's"
+    + " name, or pass [bold]--yes[/bold] in a script. The retention period"
+    + " is read first and put back, so a database that kept readings for a"
+    + " year still does afterwards."
+    + "\n\n"
+    + "The admin token is left alone: a token belongs to the instance, not"
+    + " to a database, so sensors on other machines keep writing."
+    + "\n\n"
+    + "[bold]Examples[/bold]\n\n"
+    + "    labmon reset-database\n"
+    + "    labmon reset-database --database rig-2 --yes"
+)
+
+Hard = Annotated[
+    bool,
+    typer.Option(
+        "--hard",
+        help="Reclaim the disk space now, instead of leaving a recoverable"
+        + " copy the server clears in its own time",
+    ),
+]
+
+Yes = Annotated[
+    bool,
+    typer.Option(
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt, for a script that means it",
+    ),
+]
+
+
+def reset_database(
+    database: Database = None,
+    hard: Hard = False,
+    yes: Yes = False,
+    log_level: LogLevelOption = "INFO",  # pyright: ignore[reportArgumentType]
+) -> None:
+    """Drop and recreate the database, keeping its retention."""
+    configure(log_level)
+    # Imported here, not at module scope: `labmon.influx` pulls in the
+    # InfluxDB client, and `test_the_command_line_loads_without_the_heavy_libraries`
+    # holds every `labmon --help` to not paying for it.
+    from labmon.influx import AUTH_TOKEN, auth_token, influx_database, influx_host
+
+    host = influx_host()
+    name = database or influx_database()
+
+    token = auth_token()
+    if token is None:
+        logger.error(
+            "no admin token",
+            extra={"reason": f"{AUTH_TOKEN} is unset; run `labmon init` first"},
+        )
+        raise SystemExit(REFUSED)
+
+    if not admin.database_exists(host, token, name):
+        # Creating it here would be a surprising thing for a command whose
+        # name says reset, and the usual cause is a typo in --database.
+        logger.error(
+            "no such database",
+            extra={"database": name, "host": host, "reason": "nothing to reset"},
+        )
+        raise SystemExit(REFUSED)
+
+    # Read before the delete, because afterwards there is nothing to read
+    # it from. Without this a reset silently returns a database that kept
+    # a year of readings to keeping them for ever.
+    retention = admin.read_retention(host, token, name)
+
+    if not yes:
+        # The name typed back rather than a y/n. This destroys readings
+        # that cannot be recovered, and the mistake worth catching is
+        # resetting the right way round on the wrong database.
+        typed = cast(
+            str,
+            typer.prompt(
+                f"This deletes every reading in {name!r} on {host}."
+                + "\nType the database name to confirm"
+            ),
+        )
+        if typed != name:
+            logger.info("not confirmed; nothing was deleted", extra={"database": name})
+            raise SystemExit(REFUSED)
+
+    admin.delete_database(host, token, name, hard=hard)
+    _ = admin.create_database(host, token, name, retention)
+    logger.info(
+        "reset the database",
+        extra={
+            "database": name,
+            "retention": retention or "unlimited",
+            # Named because the two differ in what can be undone, and the
+            # difference is invisible from the command line afterwards.
+            "deleted": "hard" if hard else "soft",
+        },
+    )

--- a/src/labmon/cli/main.py
+++ b/src/labmon/cli/main.py
@@ -13,9 +13,11 @@ separate to keep in step with them.
 import typer
 
 from labmon.cli.commands import export as export_command
+from labmon.cli.commands import init as init_command
 from labmon.cli.commands import mock_sensor as mock_sensor_command
 from labmon.cli.commands import monitor as monitor_command
 from labmon.cli.commands import query as query_command
+from labmon.cli.commands import reset_database as reset_database_command
 from labmon.cli.commands import sensors as sensors_command
 from labmon.cli.commands import serial_sensor as serial_sensor_command
 from labmon.cli.runtime import reporting
@@ -71,6 +73,10 @@ def build_app() -> typer.Typer:
     )
     _ = app.command("export", help=export_command.HELP)(
         reporting(export_command.export)
+    )
+    _ = app.command("init", help=init_command.HELP)(reporting(init_command.init))
+    _ = app.command("reset-database", help=reset_database_command.HELP)(
+        reporting(reset_database_command.reset_database)
     )
     _ = app.command("mock-sensor", help=mock_sensor_command.HELP)(
         reporting(mock_sensor_command.mock_sensor)

--- a/src/labmon/cli/runtime.py
+++ b/src/labmon/cli/runtime.py
@@ -96,6 +96,7 @@ def _report(action: Callable[[], None]) -> None:
     # reaches this function at all.
     from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
 
+    from labmon.admin import AdminError
     from labmon.config import ConfigError
     from labmon.export.query import QueryError
     from labmon.export.window import WindowError
@@ -104,7 +105,7 @@ def _report(action: Callable[[], None]) -> None:
 
     try:
         action()
-    except (ConfigError, ExportError, QueryError, WindowError) as error:
+    except (AdminError, ConfigError, ExportError, QueryError, WindowError) as error:
         logger.error("command failed", extra={"reason": str(error)})
         raise SystemExit(REFUSED) from None
     except InfluxDB3ClientError as error:

--- a/src/labmon/env.py
+++ b/src/labmon/env.py
@@ -76,3 +76,49 @@ def load(directory: Path | None = None) -> Path | None:
         extra={"path": str(path), "applied": len(applied)},
     )
     return path
+
+
+def write(name: str, value: str, directory: Path | None = None) -> Path:
+    """Set `name` to `value` in `./.env`, and return the file written.
+
+    An assignment that is already there is replaced where it stands, so
+    the comment above it — `.env.example` explains every setting — still
+    describes the line beneath it. Anything else in the file is left
+    exactly as it was, because Compose reads this same file and a
+    rewriter that tidied it would be rewriting a deployment's
+    configuration as a side effect of setting one value.
+
+    Created with owner-only permissions when it does not exist. The only
+    value labmon writes here is the admin token, and a token in a
+    world-readable file in a shared checkout is the kind of thing nobody
+    notices until it matters. An existing file's permissions are left
+    alone: whatever the deployment chose is not this function's to
+    override.
+    """
+    path = (directory or Path.cwd()) / ENV_FILE
+    assignment = f"{name}={value}"
+
+    if path.is_file():
+        lines = path.read_text(encoding="utf-8").splitlines()
+        prefix = f"{name}="
+        replaced = False
+        for index, line in enumerate(lines):
+            if line.startswith(prefix):
+                lines[index] = assignment
+                replaced = True
+                break
+        if not replaced:
+            lines.append(assignment)
+        _ = path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    else:
+        # Opened rather than written through `write_text`, so the mode is
+        # applied as the file is created rather than after it has briefly
+        # existed holding a token at the default umask.
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            _ = handle.write(assignment + "\n")
+
+    # The value is deliberately not logged: the one setting labmon writes
+    # here is a credential.
+    logger.info("wrote environment file", extra={"path": str(path), "setting": name})
+    return path

--- a/src/labmon/influx.py
+++ b/src/labmon/influx.py
@@ -23,6 +23,24 @@ def _setting(name: str, default: str) -> str:
     return os.environ.get(name) or default
 
 
+# The name of the variable, not a value. S105 matches on the name.
+AUTH_TOKEN = "INFLUXDB3_AUTH_TOKEN"  # noqa: S105
+
+
+def auth_token() -> str | None:
+    """The admin token this machine holds, or None.
+
+    `get_client` reads the same variable and raises when it is absent,
+    which is right for a command that cannot proceed without it. `labmon
+    init` can: not having a token is the ordinary state of a machine
+    about to be given one, so it asks rather than being stopped.
+
+    An empty value counts as absent, matching `_setting` and the
+    `.env.example` that ships this variable blank.
+    """
+    return os.environ.get(AUTH_TOKEN) or None
+
+
 def influx_host() -> str:
     """Where readings are written, from INFLUXDB_HOST.
 
@@ -91,7 +109,7 @@ def get_client() -> InfluxDBClient3:
 
     return InfluxDBClient3(
         host=host,
-        token=os.environ["INFLUXDB3_AUTH_TOKEN"],
+        token=os.environ[AUTH_TOKEN],
         database=influx_database(),
         **options,
     )

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -32,9 +32,14 @@ class Invocation:
     stderr: str
 
 
-def invoke(app: typer.Typer, args: list[str]) -> Invocation:
-    """Run `app` with `args` and return its unstyled result."""
-    result = _runner.invoke(app, args)
+def invoke(app: typer.Typer, args: list[str], stdin: str | None = None) -> Invocation:
+    """Run `app` with `args` and return its unstyled result.
+
+    `stdin` answers a command that prompts — `reset-database` asks for
+    the database name before destroying it, and a test that could not
+    answer would hang rather than fail.
+    """
+    result = _runner.invoke(app, args, input=stdin)
     return Invocation(
         exit_code=result.exit_code,
         output=_ANSI.sub("", result.output),

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,343 @@
+"""The configure API calls behind `labmon init` and `reset-database`.
+
+Every request is faked at `urllib.request.urlopen`. What is asserted is
+the shape labmon sends and what it makes of each answer — particularly
+the statuses that are not failures: a 409 means the thing is already
+there, which is the ordinary result of running `init` twice.
+
+The real endpoints are exercised by the smoke job, which runs `init`
+against a live server as the quickstart does.
+"""
+
+import io
+import json
+import ssl
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from email.message import Message
+from pathlib import Path
+from typing import Self, cast
+
+import certifi
+import pytest
+
+from labmon import admin
+
+
+class _Recorder:
+    """Stands in for `urlopen`, keeping the requests it was given."""
+
+    def __init__(self, *answers: object) -> None:
+        self.answers: list[object] = list(answers)
+        self.requests: list[urllib.request.Request] = []
+        self.contexts: list[ssl.SSLContext | None] = []
+
+    def __call__(self, request: urllib.request.Request, **kwargs: object) -> object:
+        self.requests.append(request)
+        self.contexts.append(cast("ssl.SSLContext | None", kwargs.get("context")))
+        answer = self.answers.pop(0) if len(self.answers) > 1 else self.answers[0]
+        if isinstance(answer, BaseException):
+            raise answer
+        return answer
+
+    @property
+    def sent(self) -> dict[str, object]:
+        """The JSON body of the single request made."""
+        assert len(self.requests) == 1, f"wanted one request, got {len(self.requests)}"
+        return cast(dict[str, object], json.loads(cast(bytes, self.requests[0].data)))
+
+
+def _response(payload: object, status: int = 200) -> object:
+    """Something `urlopen` could have returned for a successful call."""
+    body = json.dumps(payload).encode()
+
+    class _Response:
+        def __init__(self) -> None:
+            self.status: int = status
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return body
+
+    return _Response()
+
+
+def _http_error(status: int, body: str) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "http://x", status, "nope", Message(), io.BytesIO(body.encode())
+    )
+
+
+Install = Callable[..., _Recorder]
+
+
+@pytest.fixture
+def urlopen(monkeypatch: pytest.MonkeyPatch) -> Install:
+    """Install a recorder in place of the network, per test."""
+
+    def install(*answers: object) -> _Recorder:
+        recorder = _Recorder(*answers)
+        monkeypatch.setattr("urllib.request.urlopen", recorder)
+        return recorder
+
+    return install
+
+
+class TestAdminToken:
+    """The one unauthenticated call, which bootstraps the rest."""
+
+    def test_a_fresh_instance_issues_a_token(self, urlopen: Install) -> None:
+        recorder = urlopen(_response({"token": "apiv3_abc"}))
+
+        assert admin.create_admin_token("http://influx:8181") == "apiv3_abc"
+
+        [request] = recorder.requests
+        assert request.full_url == "http://influx:8181/api/v3/configure/token/admin"
+        assert request.get_method() == "POST"
+        # No credential: this is the call that issues one.
+        assert request.get_header("Authorization") is None
+
+    def test_a_trailing_slash_on_the_host_does_not_double_up(
+        self, urlopen: Install
+    ) -> None:
+        recorder = urlopen(_response({"token": "apiv3_abc"}))
+
+        _ = admin.create_admin_token("http://influx:8181/")
+
+        assert recorder.requests[0].full_url.count("//") == 1
+
+    def test_an_initialised_instance_reports_no_token_rather_than_failing(
+        self, urlopen: Install
+    ) -> None:
+        """409 is the ordinary answer to running `init` a second time."""
+        _ = urlopen(_http_error(409, "token name already exists, _admin"))
+
+        assert admin.create_admin_token("http://influx:8181") is None
+
+    def test_another_failure_carries_the_server_s_own_words(
+        self, urlopen: Install
+    ) -> None:
+        _ = urlopen(_http_error(500, "catalog unavailable"))
+
+        with pytest.raises(admin.AdminError, match="catalog unavailable"):
+            _ = admin.create_admin_token("http://influx:8181")
+
+    def test_a_token_with_no_value_is_refused(self, urlopen: Install) -> None:
+        """Better than writing an empty credential into `.env`."""
+        _ = urlopen(_response({"token": ""}))
+
+        with pytest.raises(admin.AdminError, match="no value in it"):
+            _ = admin.create_admin_token("http://influx:8181")
+
+    def test_an_unreachable_host_names_itself(self, urlopen: Install) -> None:
+        """The usual cause is a command run against the wrong host."""
+        _ = urlopen(urllib.error.URLError("connection refused"))
+
+        with pytest.raises(admin.AdminError, match="cannot reach http://influx:8181"):
+            _ = admin.create_admin_token("http://influx:8181")
+
+
+class TestDatabase:
+    """Create, update and delete, and what each status means."""
+
+    def test_creating_sends_the_name_and_retention(self, urlopen: Install) -> None:
+        recorder = urlopen(_response({}))
+
+        assert admin.create_database("http://x", "tok", "lab", "1y") is True
+
+        assert recorder.sent == {"db": "lab", "retention_period": "1y"}
+        assert recorder.requests[0].get_header("Authorization") == "Bearer tok"
+
+    def test_no_retention_is_sent_as_null(self, urlopen: Install) -> None:
+        """Which the server reads as unlimited, matching an auto-created one."""
+        recorder = urlopen(_response({}))
+
+        _ = admin.create_database("http://x", "tok", "lab", None)
+
+        assert recorder.sent == {"db": "lab", "retention_period": None}
+
+    def test_an_existing_database_is_not_an_error(self, urlopen: Install) -> None:
+        _ = urlopen(_http_error(409, "attempted to create a resource that exists"))
+
+        assert admin.create_database("http://x", "tok", "lab", None) is False
+
+    def test_a_rejected_retention_quotes_the_server(self, urlopen: Install) -> None:
+        """The server says `expected a duration`, which beats anything here."""
+        _ = urlopen(_http_error(400, 'invalid value: string "banana"'))
+
+        with pytest.raises(admin.AdminError, match="banana"):
+            _ = admin.create_database("http://x", "tok", "lab", "banana")
+
+    def test_setting_retention_uses_put(self, urlopen: Install) -> None:
+        recorder = urlopen(_response({}))
+
+        admin.set_retention("http://x", "tok", "lab", "30d")
+
+        assert recorder.requests[0].get_method() == "PUT"
+        assert recorder.sent == {"db": "lab", "retention_period": "30d"}
+
+    def test_a_refused_retention_change_is_reported(self, urlopen: Install) -> None:
+        _ = urlopen(_http_error(404, "database not found"))
+
+        with pytest.raises(admin.AdminError, match="database not found"):
+            admin.set_retention("http://x", "tok", "lab", "30d")
+
+    def test_deleting_is_soft_by_default(self, urlopen: Install) -> None:
+        """The renamed copy is what makes an accidental reset recoverable."""
+        recorder = urlopen(_response({}))
+
+        admin.delete_database("http://x", "tok", "lab")
+
+        url = recorder.requests[0].full_url
+        assert recorder.requests[0].get_method() == "DELETE"
+        assert "db=lab" in url
+        assert "hard_delete_at" not in url
+
+    def test_a_hard_delete_asks_for_the_space_now(self, urlopen: Install) -> None:
+        recorder = urlopen(_response({}))
+
+        admin.delete_database("http://x", "tok", "lab", hard=True)
+
+        assert "hard_delete_at=now" in recorder.requests[0].full_url
+
+    def test_a_refused_delete_is_reported(self, urlopen: Install) -> None:
+        _ = urlopen(_http_error(404, "database not found"))
+
+        with pytest.raises(admin.AdminError, match="could not delete"):
+            admin.delete_database("http://x", "tok", "lab")
+
+
+# What `SELECT ... FROM system.databases` answers: one row with a
+# retention, one without (created by a write), and the server's own.
+_ROWS = [
+    {"database_name": "_internal", "retention_period_ns": 604_800_000_000_000},
+    {"database_name": "lab", "retention_period_ns": 2_592_000_000_000_000},
+    {"database_name": "scratch"},
+]
+
+
+class TestReadingTheCatalogue:
+    """Retention and existence, read from `_internal`.
+
+    The configure endpoint lists names and nothing else, so this is the
+    only way to learn what retention a database has — which a reset needs
+    before it destroys the database holding it.
+    """
+
+    def test_retention_comes_back_in_days(self, urlopen: Install) -> None:
+        _ = urlopen(_response(_ROWS))
+
+        assert admin.read_retention("http://x", "tok", "lab") == "30d"
+
+    def test_a_year_survives_the_round_trip(self, urlopen: Install) -> None:
+        """The server stores `1y` as 365.25 days; a reset puts back 365d.
+
+        The quarter day is InfluxDB's own definition of a year rather
+        than anything labmon chose, and carrying it through a reset would
+        mean inventing a duration the user never typed.
+        """
+        rows = [{"database_name": "lab", "retention_period_ns": 31_557_600_000_000_000}]
+        _ = urlopen(_response(rows))
+
+        assert admin.read_retention("http://x", "tok", "lab") == "365d"
+
+    def test_an_unlimited_database_reports_none(self, urlopen: Install) -> None:
+        """A database a write created carries no retention at all."""
+        _ = urlopen(_response(_ROWS))
+
+        assert admin.read_retention("http://x", "tok", "scratch") is None
+
+    def test_an_unknown_database_reports_none(self, urlopen: Install) -> None:
+        _ = urlopen(_response(_ROWS))
+
+        assert admin.read_retention("http://x", "tok", "absent") is None
+
+    def test_a_sub_day_retention_does_not_round_to_nothing(
+        self, urlopen: Install
+    ) -> None:
+        """`24h` is a day; anything shorter would otherwise become `0d`.
+
+        A reset that put back `0d` would ask the server to keep nothing,
+        which is a far worse answer than keeping a day too much.
+        """
+        rows = [{"database_name": "lab", "retention_period_ns": 3_600_000_000_000}]
+        _ = urlopen(_response(rows))
+
+        assert admin.read_retention("http://x", "tok", "lab") == "1d"
+
+    def test_the_query_ignores_tombstones(self, urlopen: Install) -> None:
+        """A soft delete leaves a `<name>-<timestamp>` row marked deleted.
+
+        Without the filter, a database dropped and recreated would be
+        reported twice and the wrong row could answer first.
+        """
+        recorder = urlopen(_response(_ROWS))
+
+        _ = admin.read_retention("http://x", "tok", "lab")
+
+        assert "deleted+%3D+false" in recorder.requests[0].full_url
+
+    def test_existence_is_read_from_the_same_place(self, urlopen: Install) -> None:
+        _ = urlopen(_response(_ROWS))
+
+        assert admin.database_exists("http://x", "tok", "lab") is True
+
+    def test_a_database_that_is_not_there(self, urlopen: Install) -> None:
+        _ = urlopen(_response(_ROWS))
+
+        assert admin.database_exists("http://x", "tok", "absent") is False
+
+    def test_a_failed_listing_is_reported(self, urlopen: Install) -> None:
+        _ = urlopen(_http_error(500, "catalog unavailable"))
+
+        with pytest.raises(admin.AdminError, match="could not list the databases"):
+            _ = admin.database_exists("http://x", "tok", "lab")
+
+    def test_a_failed_retention_read_is_reported(self, urlopen: Install) -> None:
+        _ = urlopen(_http_error(500, "catalog unavailable"))
+
+        with pytest.raises(admin.AdminError, match="could not read the current"):
+            _ = admin.read_retention("http://x", "tok", "lab")
+
+
+class TestTls:
+    """`INFLUXDB_TLS_CA`, so the `tls` profile needs configuring once."""
+
+    def test_no_ca_uses_the_system_store(
+        self, urlopen: Install, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("INFLUXDB_TLS_CA", raising=False)
+        recorder = urlopen(_response({"token": "apiv3_a"}))
+
+        _ = admin.create_admin_token("https://caddy:8443")
+
+        assert recorder.contexts == [None]
+
+    def test_a_ca_is_trusted(
+        self, urlopen: Install, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        certificate = tmp_path / "ca.crt"
+        _ = certificate.write_bytes(Path(certifi.where()).read_bytes())
+        monkeypatch.setenv("INFLUXDB_TLS_CA", str(certificate))
+        recorder = urlopen(_response({"token": "apiv3_a"}))
+
+        _ = admin.create_admin_token("https://caddy:8443")
+
+        [context] = recorder.contexts
+        assert isinstance(context, ssl.SSLContext)
+        assert context.get_ca_certs()
+
+    def test_a_ca_that_is_not_a_file_names_the_variable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The same message `get_client` gives, for the same typo."""
+        monkeypatch.setenv("INFLUXDB_TLS_CA", str(tmp_path / "absent.crt"))
+
+        with pytest.raises(admin.AdminError, match="INFLUXDB_TLS_CA points at"):
+            _ = admin.create_admin_token("https://caddy:8443")

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,351 @@
+"""`labmon init` and `labmon reset-database`, driven through the CLI.
+
+The admin calls are faked at `labmon.admin`, so what these check is the
+command's own decisions: what it writes, what it refuses, and what it
+says afterwards. `tests/test_admin.py` covers the requests themselves,
+and the smoke job runs `init` against a live server.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from labmon import admin, env
+from labmon.cli.main import build_app
+from tests.cli_runner import invoke
+
+
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a logfmt field off a record.
+
+    `extra=` fields become attributes a type checker cannot know about,
+    the same way `tests/test_polling.py` reads them.
+    """
+    return getattr(record, name)  # pyright: ignore[reportAny]
+
+
+def _already_initialised(_host: str) -> str | None:
+    """A server that has issued its admin token already."""
+    return None
+
+
+def _already_exists(*_args: object, **_kwargs: object) -> bool:
+    """A database that is already there."""
+    return False
+
+
+def _absent(*_args: object, **_kwargs: object) -> bool:
+    """A database that is not."""
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _local_host(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host and no inherited token, whatever the machine running this.
+
+    A contributor with direnv has a real token exported, and `env.load`
+    deliberately lets the process environment win over `.env` — so
+    without this the suite would read that token and these tests would
+    pass or fail on somebody's personal setup.
+    """
+    monkeypatch.setenv("INFLUXDB_HOST", "http://influx:8181")
+    monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("INFLUXDB_DATABASE", raising=False)
+
+
+class _Calls:
+    """What the command asked the admin API to do, in order."""
+
+    def __init__(self) -> None:
+        self.made: list[tuple[object, ...]] = []
+
+    def record(self, name: str, *args: object) -> None:
+        self.made.append((name, *args))
+
+    @property
+    def names(self) -> list[str]:
+        return [str(call[0]) for call in self.made]
+
+
+@pytest.fixture
+def calls(monkeypatch: pytest.MonkeyPatch) -> _Calls:
+    """Fake the whole admin surface, recording what was asked of it."""
+    recorded = _Calls()
+
+    def create_admin_token(host: str) -> str | None:
+        recorded.record("create_admin_token", host)
+        return "apiv3_issued"
+
+    def create_database(
+        _host: str, _token: str, name: str, retention: str | None
+    ) -> bool:
+        recorded.record("create_database", name, retention)
+        return True
+
+    def set_retention(
+        _host: str, _token: str, name: str, retention: str | None
+    ) -> None:
+        recorded.record("set_retention", name, retention)
+
+    def delete_database(
+        _host: str, _token: str, name: str, *, hard: bool = False
+    ) -> None:
+        recorded.record("delete_database", name, hard)
+
+    def read_retention(_host: str, _token: str, name: str) -> str | None:
+        recorded.record("read_retention", name)
+        return "30d"
+
+    def database_exists(_host: str, _token: str, name: str) -> bool:
+        recorded.record("database_exists", name)
+        return True
+
+    monkeypatch.setattr(admin, "create_admin_token", create_admin_token)
+    monkeypatch.setattr(admin, "create_database", create_database)
+    monkeypatch.setattr(admin, "set_retention", set_retention)
+    monkeypatch.setattr(admin, "delete_database", delete_database)
+    monkeypatch.setattr(admin, "read_retention", read_retention)
+    monkeypatch.setattr(admin, "database_exists", database_exists)
+    return recorded
+
+
+class TestInit:
+    """The command that turns a bare instance into a working one."""
+
+    def test_it_issues_a_token_saves_it_and_creates_the_database(
+        self, calls: _Calls, tmp_path: Path
+    ) -> None:
+        result = invoke(build_app(), ["init", "--retention", "1y"])
+
+        assert result.exit_code == 0
+        assert calls.names == ["create_admin_token", "create_database"]
+        assert calls.made[1] == ("create_database", "lab", "1y")
+        written = (tmp_path / env.ENV_FILE).read_text(encoding="utf-8")
+        assert "INFLUXDB3_AUTH_TOKEN=apiv3_issued" in written
+
+    @pytest.mark.usefixtures("calls")
+    def test_a_new_env_file_is_readable_only_by_its_owner(self, tmp_path: Path) -> None:
+        """It holds a credential from the moment it exists.
+
+        A world-readable token in a shared checkout is the kind of thing
+        nobody notices until it matters.
+        """
+        _ = invoke(build_app(), ["init"])
+
+        assert (tmp_path / env.ENV_FILE).stat().st_mode & 0o077 == 0
+
+    def test_no_retention_asks_for_none(self, calls: _Calls) -> None:
+        """Which is what a database created by a write gets anyway."""
+        _ = invoke(build_app(), ["init"])
+
+        assert calls.made[1] == ("create_database", "lab", None)
+
+    def test_the_database_can_be_named(self, calls: _Calls) -> None:
+        _ = invoke(build_app(), ["init", "--database", "rig-2"])
+
+        assert calls.made[1] == ("create_database", "rig-2", None)
+
+    def test_it_defaults_to_the_configured_database(
+        self, calls: _Calls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("INFLUXDB_DATABASE", "from-env")
+
+        _ = invoke(build_app(), ["init"])
+
+        assert calls.made[1] == ("create_database", "from-env", None)
+
+    @pytest.mark.usefixtures("calls")
+    def test_a_second_run_changes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Both server calls refuse, and the command says so calmly."""
+        monkeypatch.setattr(admin, "create_admin_token", _already_initialised)
+        monkeypatch.setattr(admin, "create_database", _already_exists)
+        monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "apiv3_existing")
+
+        result = invoke(build_app(), ["init"])
+
+        assert result.exit_code == 0
+        assert "already exists" in result.output
+        # Nothing was written: the token in hand is the one that works.
+        assert not (tmp_path / env.ENV_FILE).exists()
+
+    def test_a_second_run_can_still_change_the_retention(
+        self, calls: _Calls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Creation is refused; retention is a property of the database."""
+        monkeypatch.setattr(admin, "create_admin_token", _already_initialised)
+        monkeypatch.setattr(admin, "create_database", _already_exists)
+        monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "apiv3_existing")
+
+        _ = invoke(build_app(), ["init", "--retention", "90d"])
+
+        assert ("set_retention", "lab", "90d") in calls.made
+
+    def test_an_initialised_instance_with_no_token_here_is_refused(
+        self, calls: _Calls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The one case that cannot be repaired by trying again.
+
+        An admin token is shown once and the server keeps no copy it will
+        hand back, so the command has to say where one can come from
+        rather than appear to do something.
+        """
+        monkeypatch.setattr(admin, "create_admin_token", _already_initialised)
+
+        result = invoke(build_app(), ["init"])
+
+        assert result.exit_code == 2
+        assert "no token is configured here" in result.output
+        assert "regenerate" in result.output
+        assert "create_database" not in calls.names
+
+    def test_a_server_that_is_not_there_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def refuse(_host: str) -> str | None:
+            raise admin.AdminError("cannot reach http://influx:8181: refused")
+
+        monkeypatch.setattr(admin, "create_admin_token", refuse)
+
+        result = invoke(build_app(), ["init"])
+
+        assert result.exit_code == 2
+        assert "cannot reach" in result.output
+
+
+@pytest.fixture
+def token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token in the environment, as `labmon init` would have left."""
+    monkeypatch.setenv("INFLUXDB3_AUTH_TOKEN", "apiv3_configured")
+
+
+@pytest.mark.usefixtures("token")
+class TestResetDatabase:
+    """The destructive one, and what stands between it and a mistake."""
+
+    def test_confirmed_by_name_it_drops_and_recreates(self, calls: _Calls) -> None:
+        result = invoke(build_app(), ["reset-database", "--yes"])
+
+        assert result.exit_code == 0
+        assert calls.names == [
+            "database_exists",
+            # Read before the delete, because afterwards there is nothing
+            # left to read it from.
+            "read_retention",
+            "delete_database",
+            "create_database",
+        ]
+        assert calls.made[3] == ("create_database", "lab", "30d")
+
+    def test_it_is_soft_unless_asked_otherwise(self, calls: _Calls) -> None:
+        _ = invoke(build_app(), ["reset-database", "--yes"])
+
+        assert calls.made[2] == ("delete_database", "lab", False)
+
+    def test_hard_reclaims_the_space(self, calls: _Calls) -> None:
+        _ = invoke(build_app(), ["reset-database", "--yes", "--hard"])
+
+        assert calls.made[2] == ("delete_database", "lab", True)
+
+    def test_the_prompt_wants_the_database_name(self, calls: _Calls) -> None:
+        """A y/n would be answered by reflex; a name has to be read."""
+        result = invoke(build_app(), ["reset-database"], stdin="lab\n")
+
+        assert result.exit_code == 0
+        assert "delete_database" in calls.names
+
+    def test_a_wrong_name_deletes_nothing(self, calls: _Calls) -> None:
+        """The mistake worth catching is resetting the wrong database."""
+        result = invoke(build_app(), ["reset-database"], stdin="lba\n")
+
+        assert result.exit_code == 2
+        assert "nothing was deleted" in result.output
+        assert "delete_database" not in calls.names
+
+    def test_a_database_that_is_not_there_is_not_created(
+        self, calls: _Calls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`reset` creating a database would be a surprising reading of it."""
+        monkeypatch.setattr(admin, "database_exists", _absent)
+
+        result = invoke(build_app(), ["reset-database", "--database", "typo", "--yes"])
+
+        assert result.exit_code == 2
+        assert "no such database" in result.output
+        assert "delete_database" not in calls.names
+
+    def test_without_a_token_it_points_at_init(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing can be reset before the instance has been set up."""
+        monkeypatch.delenv("INFLUXDB3_AUTH_TOKEN", raising=False)
+
+        result = invoke(build_app(), ["reset-database", "--yes"])
+
+        assert result.exit_code == 2
+        assert "labmon init" in result.output
+
+
+class TestEnvWrite:
+    """Editing `.env` in place, which Compose reads as well."""
+
+    def test_an_existing_assignment_is_replaced_where_it_stands(
+        self, tmp_path: Path
+    ) -> None:
+        """So the comment above it still describes the line beneath."""
+        path = tmp_path / env.ENV_FILE
+        _ = path.write_text(
+            "# The token InfluxDB issued.\nINFLUXDB3_AUTH_TOKEN=\nOTHER=keep\n",
+            encoding="utf-8",
+        )
+
+        _ = env.write("INFLUXDB3_AUTH_TOKEN", "apiv3_new", tmp_path)
+
+        assert path.read_text(encoding="utf-8") == (
+            "# The token InfluxDB issued.\nINFLUXDB3_AUTH_TOKEN=apiv3_new\nOTHER=keep\n"
+        )
+
+    def test_a_missing_assignment_is_appended(self, tmp_path: Path) -> None:
+        path = tmp_path / env.ENV_FILE
+        _ = path.write_text("OTHER=keep\n", encoding="utf-8")
+
+        _ = env.write("INFLUXDB3_AUTH_TOKEN", "apiv3_new", tmp_path)
+
+        assert path.read_text(encoding="utf-8") == (
+            "OTHER=keep\nINFLUXDB3_AUTH_TOKEN=apiv3_new\n"
+        )
+
+    def test_a_file_that_does_not_exist_is_created(self, tmp_path: Path) -> None:
+        written = env.write("INFLUXDB3_AUTH_TOKEN", "apiv3_new", tmp_path)
+
+        assert written == tmp_path / env.ENV_FILE
+        assert written.read_text(encoding="utf-8") == "INFLUXDB3_AUTH_TOKEN=apiv3_new\n"
+
+    def test_the_value_is_never_logged(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The only setting labmon writes here is a credential."""
+        with caplog.at_level(logging.INFO):
+            _ = env.write("INFLUXDB3_AUTH_TOKEN", "apiv3_secret", tmp_path)
+
+        [record] = caplog.records
+        rendered = caplog.text + repr(sorted(record.__dict__.items(), key=str))
+        assert "apiv3_secret" not in rendered
+        # The name is logged, because knowing which setting changed is the
+        # point of the line.
+        assert _field(record, "setting") == "INFLUXDB3_AUTH_TOKEN"
+
+    def test_a_name_that_is_a_prefix_of_another_is_not_confused(
+        self, tmp_path: Path
+    ) -> None:
+        """`INFLUXDB_DATABASE=` must not be matched by `INFLUXDB_DATA`."""
+        path = tmp_path / env.ENV_FILE
+        _ = path.write_text("INFLUXDB_DATABASE=lab\n", encoding="utf-8")
+
+        _ = env.write("INFLUXDB_DATA", "x", tmp_path)
+
+        assert "INFLUXDB_DATABASE=lab" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
Two new commands, and the configure-API client behind them.

```bash
labmon init [--retention 1y] [--database lab]
labmon reset-database [--hard] [--yes]
```

`init` replaces the quickstart's worst step — exec into the container, read a token off the terminal, paste it into `.env`. That never worked from a machine without the stack on it, and the token endpoint is plain HTTP, so the container was never needed. `--retention` is the reason creating a database is worth a command at all: a write creates one on its own, but always with unlimited retention, and a retention period can only be set at creation.

`reset-database` exists because `docker compose down -v` doesn't do it. InfluxDB's data is a bind mount rather than a named volume, so the alternative was `rm -rf .influxdb3/data` against a hand-typed path with the stack stopped.

**Everything here was checked against a live `influxdb:3-core`, not assumed.** A second `init` gets 409 from both the token and the database endpoints, so re-running is safe without labmon doing anything clever — it reports both and changes only the retention, if asked. A reset reads the retention before dropping and puts it back. `1y` stores as 365.25 days and reads back as `365d`. And the admin token survives a reset, because a token belongs to the instance rather than to a database — which is what makes this safe to run on a stack with sensors on it.

Three things worth a reviewer's attention.

**An existing test caught a regression I'd have shipped.** `test_the_command_line_loads_without_the_heavy_libraries` failed because the new commands imported `labmon.influx` at module scope, which drags pyarrow and numpy into every `labmon --help` and every Tab press. I first tried deferring the client import inside `influx.py` — fixes it globally, but breaks five existing tests that patch the module attribute, so I reverted that and used the pattern `runtime._report` already uses. The global fix is still worth doing one day; it doesn't belong here.

**Soft delete is the default, and I've exposed the choice rather than hiding it.** A delete renames the data to `<name>-<timestamp>` and reclaims it later, so an accidental reset is recoverable for a while — but the disk space doesn't come back at once. `--hard` asks for it now, mirroring `influxdb3`'s own `--hard-delete`. What I could verify is that `--hard` shortens how long the data lives; the catalogue keeps a deletion record either way, and the docstring says that rather than more.

**The smoke job changed too.** It opens by calling itself "deliberately the README's quickstart, command for command", and the quickstart no longer execs into anything. It now installs the CLI and runs `labmon init --retention 1y`, which makes CI the end-to-end test of the new command — everything below that step depends on a token `init` issued itself. The token is masked as soon as it is read back, since that log is public.

The `deployment.md` drop-downs also write down the answer to a question that came up twice while designing this: there is no command to delete a narrower slice than a whole database because InfluxDB 3 Core has no `DELETE ... WHERE` at all. Retention is what it offers instead.

## Test plan

- [x] `pytest --cov --cov-fail-under=100` — 1140 tests (+51), 100% of 3065 statements
- [x] `basedpyright` — 0 errors, 0 warnings
- [x] `ruff check` / `ruff format --check` / `typos`
- [x] every relative link and heading anchor across README, CHANGELOG and `docs/` resolves
- [x] actionlint clean on the changed workflow
- [x] the quickstart rehearsed as written against a live server: `.env` came out structurally identical to `.env.example`, only values changed
- [x] `smoke` green — `labmon init` issued the token and created `lab` with a 1y retention on the runner, and every step below it used that token
