### PR TITLE
fix(grafana): a plugin that cannot be fetched no longer stops the stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,9 +49,12 @@ COMPOSE_PROFILES=demo
 LOKI_RETENTION_PERIOD=
 
 # Grafana panel plugins to install at startup, as a comma-separated list of
-# `id@version`. The demo dashboard's needle gauge needs this one. Leave it
-# blank/unset on a server deployment: Grafana then installs nothing and
-# needs no network at boot, at the cost of that one panel not rendering.
+# `id@version`. The demo dashboard's needle gauge needs this one, and the
+# first boot fetches it from grafana.com. A fetch that fails is logged and
+# Grafana comes up regardless, with that panel reading "plugin not found".
+# Leave it blank/unset on a server deployment: Grafana then installs
+# nothing and needs no network at boot, at the cost of that one panel not
+# rendering.
 GRAFANA_PLUGINS=briangann-gauge-panel@2.2.0
 
 # Where the TLS proxy answers, when the "tls" profile is active — one

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -473,3 +473,89 @@ jobs:
       - name: Stop
         if: always()
         run: COMPOSE_PROFILES=demo,logs,tls docker compose down -v
+
+  # The other half of the first-run story. `cold-start` above always has a
+  # route to grafana.com, so the state a bench behind a proxy actually
+  # meets — a plugin Grafana cannot fetch — is the one no runner reaches by
+  # accident. Asked for with an id that does not exist, which fails the
+  # same way an unreachable registry does and needs no network trickery.
+  #
+  # Its own job rather than a step in `cold-start`, because it needs a .env
+  # seeded differently and a stack it is free to fail — and because a job
+  # re-runs on its own where a step in the middle of a twenty-minute
+  # sequence does not, which is why ci.yml keeps `lint`, `typecheck` and
+  # `typos` apart too.
+  #
+  # Shell in the workflow rather than a `scripts/smoke_*.py` beside the
+  # other two: anything under scripts/ sits inside the 100% coverage gate
+  # and would need a test file of its own, which is a lot of apparatus for
+  # three assertions against a running container.
+  plugin-fetch-failure:
+    name: an unfetchable plugin does not stop the stack
+    runs-on: ubuntu-latest
+    # Two containers and no build; the budget is image pulls.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Ask for a plugin that cannot be installed
+        run: |
+          cp .env.example .env
+          sed -i 's/^INFLUXDB_NODE_ID=.*/INFLUXDB_NODE_ID=ci/' .env
+          sed -i 's/^GRAFANA_PLUGINS=.*/GRAFANA_PLUGINS=labmon-no-such-panel@1.0.0/' .env
+          grep '^GRAFANA_PLUGINS=' .env
+
+      # The assertion is the exit status. With GF_PLUGINS_PREINSTALL_SYNC
+      # this step is where the job ends: Grafana exits on the failed
+      # install, `restart: unless-stopped` starts it again, and --wait
+      # times out on a container that is never healthy.
+      - name: The stack still comes up
+        run: COMPOSE_PROFILES='' docker compose up -d --wait
+
+      - name: Grafana answers /api/health
+        run: |
+          code="$(curl -s -o /dev/null -w '%{http_code}' \
+            http://127.0.0.1:3000/api/health)"
+          echo "/api/health: HTTP $code"
+          [ "$code" = "200" ]
+
+      # Without this the job would pass identically against a plugin id
+      # that quietly installed, having proved nothing. The log line is the
+      # evidence that the failure happened and was survived.
+      #
+      # Waited for rather than read once. Grafana queues this install
+      # behind its own core plugins and works through them in an order
+      # that varies run to run, so the healthcheck can go green a minute
+      # before ours is even attempted.
+      - name: The install did fail, and was survived
+        run: |
+          deadline=$((SECONDS + 240))
+          until docker compose logs grafana --no-color \
+                | grep -q 'Failed to install plugin'; do
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "no failed install logged in 240s; either the plugin id is" >&2
+              echo "installable or it was never attempted, and either way this" >&2
+              echo "job proves nothing" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          docker compose logs grafana --no-color \
+            | grep 'Failed to install plugin' | tail -1
+          # A container that died and came back reads healthy a minute
+          # later, so uptime alone would not catch the crash-loop this job
+          # exists to pin. The restart count does.
+          restarts="$(docker inspect grafana --format '{{.RestartCount}}')"
+          echo "grafana restarts: $restarts"
+          if [ "$restarts" != "0" ]; then
+            echo "grafana restarted $restarts times on a failed plugin fetch" >&2
+            exit 1
+          fi
+
+      - name: Logs
+        if: failure()
+        run: docker compose logs --no-color --tail 200
+
+      - name: Stop
+        if: always()
+        run: docker compose down -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,12 @@ so the sections below map onto commit types.
 - Simulated sensors reported full float64 precision, filling the
   database with readings no thermometer could produce.
   [#152](https://github.com/quentinmarolleau/labmon/issues/152)
+- A Grafana panel plugin that could not be fetched stopped the whole
+  stack starting, crash-looping the container behind an `unhealthy`
+  status that named no cause. The install is now asynchronous: the
+  failure is logged, Grafana serves, and the panel reads "plugin not
+  found".
+  [#186](https://github.com/quentinmarolleau/labmon/issues/186)
 
 ## [0.2.0-beta.1] — 2026-08-23
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,11 +143,17 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       # Extra panel plugins, empty by default so a server install stays
       # offline-capable; the demo's .env sets it (see docs/demo-stack.md).
-      # "_SYNC" installs before Grafana starts, so a provisioned dashboard
-      # never loads while its panel type is still missing. Note that
-      # GF_INSTALL_PLUGINS is deprecated in this image and ignored unless
-      # GF_INSTALL_PLUGINS_FORCE is also set.
-      - GF_PLUGINS_PREINSTALL_SYNC=${GRAFANA_PLUGINS:-}
+      # The async form on purpose. "_SYNC" finishes the install before
+      # Grafana serves, so a provisioned dashboard never loads while its
+      # panel type is missing — but a fetch it cannot complete is fatal,
+      # and with `restart: unless-stopped` an unreachable grafana.com
+      # crash-loops the container and fails `up --wait` for the whole
+      # stack. This form logs the failure at error level and carries on.
+      # The cost is a panel reading "plugin not found" for the seconds
+      # before the install lands. Note that GF_INSTALL_PLUGINS is
+      # deprecated in this image and ignored unless GF_INSTALL_PLUGINS_FORCE
+      # is also set.
+      - GF_PLUGINS_PREINSTALL=${GRAFANA_PLUGINS:-}
     volumes:
       - type: bind
         source: ./grafana/provisioning

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ Only meaningful on the machine running `docker-compose.yml`.
 | `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana admin login |
 | `LABMON_BIND_ADDRESS` | `127.0.0.1` | Which address InfluxDB's and Grafana's ports bind to. Loopback by default; a server clients push to sets `0.0.0.0`. Does not affect the `tls` profile's proxy |
 | `COMPOSE_PROFILES` | *(unset)* | Which optional services start — see below |
-| `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Unset means Grafana needs no network at boot |
+| `GRAFANA_PLUGINS` | *(unset)* | Panel plugins to preinstall, as `id@version`, comma-separated. Fetched from grafana.com at boot, and a fetch that fails is logged rather than fatal. Unset means Grafana needs no network at boot |
 | `LOKI_RETENTION_PERIOD` | `720h` | How long a log line is kept, with the `logs` profile active. Never below `24h` — Loki accepts less and cannot honour it |
 | *(not a variable)* `--log-filter` | see `docker-compose.yml` | InfluxDB's log level per module. Lowers the once-a-second WAL flush line, which is otherwise its entire output — see docs/logging.md |
 | `LABMON_TLS_INFLUXDB_SITES` | `https://127.0.0.1:8443` | Addresses the proxy answers on for InfluxDB, with the `tls` profile active. Comma-*and-space* separated; each entry a whole `https://host:port` |

--- a/docs/demo-stack.md
+++ b/docs/demo-stack.md
@@ -112,19 +112,27 @@ defaults to empty, so a server deployment installs nothing and needs no
 network when Grafana boots. The cost of leaving it unset is that one panel
 renders as "plugin not found"; everything else works.
 
+Set, it is fetched from grafana.com the first time Grafana starts. A fetch
+that fails leaves an error in the log and nothing else: Grafana serves, and
+the gauge reads "plugin not found" until the next boot manages the
+download.
+
 <details>
 <summary><b>Three details in that one line that are easy to get wrong</b></summary>
 
 <br>
 
 
-- **The variable is `GF_PLUGINS_PREINSTALL_SYNC`, not
-  `GF_INSTALL_PLUGINS`.** The obvious spelling is deprecated in this image
-  and silently ignored unless `GF_INSTALL_PLUGINS_FORCE=true` is also set
-  — it installs nothing and reports no error.
-- **`_SYNC` rather than the async form**, so the install finishes before
-  Grafana starts serving. Otherwise provisioning can load the dashboard
-  while its panel type is still missing.
+- **The variable is `GF_PLUGINS_PREINSTALL`, not `GF_INSTALL_PLUGINS`.**
+  The obvious spelling is deprecated in this image and silently ignored
+  unless `GF_INSTALL_PLUGINS_FORCE=true` is also set — it installs nothing
+  and reports no error.
+- **The async form rather than `GF_PLUGINS_PREINSTALL_SYNC`.** The `_SYNC`
+  spelling finishes the install before Grafana serves, which reads like the
+  safer choice and is not: a download it cannot complete is fatal, so an
+  offline bench or an unreachable grafana.com stops the whole stack
+  starting. See [when Grafana will not
+  start](grafana.md#when-grafana-will-not-start).
 - **The version is pinned.** `preinstall_auto_update` defaults to true, so
   an unpinned id would silently follow upstream releases.
 
@@ -132,8 +140,11 @@ renders as "plugin not found"; everything else works.
 
 > [!NOTE]
 > If the panel still reports "plugin not found" after the container is up,
-> the tab is stale rather than the install broken. A hard reload
-> (Ctrl+Shift+R) fixes it — see below.
+> the install is either unfinished or the tab is stale — neither means it
+> is broken. Grafana serves before the download lands, and queues it
+> behind its own core plugins, so give it a moment and hard-reload
+> (Ctrl+Shift+R). `docker compose logs grafana | grep -i plugin` says
+> which of the two it is.
 
 The
 available-panels map is baked into `index.html` at page load, so a tab

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -69,7 +69,10 @@ COMPOSE_PROFILES=logs
 lists Grafana panel plugins to fetch at startup, and the demo sets it to
 the one plugin its detuning gauge needs. Blank, Grafana installs nothing
 and needs no network when it boots, at the cost of that one panel not
-rendering. See
+rendering. Left set on a machine that cannot reach grafana.com, the fetch
+fails into the log and Grafana starts anyway — see [when Grafana will not
+start](grafana.md#when-grafana-will-not-start) — but there is no reason to
+retry it on every boot. See
 [`demo-stack.md`](demo-stack.md#the-dashboard-needs-one-panel-plugin).
 
 ## Opening the server to the network

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -212,3 +212,52 @@ to that until someone exempts it by name. Every dashboard means every
 profile behind one has to be running, so `--dashboard` narrows it to a
 subset. `scripts/smoke_logs.py` covers the half neither reaches, proving
 collection gets to Loki at all.
+
+## When Grafana will not start
+
+Grafana is the service most likely to hold up a first `docker compose up -d
+--wait`, and its failures are quiet: the command exits non-zero naming a
+container that never went healthy, and `docker compose ps` reports
+
+```
+grafana   Up 8 minutes (unhealthy)
+```
+
+on a container created twelve minutes ago. That uptime is the tell — it is
+younger than the container, because what you are looking at is the latest
+of a series of restarts rather than one long unhealthy run. The reason is
+only ever in the log:
+
+```bash
+docker compose logs grafana
+```
+
+### The plugin fetch
+
+`GRAFANA_PLUGINS` is fetched from grafana.com when Grafana boots, so a
+machine that cannot reach it — an offline bench, a proxy that intercepts
+TLS, a plugin id or version that no longer exists — fails the install. That
+failure is logged at error level and Grafana carries on serving:
+
+```
+level=error msg="Failed to install plugin" pluginId=… error="404: Plugin not found"
+```
+
+The panel that needed it reads "plugin not found"; nothing else is
+affected, and the next boot retries. To stop it retrying, blank
+`GRAFANA_PLUGINS` in `.env`, which is what a server deployment wants
+anyway — see
+[`deployment.md`](deployment.md#choosing-what-runs-compose_profiles).
+
+Compose asks for this with `GF_PLUGINS_PREINSTALL`. The `_SYNC` variant of
+the same variable installs before Grafana starts serving, and treats a
+failed install as fatal:
+
+```
+Error: ✗ invalid service state: Failed … failed to install plugin: 404: Plugin not found
+```
+
+The process exits, `restart: unless-stopped` starts it again, and the stack
+never comes up on a machine with no route to grafana.com. That is the
+crash-loop the uptime above describes, and it is why this deployment
+accepts a few seconds of missing panel instead.


### PR DESCRIPTION
Closes #186.

`.env.example` ships `GRAFANA_PLUGINS=briangann-gauge-panel@2.2.0`, and compose passed it to `GF_PLUGINS_PREINSTALL_SYNC`. Under that spelling a plugin Grafana cannot fetch is fatal: the process exits, `restart: unless-stopped` brings it back, `docker compose up -d --wait` fails, and `docker compose ps` shows `Up 8 minutes (unhealthy)` on a container created twelve minutes earlier. So the first run of a fresh clone depended on reaching grafana.com, and on an offline bench or behind an intercepting proxy the whole stack looked broken with the cause visible only in `docker compose logs grafana`.

This switches to `GF_PLUGINS_PREINSTALL`, keeping the `.env` key and the compose variable name unchanged.

## The trade

The comment being replaced argued for `_SYNC` deliberately: the install finishes before Grafana serves, so a provisioned dashboard never loads while its panel type is still missing. That race is real, but it is the wrong side of the trade for a first run. A needle gauge reading "plugin not found" for a few seconds costs far less than a stack that will not start at all on a machine where nothing on the surface says why. The race is handled in `docs/demo-stack.md` instead, which now separates an unfinished install from a stale tab and gives the log line that tells them apart.

## Verified

Both halves probed directly against `grafana/grafana:13.2.0` with a plugin id that does not exist:

| Setting | Behaviour |
|---|---|
| `GF_PLUGINS_PREINSTALL_SYNC` | exits 1 on `invalid service state: Failed`, underlying error a 404 from the registry |
| `GF_PLUGINS_PREINSTALL` | `HTTP Server Listen`, the 404 logged at error level, Grafana carries on |

Then against the real stack: `up --wait` succeeded, `/api/health` answered 200, the failure appeared in the log, and `RestartCount` stayed at 0.

## The new smoke job

`plugin-fetch-failure` seeds `.env` with an id that 404s and requires the stack up regardless, `/api/health` at 200, the failed install present in the log, and Grafana's restart count at zero. Two of those four exist to stop it passing vacuously — without the log check it would pass identically against an id that turned out to be installable, and the restart count is what catches the crash-loop specifically, since a container that died and came back reads healthy a minute later. The log check waits rather than reading once, because Grafana queues this install behind its own core plugins in an order that varies run to run.

Confirmed it catches the regression: reverting `docker-compose.yml` to `_SYNC` fails the job at "The stack still comes up" with `container grafana is unhealthy`.

It is its own job rather than a step in `cold-start`, since it needs a differently seeded `.env` and a stack it is free to fail, and since a job re-runs on its own where a step in a twenty-minute sequence does not. The assertions are shell in the workflow rather than a script beside `smoke_dashboard.py` and `smoke_logs.py`, because anything under `scripts/` sits inside the 100% coverage gate and would need a test file of its own to carry three assertions against a container.

## Test plan

- [x] `pytest` — 1140 passed
- [x] `pre-commit run --all-files` — gitleaks, ruff format, ruff check, typos, docker compose config
- [x] actionlint against the pinned image used by the `workflows` job
- [x] new job's commands run end to end against a live stack
- [x] negative half confirmed by reverting to `_SYNC`
- [x] `smoke` green on this PR, including `plugin-fetch-failure`

