### PR TITLE
Make the distribution fit to publish, and add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: release
+
+on:
+  # A pushed `v*` tag is the release. Nothing else publishes to PyPI.
+  push:
+    tags: ["v*"]
+  # And a manual run, for rehearsing on TestPyPI. The first upload of a
+  # name is permanent and a published filename can never be reused, so
+  # there has to be somewhere to make the mistake instead.
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: Where to upload
+        type: choice
+        default: testpypi
+        options: [testpypi, pypi]
+
+# A tag is pushed once. Cancelling a superseded run would mean cancelling
+# a publish halfway, so this workflow deliberately has no `concurrency`
+# block, unlike ci.yml and smoke.yml.
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build the distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+          enable-cache: true
+
+      - name: Build the sdist and the wheel
+        run: uv build
+
+      # The git tag is SemVer (`v0.3.0`, `v0.2.0-beta.1`) and the version
+      # in pyproject.toml is PEP 440 (`0.3.0`, `0.2.0b1`). They are the
+      # same version in two conventions and are maintained by hand in two
+      # files, which is exactly the pair that drifts — and a drift is only
+      # visible after the upload, when it cannot be taken back.
+      - name: The tag and the packaged version agree
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          uvx --with packaging python - <<'PY'
+          import os, pathlib, sys
+          from packaging.version import InvalidVersion, Version
+
+          tag = os.environ["TAG"].removeprefix("v")
+          built = [p.name.removesuffix(".tar.gz").split("-", 1)[1]
+                   for p in pathlib.Path("dist").glob("*.tar.gz")]
+          try:
+              wanted = str(Version(tag))
+          except InvalidVersion:
+              sys.exit(f"tag {tag!r} is not a version PEP 440 recognises")
+          if built != [wanted]:
+              sys.exit(f"tag {tag!r} normalises to {wanted!r}, built {built}")
+          print(f"{tag} -> {wanted}")
+          PY
+
+      # Long-description rendering is the one thing that cannot be fixed
+      # after an upload: PyPI stores the rendered page with the file.
+      - name: The metadata is well formed
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: publish to ${{ inputs.repository || 'pypi' }}
+    needs: build
+    runs-on: ubuntu-latest
+    # Trusted publishing: the runner mints a short-lived OIDC token that
+    # PyPI exchanges for upload rights. No API token exists anywhere, so
+    # there is none to leak or rotate.
+    permissions:
+      id-token: write
+    # Also the approval gate. The `pypi` environment carries a required
+    # reviewer, so the irreversible upload waits for a click; `testpypi`
+    # does not.
+    environment: ${{ inputs.repository || 'pypi' }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: ${{ inputs.repository == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-install-project --no-dev
 
-# hatchling's build needs README.md present (pyproject.toml: readme = "README.md").
-COPY README.md ./
+# hatchling's build reads whatever file `readme` names in pyproject.toml,
+# and fails if it is not there. That is README.pypi.md, not README.md —
+# the long README is written for GitHub and does not render on an index.
+COPY README.pypi.md ./
 COPY src ./src
 RUN uv sync --locked --no-dev
 

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,0 +1,74 @@
+# labmon
+
+Records experiment readings — cryostat temperature, chamber pressure,
+laser power, a magnet's current — into [InfluxDB 3][influx], and reads
+them back three ways: a command line, a terminal panel, and Grafana in a
+browser.
+
+This package is the Python half: the sensors, the calibration, the writer
+and the `labmon` command. The other half is a Docker Compose stack —
+InfluxDB, Grafana and its provisioned dashboards, Loki, Alloy — which
+lives in the [repository][repo] and cannot usefully be delivered by an
+installer.
+
+## Install
+
+```bash
+uv tool install labmon          # or: pip install labmon
+```
+
+Nothing else is needed if you already have an InfluxDB 3 instance to talk
+to. Three environment variables point at it, in the process environment or
+in a `.env` beside you:
+
+| | |
+|---|---|
+| `INFLUXDB_HOST` | where the server is, e.g. `http://192.168.1.50:8181` |
+| `INFLUXDB_DATABASE` | which database to use, e.g. `lab` |
+| `INFLUXDB3_AUTH_TOKEN` | the admin token InfluxDB issued |
+
+If you have no instance yet, `labmon init` mints the token and creates the
+database over HTTP, from any machine.
+
+## What you get
+
+| | |
+|---|---|
+| `labmon query` | print readings as a table; `query latest` gives one row per sensor, with how long ago each spoke |
+| `labmon export` | the same selection, written to CSV, Parquet, Feather or netCDF, with the unit carried along |
+| `labmon monitor` | a panel that redraws in place, as a grid of tiles or a table of everything |
+| `labmon sensors` | every sensor labmon has seen, cached, so one that stopped reporting is still listed |
+| `labmon serial-sensor` | read a board over a serial port, converting raw counts through a calibration file |
+| `labmon mock-sensor` | invent a plausible reading, for confirming an address and a token before wiring anything up |
+| `labmon init`, `labmon reset-database` | set the database up, or wipe it and start again |
+
+## Extras
+
+| | |
+|---|---|
+| `labmon[tui]` | Textual, which `labmon monitor` needs |
+| `labmon[netcdf]` | netCDF export. CSV, Parquet and Feather need nothing extra |
+| `labmon[spline]` | SciPy, for the `spline` calibration mode |
+
+Combine them as `labmon[tui,netcdf]`.
+
+## Documentation
+
+Everything is in the [repository][repo]: the
+[README][readme] for the whole stack, and
+[`docs/`][docs] for one page per component —
+[client setup][client], [export][export], [the monitor panel][monitor],
+[serial sensors][serial], [Grafana][grafana], [deployment][deployment].
+
+Licensed GPLv3.
+
+[influx]: https://docs.influxdata.com/influxdb3/core/
+[repo]: https://github.com/quentinmarolleau/labmon
+[readme]: https://github.com/quentinmarolleau/labmon/blob/main/README.md
+[docs]: https://github.com/quentinmarolleau/labmon/tree/main/docs
+[client]: https://github.com/quentinmarolleau/labmon/blob/main/docs/client-setup.md
+[export]: https://github.com/quentinmarolleau/labmon/blob/main/docs/export.md
+[monitor]: https://github.com/quentinmarolleau/labmon/blob/main/docs/monitor.md
+[serial]: https://github.com/quentinmarolleau/labmon/blob/main/docs/serial-sensor.md
+[grafana]: https://github.com/quentinmarolleau/labmon/blob/main/docs/grafana.md
+[deployment]: https://github.com/quentinmarolleau/labmon/blob/main/docs/deployment.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,39 @@
 name = "labmon"
 version = "0.2.0b1"
 description = "Flexible laboratory monitoring system"
-readme = "README.md"
+# Not README.md. That file is written for GitHub — a header image, four
+# terminal recordings, and two dozen links relative to the repository
+# root, every one of which 404s on a PyPI project page, which has no
+# repository behind it to resolve them against.
+readme = "README.pypi.md"
 requires-python = ">=3.12"
+# PEP 639 spelling: an SPDX expression plus the files it refers to. The
+# `License :: OSI Approved ::` classifier is the older way of saying the
+# same thing and is deprecated; the two must not both appear, so the
+# classifier list below deliberately has no license entry.
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
+authors = [{ name = "Quentin Marolleau", email = "q.marolleau-dev@pm.me" }]
+keywords = [
+    "laboratory",
+    "monitoring",
+    "time-series",
+    "influxdb",
+    "sensors",
+    "physics",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering",
+    "Topic :: System :: Monitoring",
+    "Typing :: Typed",
+]
 dependencies = [
     "asteval>=1.0.9",
     "influxdb3-python>=0.20.0",
@@ -12,6 +43,12 @@ dependencies = [
     "python-dotenv>=1.2.3",
     "typer>=0.27.1",
 ]
+
+[project.urls]
+Homepage = "https://github.com/quentinmarolleau/labmon"
+Documentation = "https://github.com/quentinmarolleau/labmon/tree/main/docs"
+Changelog = "https://github.com/quentinmarolleau/labmon/blob/main/CHANGELOG.md"
+Issues = "https://github.com/quentinmarolleau/labmon/issues"
 
 [dependency-groups]
 dev = [
@@ -67,8 +104,38 @@ tui = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+# 1.27 is where PEP 639 landed; an older hatchling rejects the `license`
+# expression and `license-files` above.
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# Hatchling infers this from the project name under a src layout. Spelled
+# out because the inference is silent when it goes wrong, and because
+# py.typed is only picked up if the package directory is the unit being
+# copied.
+packages = ["src/labmon"]
+
+[tool.hatch.build.targets.sdist]
+# Without an include list hatchling ships everything git does not ignore,
+# which measured 1.9 MB: docs/ and its screenshots and recordings, the
+# firmware tree, the type stubs, and whatever a manual `labmon export`
+# had last left in the working tree.
+#
+# tests/ is left out on purpose rather than by omission. The suite checks
+# the repository, not the package: test_dashboard.py reads grafana/,
+# test_alloy_config.py reads alloy/, test_calibration.py reads demo/ and
+# calibration.example.toml. Shipping it would mean shipping those trees
+# too, which is the whole repository again by a longer route.
+#
+# README.md is not here either. It is the GitHub page, it links to images
+# and docs that are not in the sdist, and README.pypi.md reaches it by
+# absolute URL rather than by path.
+include = [
+    "/src",
+    "/README.pypi.md",
+    "/CHANGELOG.md",
+]
 
 [tool.ruff]
 # Matches requires-python above. Without it ruff infers a target from

--- a/src/labmon/cli/main.py
+++ b/src/labmon/cli/main.py
@@ -4,11 +4,14 @@
     labmon export --measurement temperature --since 5m --format feather -o test
     labmon mock-sensor --sensor-id room-1 --setpoint 21 --unit °C
     labmon --install-completion fish
+    labmon --version
 
 Built on Typer: the help text, the choice validation and the shell
 completion all come from the command signatures, so there is nothing
 separate to keep in step with them.
 """
+
+from typing import Annotated
 
 import typer
 
@@ -21,6 +24,7 @@ from labmon.cli.commands import reset_database as reset_database_command
 from labmon.cli.commands import sensors as sensors_command
 from labmon.cli.commands import serial_sensor as serial_sensor_command
 from labmon.cli.runtime import reporting
+from labmon.version import installed_version
 
 HELP = (
     "[bold]labmon[/bold] — laboratory monitoring."
@@ -33,6 +37,33 @@ HELP = (
     + "Run [bold]labmon --install-completion[/bold] once to get tab"
     + " completion, which shows each flag's help text as you type it."
 )
+
+
+def _report_version(requested: bool) -> None:
+    """Print the installed version and stop.
+
+    Eager, so `labmon --version` answers without Typer first deciding
+    that no subcommand was given and printing the help instead.
+    """
+    if requested:
+        typer.echo(f"labmon {installed_version()}")
+        raise typer.Exit
+
+
+def _root(
+    _version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            callback=_report_version,
+            is_eager=True,
+            help="Show the installed version and exit.",
+        ),
+    ] = False,
+) -> None:
+    """Carry the options that belong to `labmon` itself rather than to a
+    subcommand. Typer has one place to put those, and this is it.
+    """
 
 
 def build_app() -> typer.Typer:
@@ -84,6 +115,7 @@ def build_app() -> typer.Typer:
     _ = app.command("serial-sensor", help=serial_sensor_command.HELP)(
         reporting(serial_sensor_command.serial_sensor)
     )
+    _ = app.callback()(_root)
     return app
 
 

--- a/src/labmon/export/table.py
+++ b/src/labmon/export/table.py
@@ -17,13 +17,13 @@ a `Categorical` in polars rather than as an object column.
 import json
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from importlib import metadata
 from typing import cast
 
 import pyarrow as pa
 import pyarrow.compute as pc
 
 from labmon.export.window import Window
+from labmon.version import installed_version
 
 # Column order every export uses, whichever format it lands in. Time
 # first, then what the reading is of, then the number, then provenance.
@@ -53,13 +53,6 @@ TIME_TYPE: pa.DataType = pa.timestamp("ms", tz="UTC")
 _LABEL_TYPE: pa.DataType = pa.dictionary(pa.int32(), pa.string())
 
 _METADATA_KEY = b"labmon"
-
-
-def _labmon_version() -> str:
-    try:
-        return metadata.version("labmon")
-    except metadata.PackageNotFoundError:  # pragma: no cover - installed in CI
-        return "unknown"
 
 
 def _utc_time_column(column: pa.ChunkedArray) -> pa.ChunkedArray:
@@ -217,7 +210,7 @@ def attach_metadata(table: pa.Table, window: Window) -> pa.Table:
     """
     units = units_by_sensor(table)
     manifest = {
-        "labmon_version": _labmon_version(),
+        "labmon_version": installed_version(),
         "exported_at": datetime.now(UTC).isoformat(),
         "window_since": window.since.isoformat(),
         "window_until": window.until.isoformat(),

--- a/src/labmon/version.py
+++ b/src/labmon/version.py
@@ -1,0 +1,28 @@
+"""What version of labmon is installed.
+
+Read back from the installed distribution's metadata rather than kept as
+a constant in the source. The version is declared once, in
+`pyproject.toml`, and a second copy here would be a second place to bump
+and the first place to forget.
+"""
+
+from importlib import metadata
+
+#: The distribution name, which is also the import name.
+DISTRIBUTION = "labmon"
+
+#: Reported when the metadata is not there to read.
+UNKNOWN = "unknown"
+
+
+def installed_version() -> str:
+    """The installed version, or `UNKNOWN`.
+
+    A checkout that was never installed has no metadata to answer from —
+    running the package straight off `PYTHONPATH`, say — and that is not
+    an error worth failing an export or a `--version` over.
+    """
+    try:
+        return metadata.version(DISTRIBUTION)
+    except metadata.PackageNotFoundError:
+        return UNKNOWN

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,61 @@
+"""What labmon reports as its own version, and the flag that asks.
+
+The number itself is not asserted — it comes from `pyproject.toml` and
+would make this a second place to bump. What is asserted is that the
+lookup agrees with installed metadata, that a tree with no metadata
+degrades rather than raising, and that `--version` reaches the same
+answer through the CLI.
+"""
+
+from importlib import metadata
+
+import pytest
+
+from labmon import version
+from labmon.cli.main import build_app
+from tests.cli_runner import invoke
+
+
+def test_the_version_is_the_installed_distributions() -> None:
+    assert version.installed_version() == metadata.version("labmon")
+
+
+def test_a_tree_with_no_metadata_reports_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Running off PYTHONPATH with nothing installed is not an error.
+
+    `labmon.export.table` stamps this into every exported file, so a
+    raise here would fail an export over a fact nobody asked for.
+    """
+
+    def _missing(_name: str) -> str:
+        raise metadata.PackageNotFoundError(_name)
+
+    # `labmon.version` holds the same module object, so patching the
+    # attribute here is what its call sees.
+    monkeypatch.setattr(metadata, "version", _missing)
+    assert version.installed_version() == version.UNKNOWN
+
+
+def test_the_flag_prints_the_version() -> None:
+    result = invoke(build_app(), ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == f"labmon {metadata.version('labmon')}"
+
+
+def test_the_root_callback_does_not_swallow_a_subcommand() -> None:
+    """The callback carrying `--version` runs before every subcommand.
+
+    A callback that raised or consumed the arguments would break all of
+    them at once, and nothing else in the suite would say why.
+    """
+    result = invoke(build_app(), ["sensors", "--help"])
+    assert result.exit_code == 0
+    assert "sensors" in result.output
+
+
+def test_no_arguments_still_prints_the_help() -> None:
+    result = invoke(build_app(), [])
+    assert result.exit_code != 0
+    assert "Usage" in result.output


### PR DESCRIPTION
First of three PRs towards #169. This one makes the distribution fit to publish and gives the repository a way to publish it. It changes nothing a reader sees: no documentation claims labmon is on PyPI yet, and nothing here uploads anything on its own.

## The distribution

Two problems, both found by building the thing and looking at what came out.

**The sdist shipped the whole repository** — 1.9 MB of it. With no `[tool.hatch]` section hatchling includes everything git does not ignore, which meant `docs/` and its screenshots and terminal recordings, the firmware tree, the type stubs, and anything a manual `labmon export` had left in the working tree. There is now an explicit include list, and the sdist is 124 KB.

`tests/` is excluded on purpose rather than by omission, and the reason is worth recording: the suite checks the repository, not the package. `test_dashboard.py` reads `grafana/`, `test_alloy_config.py` reads `alloy/`, `test_calibration.py` reads `demo/` and `calibration.example.toml`. Shipping it would mean shipping those trees too, which is the whole repository again by a longer route.

**The metadata was five fields.** `twine check` passed on it, but the page a visitor landed on would have carried no license, no classifiers and no link back to the repository or the issue tracker. It now has an SPDX license expression, authors, keywords, ten classifiers and four project URLs.

The license is spelled the PEP 639 way — an expression plus the files it refers to — which is why there is no `License :: OSI Approved ::` classifier: that is the older way of saying the same thing and the two must not both appear. `GPL-3.0-only` rather than `-or-later`, because that is what the repository actually says; there is no "or later" notice in `LICENSE`, the README or any source file. Say so if the intent was the FSF default and I will change it. Hatchling only understands that spelling from 1.27, hence the raised floor.

**`README.pypi.md` is new.** `README.md` is written for GitHub: a header image, four terminal recordings, and two dozen links relative to the repository root, every one of which resolves to nothing on a project page that has no repository behind it. The substitute is short — what labmon is, how to install it, the commands, the extras, absolute links back — and the two overlap little enough to drift slowly.

## `labmon --version` and `py.typed`

There was no way to ask an installed labmon what it was, which did not matter while the only way to get it was a checkout and starts mattering the moment somebody installs from an index and opens a bug report.

`export/table.py` already had the lookup, stamping `labmon_version` into every exported file's schema metadata. It moves to `labmon/version.py` so there is one implementation rather than two, and the `PackageNotFoundError` branch trades its `# pragma: no cover` for a real test.

`py.typed` is one empty file. Without it a downstream type checker ignores every annotation in the installed wheel, which for a package gated at zero basedpyright errors is a waste.

## The release workflow

`release.yml` triggers on a pushed `v*` tag, and on `workflow_dispatch` with a TestPyPI/PyPI choice for rehearsing. Trusted publishing over OIDC, so no long-lived token exists anywhere. Every action pinned by digest, and actionlint passes.

Two guards, both there because the first upload of a name claims it permanently and a published filename can never be reused:

- The tag and the packaged version have to agree. The tag is SemVer and `pyproject.toml` is PEP 440 — `v0.3.0` against `0.3.0`, but also `v0.2.0-beta.1` against `0.2.0b1` — two hand-maintained spellings of one number in two files, which is exactly the pair that drifts. The tag is normalised with `packaging` rather than a regexp, so the comparison is the one the index will make.
- The `pypi` environment carries a required reviewer, so the irreversible upload waits for a click rather than following a tag push straight through.

No `concurrency` block, unlike `ci.yml` and `smoke.yml`: a tag is pushed once, and cancelling a superseded run would mean cancelling a publish halfway through.

## Before this can publish anything

Two settings changes that cannot be made from a commit, and which nothing here depends on until a tag is pushed:

- `pypi` and `testpypi` environments in the repository settings, the former with a required reviewer.
- A *pending* trusted publisher on both indexes — the flavour that exists precisely for a project that has never been uploaded. Project `labmon`, owner `quentinmarolleau`, repository `labmon`, workflow `release.yml`, environment as above.

## Test plan

- [x] `uv run --locked pytest --cov --cov-fail-under=100` — 1145 passed, 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright` (0 errors, 0 warnings), `typos`
- [x] `uv build` then `twine check dist/*` — both artefacts pass, `Metadata-Version: 2.5`
- [x] sdist contents: `src/`, `README.pypi.md`, `CHANGELOG.md`, `LICENSE`, `pyproject.toml`, and nothing else. 1.9 MB → 124 KB
- [x] wheel contents: `labmon/` including `py.typed`, plus `dist-info`
- [x] `labmon --version`, and every subcommand still reachable through the new root callback
- [x] the tag-agreement check, exercised against `v0.2.0b1`, `v0.2.0-beta.1`, a mismatched `v0.3.0` and a malformed tag
- [x] actionlint over all three workflows
- [ ] a TestPyPI upload, which needs the settings above and happens after this merges

Refs #169.
