### PR TITLE
Install the command line without a checkout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,6 +37,7 @@ body:
         - Everything on one machine (the quickstart)
         - Server on one machine, sensors on another
         - Bare install, no Docker
+        - Command line only, installed from PyPI
         - Other
     validations:
       required: true
@@ -83,8 +84,9 @@ body:
     attributes:
       label: Versions
       description: >-
-        `docker compose version`, the image tags from your `docker compose ps`,
-        and your OS. Add `python --version` for a bare install.
+        `labmon --version` and your OS, always. Add `docker compose version`
+        and the image tags from your `docker compose ps` if the stack is
+        involved, and `python --version` for a bare install.
       render: shell
     validations:
       required: true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -59,9 +59,9 @@ jobs:
           sed -i 's/^INFLUXDB_NODE_ID=.*/INFLUXDB_NODE_ID=ci/' .env
 
       # The README installs the CLI before starting anything, because
-      # `labmon init` is what sets the database up. Installed from the
-      # checkout, so this is the package under test rather than a
-      # published one.
+      # `labmon init` is what sets the database up. Editable, from the
+      # checkout: the quickstart's own spelling, and the one that tests
+      # this commit rather than whatever is on PyPI.
       #
       # Before the first `docker compose up`, and that ordering is load
       # bearing rather than cosmetic: setup-uv's cache key globs the whole

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ come pre-configured, so neither needs setting up by hand.
 You need [Docker](https://docs.docker.com/get-started/get-docker/) and
 [uv](https://docs.astral.sh/uv/). Nothing else — no sensors, no hardware.
 
+This sets up the whole stack — database, dashboards, log collection — so it
+starts from the repository. If you already have an InfluxDB 3 instance and
+want only the command line against it, that is `uv tool install
+'labmon[tui]'` and three environment variables; see
+[Reading the data](#reading-the-data).
+
 **1. Get the repository and its settings file.**
 
 ```bash
@@ -72,6 +78,10 @@ cp .env.example .env
 ```bash
 uv tool install --editable '.[tui]'
 ```
+
+`--editable` installs it from the checkout you just made, so `labmon`
+follows the working tree. Elsewhere it comes from PyPI, as
+`uv tool install 'labmon[tui]'`.
 
 **3. Start InfluxDB and set it up.**
 
@@ -205,6 +215,19 @@ Three commands, one job each. `query` and `export` ask the database the
 same question and share the same four selection flags —
 `--measurement`, `--sensor-id`, `--since`, `--until` — so learning one
 teaches the other.
+
+They are a client and nothing more: they speak HTTP to the server, so the
+machine they run on needs no container, no repository and no InfluxDB of
+its own.
+
+```bash
+uv tool install 'labmon[tui]'    # or: pip install 'labmon[tui]'
+```
+
+Then `INFLUXDB_HOST`, `INFLUXDB_DATABASE` and `INFLUXDB3_AUTH_TOKEN`,
+in the environment or in a `.env` beside you —
+[`docs/configuration.md`](docs/configuration.md). The `tui` extra is
+Textual, which only `labmon monitor` needs.
 
 ### `labmon query` — a table, now
 
@@ -482,8 +505,8 @@ a small network:
 | **Client** | A sensor script, on whatever machine the instrument is wired to — a Raspberry Pi, a lab PC | [`docs/client-setup.md`](docs/client-setup.md) |
 | **Viewer** | A browser | nothing |
 
-A client can be a Docker container or a plain Python install; both are
-documented. A board can equally well be plugged straight into the server,
+A client can be a Docker container or a plain `uv tool install labmon`;
+both are documented. A board can equally well be plugged straight into the server,
 in which case there is no client machine at all.
 
 ### Opening the server to the network

--- a/deploy/labmon-sensor.service
+++ b/deploy/labmon-sensor.service
@@ -1,7 +1,7 @@
 # Example systemd unit for running a sensor directly on a client machine
 # (bare install, no Docker) — see docs/client-setup.md. Copy this file to
-# /etc/systemd/system/labmon-sensor.service, edit the paths/command below
-# for your setup, then:
+# /etc/systemd/system/labmon-sensor.service, edit the user and the
+# command below for your setup, then:
 #
 #   sudo systemctl daemon-reload
 #   sudo systemctl enable --now labmon-sensor.service
@@ -17,9 +17,12 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=pi
-WorkingDirectory=/home/pi/labmon
-EnvironmentFile=/home/pi/labmon/.env
-ExecStart=/home/pi/labmon/.venv/bin/labmon mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
+WorkingDirectory=/home/pi
+EnvironmentFile=/home/pi/.config/labmon/sensor.env
+# Where `uv tool install labmon` puts it. A checkout installed with
+# `uv sync` instead has it at <checkout>/.venv/bin/labmon; systemd needs
+# an absolute path either way, since it runs with no PATH of its own.
+ExecStart=/home/pi/.local/bin/labmon mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
 Restart=on-failure
 RestartSec=5
 

--- a/deploy/labmon-serial-sensor.service
+++ b/deploy/labmon-serial-sensor.service
@@ -18,9 +18,12 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=pi
-WorkingDirectory=/home/pi/labmon
-EnvironmentFile=/home/pi/labmon/.env
-ExecStart=/home/pi/labmon/.venv/bin/labmon serial-sensor --port /dev/labmon-due --calibration /home/pi/labmon/calibration.toml
+WorkingDirectory=/home/pi
+EnvironmentFile=/home/pi/.config/labmon/sensor.env
+# Where `uv tool install labmon` puts it. A checkout installed with
+# `uv sync` instead has it at <checkout>/.venv/bin/labmon; systemd needs
+# an absolute path either way, since it runs with no PATH of its own.
+ExecStart=/home/pi/.local/bin/labmon serial-sensor --port /dev/labmon-due --calibration /home/pi/.config/labmon/calibration.toml
 Restart=on-failure
 RestartSec=5
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -72,22 +72,35 @@ Better on a resource-constrained device, or where a container runtime is
 unwelcome.
 
 ```bash
-git clone https://github.com/quentinmarolleau/labmon.git && cd labmon
-uv sync --no-dev
-cp .env.client.example .env      # fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
-set -a && source .env && set +a
-uv run labmon mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
+uv tool install labmon
+mkdir -p ~/.config/labmon
+curl -o ~/.config/labmon/sensor.env \
+  https://raw.githubusercontent.com/quentinmarolleau/labmon/main/.env.client.example
+# fill in INFLUXDB_HOST and INFLUXDB3_AUTH_TOKEN
+set -a && source ~/.config/labmon/sensor.env && set +a
+labmon mock-sensor --sensor-id=CHANGE-ME --measurement=CHANGE-ME --unit=CHANGE-ME
 ```
 
+No repository. The sensor commands are a client, and `uv tool install`
+puts `labmon` on the PATH. Serial support is part of the base install;
+add an extra only for what the machine actually does —
+`labmon[spline]` for spline calibration, `labmon[tui]` to run
+`labmon monitor` on the same box.
+
 To survive a reboot, use the example unit at
-[`deploy/labmon-sensor.service`](../deploy/labmon-sensor.service) — edit the
-paths, `User` and `ExecStart` for your setup:
+[`deploy/labmon-sensor.service`](../deploy/labmon-sensor.service) — edit
+`User` and `ExecStart` for your setup:
 
 ```bash
-sudo cp deploy/labmon-sensor.service /etc/systemd/system/
+curl -O https://raw.githubusercontent.com/quentinmarolleau/labmon/main/deploy/labmon-sensor.service
+sudo cp labmon-sensor.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now labmon-sensor.service
 ```
+
+The unit reads `~/.config/labmon/sensor.env` and runs
+`~/.local/bin/labmon`, which is where `uv tool install` puts it. systemd
+starts with no PATH of its own, so that has to be an absolute path.
 
 For a second sensor on the same device, copy the unit under a different
 name with its own `ExecStart`.

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,11 +1,14 @@
 # Getting the data out
 
-The commands run on your machine, not in a container, so install them
-first:
+The commands run on your machine, not in a container, and need no
+repository — they speak HTTP to the server like any other client:
 
 ```bash
-uv tool install --editable '.[tui]'
+uv tool install 'labmon[tui]'
 ```
+
+From a checkout, `uv tool install --editable '.[tui]'` installs the same
+thing and follows the working tree.
 
 Two of them read recorded readings, and they differ only in what they do
 with the answer:
@@ -94,7 +97,7 @@ CSV, Parquet and Feather need no extra install — `pyarrow` arrives with the
 InfluxDB client. netCDF does:
 
 ```bash
-uv tool install --editable '.[tui,netcdf]'
+uv tool install 'labmon[tui,netcdf]'
 ```
 
 Loading looks like this:
@@ -532,5 +535,5 @@ attaches completions to a command word, and `uv run labmon …` is the
 command `uv`. Installing it as a tool puts it on the PATH:
 
 ```bash
-uv tool install --editable '.[tui]'
+uv tool install 'labmon[tui]'
 ```

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -141,9 +141,9 @@ different situations, and only the last produces no line at all.
 To see every reading while bringing a board up:
 
 ```bash
-uv run labmon mock-sensor --measurement temperature --unit "°C" \
+labmon mock-sensor --measurement temperature --unit "°C" \
   --log-level debug
-uv run labmon serial-sensor --port … --calibration … --log-level debug
+labmon serial-sensor --port … --calibration … --log-level debug
 ```
 
 ## Where it collects from

--- a/docs/mock-sensor.md
+++ b/docs/mock-sensor.md
@@ -13,20 +13,20 @@ an actual board, see [`serial-sensor.md`](serial-sensor.md).
 ```bash
 # --measurement and --unit are required; the rest default to sensor-id
 # "mock-sensor-1", setpoint 21, one reading every 5s
-uv run labmon mock-sensor --measurement temperature --unit "°C"
+labmon mock-sensor --measurement temperature --unit "°C"
 
 # A second room thermometer, sampled every second
-uv run labmon mock-sensor --sensor-id room-2 --measurement temperature \
+labmon mock-sensor --sensor-id room-2 --measurement temperature \
   --setpoint 22 --interval 1 --unit "°C"
 
 # A cryogenic sensor
-uv run labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
+labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
   --setpoint 77 --noise 0.3 --unit K
 
 # A vacuum gauge. Values spanning orders of magnitude need --log-scale,
 # so noise and mean-reversion scale multiplicatively rather than by a
 # fixed absolute amount.
-uv run labmon mock-sensor --sensor-id chamber-1 --measurement pressure \
+labmon mock-sensor --sensor-id chamber-1 --measurement pressure \
   --setpoint 1e-7 --noise 0.05 --log-scale --unit mbar
 ```
 
@@ -76,7 +76,7 @@ readings are rounded before they are written.
 instrument with a fixed least-significant digit is described:
 
 ```bash
-uv run labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
+labmon mock-sensor --sensor-id cryo-77k --measurement temperature \
   --setpoint 77 --unit K \
   --resolution 0.001        # 76.85006139177405 -> 76.85
 ```
@@ -148,7 +148,7 @@ directory holding it (see [`configuration.md`](configuration.md)):
 > (`http://influxdb:8181`, set in `docker-compose.yml`), while a host-side
 > run needs `http://localhost:8181`. One `.env` value cannot satisfy both,
 > so set it inline for an ad-hoc host-side run:
-> `INFLUXDB_HOST=http://elsewhere:8181 uv run labmon mock-sensor …`
+> `INFLUXDB_HOST=http://elsewhere:8181 labmon mock-sensor …`
 
 ## Checking what was written
 

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -115,14 +115,16 @@ everywhere.
 Needs the `tui` extra, which brings in Textual:
 
 ```bash
-uv tool install --editable '.[tui]'
+uv tool install 'labmon[tui]'    # or: pip install 'labmon[tui]'
 ```
 
-`pip install 'labmon[tui]'` works for an ordinary virtualenv, but not for
-a checkout installed as a uv tool — that installs into the environment
-`pip` happens to belong to, leaving the `labmon` on your PATH unchanged.
-Running the command without Textual names the interpreter it looked in
-and the install line for it, rather than an import traceback.
+Adding the extra to an install you already have needs the same form the
+install used. `pip install 'labmon[tui]'` reaches an ordinary virtualenv
+and not a checkout installed as a uv tool — `pip` installs into the
+environment it belongs to, leaving the `labmon` on your PATH unchanged.
+For that one, `uv tool install --editable '.[tui]' --force`. Running the
+command without Textual names the interpreter it looked in and the
+install line for it, rather than an import traceback.
 
 ## Why not just leave Grafana open
 

--- a/docs/serial-sensor.md
+++ b/docs/serial-sensor.md
@@ -5,7 +5,7 @@ InfluxDB. This is the non-mock counterpart to
 [`docs/mock-sensor.md`](mock-sensor.md), which simulates readings instead.
 
 ```bash
-uv run labmon serial-sensor --port /dev/labmon-due --calibration calibration.toml
+labmon serial-sensor --port /dev/labmon-due --calibration calibration.toml
 ```
 
 ## How a reading becomes a data point
@@ -382,7 +382,8 @@ to be written backwards. They differ in two ways worth knowing:
   and **extrapolates** beyond the measured range. `piecewise_linear`
   joins the points with straight lines and **clamps** to the end values
   instead — safer when a reading strays outside what was characterised.
-- `spline` needs scipy: `uv sync --extra spline`. `piecewise_linear` needs
+- `spline` needs scipy: `uv tool install 'labmon[spline]'`, or
+  `uv sync --extra spline` from a checkout. `piecewise_linear` needs
   nothing beyond the base install, which matters on a small client.
   Note that the `Dockerfile` installs the base dependencies only, so a
   containerized `serial-sensor` cannot use `spline` until that extra is
@@ -573,7 +574,7 @@ exercises the tty layer:
 socat -d -d pty,raw,echo=0 pty,raw,echo=0
 
 # Terminal 2 — read one end
-uv run labmon serial-sensor --port /dev/pts/N --calibration calibration.toml
+labmon serial-sensor --port /dev/pts/N --calibration calibration.toml
 
 # Terminal 3 — feed the other end
 printf 'A0,2048\r\n' > /dev/pts/M

--- a/src/labmon/cli/commands/monitor.py
+++ b/src/labmon/cli/commands/monitor.py
@@ -129,9 +129,10 @@ def monitor(
         raise typer.BadParameter(
             "labmon monitor needs Textual, which is not installed in"
             + f" {sys.executable}."
-            + " Install it with: pip install 'labmon[tui]' — or, for an"
-            + " editable checkout installed as a tool,"
-            + " uv tool install --editable '.[tui]' --force"
+            + " Add the extra the way labmon itself was installed:"
+            + " uv tool install 'labmon[tui]' --force,"
+            + " pip install 'labmon[tui]', or"
+            + " uv tool install --editable '.[tui]' --force from a checkout"
         ) from error
 
     # Checked here rather than left to Textual, which refuses an unknown


### PR DESCRIPTION
Second of three PRs towards #169, stacked on #199. It makes the documentation admit that labmon has two audiences with different needs.

**To be merged only once `labmon` is actually on PyPI**, or at least once the TestPyPI rehearsal has confirmed it will be — every install line here is a claim that a published package exists.

## The split

Every install path in the repository started from `git clone`, including the ones that never needed a checkout.

Only one audience genuinely needs the repository: somebody standing up the stack, who needs `docker-compose.yml`, the Grafana provisioning and the demo feeder. That path is unchanged. The Quickstart still clones, and now says why, so a reader who already has an InfluxDB does not clone a repository in order to get a command.

The other audience needs the package and nothing else. `query`, `export`, `monitor`, `sensors`, `init`, `mock-sensor` and `serial-sensor` speak HTTP to the server, read nothing from the repository, and work on a machine with neither a container nor a copy of the source. "Reading the data" now opens with the three lines that get them there: one install command and three environment variables.

## What moved

`uv run labmon …` is gone from ten call sites across `mock-sensor.md`, `logging.md` and `serial-sensor.md`. It only works in a checkout, and it is also the form that silently breaks tab completion — a shell attaches completions to a command word, and there the command word is `uv`. `export.md` makes that argument already; it was undercut by the surrounding pages using the broken form.

**`docs/client-setup.md` Option 2** is the biggest change. "Bare install, no Docker" cloned the repository and ran `uv sync`, putting a full development checkout on a Raspberry Pi to run one command. It is now `uv tool install labmon` and a `curl` for `.env.client.example`, which is the only artefact the machine actually wants.

**The two sensor systemd units** move with it — they have to, since the paths have to agree. `ExecStart` points at `/home/pi/.local/bin/labmon`, where `uv tool install` puts it, rather than inside somebody's clone, and settings live at `~/.config/labmon/sensor.env` so the page and the unit name the same file. That also stops the sensor host depending on its working directory, since `.env` is read from the current directory and a service has whatever `WorkingDirectory` says.

**`docs/monitor.md`** had a paragraph presenting `pip install 'labmon[tui]'` as a trap to warn against, which was correct when no published package existed and reads backwards now. It is the ordinary way to get the extra; the caveat narrows to what stays true, which is that adding an extra has to use the same form the install did. The runtime error in `commands/monitor.py` gets the same treatment.

**`bug.yml`** asks for `labmon --version` first — the flag added in #199 — instead of `python --version`, and gains a "Command line only, installed from PyPI" topology, which was previously "Other".

## Left alone deliberately

- **The Quickstart's clone**, and `client-setup.md` Option 1. The stack needs the files, and Option 1 builds from the repository's own `Dockerfile`, so the clone is the point rather than an accident.
- **`smoke.yml`'s `uv tool install --editable '.[tui]'`.** The job replays the README quickstart to test *this commit*, not whatever is on PyPI. Its comment now says that rather than noting that no published package exists.
- **The two `custom-sensor` units.** They run the user's own script from the user's own project directory, which is not a labmon install path.
- **The GIFs.** `quickstart.gif` shows the clone-based flow, which is still what the Quickstart does. #198 is where the recordings live.

## Test plan

- [x] `uv run --locked pytest --cov --cov-fail-under=100` — 1145 passed, 100%
- [x] `ruff check`, `ruff format --check`, `basedpyright` (0/0), `typos`
- [x] actionlint, and the issue template parses as YAML
- [x] every remaining `git clone` / `uv sync` / `--editable` in `README.md`, `docs/`, `deploy/` and `.github/` audited, and each is one of the four exceptions above
- [ ] `uv tool install labmon` on a machine with no checkout, once the package exists — the case the whole issue is about

Refs #169.
